### PR TITLE
added a check for rnv with a URL hint

### DIFF
--- a/P5/Makefile
+++ b/P5/Makefile
@@ -47,7 +47,7 @@ check.stamp:
 	@command -v  java || exit 1
 	@echo -n xmllint:
 	@command -v  xmllint || exit 1
-	@echo -n rnv (https://sourceforge.net/projects/rnv/):
+	@echo -n rnv (https://github.com/hartwork/rnv):
 	@command -v  rnv || exit 1
 	touch check.stamp
 

--- a/P5/Makefile
+++ b/P5/Makefile
@@ -47,6 +47,8 @@ check.stamp:
 	@command -v  java || exit 1
 	@echo -n xmllint:
 	@command -v  xmllint || exit 1
+	@echo -n rnv (https://sourceforge.net/projects/rnv/):
+	@command -v  rnv || exit 1
 	touch check.stamp
 
 p5.xml: ${DRIVER} Source/Specs/*.xml Source/Guidelines/en/*.xml p5odds.odd check.stamp

--- a/P5/Makefile
+++ b/P5/Makefile
@@ -47,7 +47,7 @@ check.stamp:
 	@command -v  java || exit 1
 	@echo -n xmllint:
 	@command -v  xmllint || exit 1
-	@echo -n rnv (https://github.com/hartwork/rnv):
+	@echo -n rnv (https://github.com/dtolpin/RNV):
 	@command -v  rnv || exit 1
 	touch check.stamp
 


### PR DESCRIPTION
`rnv` is invoked in the Makefile under Test/ but is not checked for, which may lead to some bitterness. Furthermore, neither of the *ubuntu systems that I run recognizes `rnv` among the software packages. So I added a little URL hint on where to find it.