### PR TITLE
fixed Schematron check for cross-references to note elements

### DIFF
--- a/P5/Exemplars/tei_jtei.odd
+++ b/P5/Exemplars/tei_jtei.odd
@@ -3177,7 +3177,7 @@
           <constraintSpec ident="jtei.sch-crossrefTargetType" scheme="isoschematron">
             <constraint>
               <sch:rule context="tei:ptr[@type='crossref']|tei:ref[@type='crossref']">
-                <sch:assert test="id(substring-after(@target, '#'))/(self::tei:div|self::tei:figure|self::tei:table|tei:note)">
+                <sch:assert test="id(substring-after(@target, '#'))/(self::tei:div|self::tei:figure|self::tei:table|self::tei:note)">
                   Cross-links (<sch:name/>[@type="crossref"]) should be targeted at div, figure, table, or note elements.
                 </sch:assert>
               </sch:rule>


### PR DESCRIPTION
Fixed a small issue in a Schematron rule.

Would someone please consider merging the accompanying pull request (https://github.com/TEIC/Stylesheets/pull/166) in the Stylesheets repo?