### PR TITLE
Fix example fsdLink/@target

### DIFF
--- a/P5/Source/Guidelines/en/FS-FeatureStructures.xml
+++ b/P5/Source/Guidelines/en/FS-FeatureStructures.xml
@@ -1215,7 +1215,7 @@ pointers to the <gi>fsDecl</gi> elements in the first:
            <!-- ... -->
            <fsdDecl>
            <fsdLink type="gpsg" target="example.xml#GPSG"/>
-           <fsdLink type="lexx" target="example.xml#GPSG"/>
+           <fsdLink type="lexx" target="example.xml#LEX"/>
 	   </fsdDecl>
            <!-- ... -->
       </encodingDesc>


### PR DESCRIPTION
The comments in the example and following prose suggests that @type="lexx" should be an alias for @type="lex", not "gpsg"