### PR TITLE
updated references to deprecated TEI datatypes in code example

### DIFF
--- a/P5/Exemplars/tei_jtei.odd
+++ b/P5/Exemplars/tei_jtei.odd
@@ -764,9 +764,9 @@
         <!-- [RvdB] The use of <ident> in the current articles should be evaluated (should it be used for file names etc, or is <code> the right tag for those?). -->
         <p>The <gi>ident</gi> element should be used to encode identifiers in a formal language, such as variable, class, and function names in a programming language. When discussing the TEI encoding scheme or customizations, the names of model and attribute classes, datatypes, macros, and TEI customizations should be encoded with <gi>ident</gi>:
           <egXML xmlns="http://www.tei-c.org/ns/Examples">
-            <p>For example <ident>data.duration.iso</ident>, <ident>data.outputMeasurement</ident>,
-              <ident>data.pattern</ident>, <ident>data.point</ident>, <ident>data.version</ident>, 
-              and <ident>data.word</ident> all map to the same datatype CDATA in XML DTD, and to 
+            <p>For example <ident>teidata.duration.iso</ident>, <ident>teidata.outputMeasurement</ident>,
+              <ident>teidata.pattern</ident>, <ident>teidata.point</ident>, <ident>teidata.version</ident>, 
+              and <ident>teidata.word</ident> all map to the same datatype CDATA in XML DTD, and to 
               various TEI-defined regular expressions in RELAX NG or W3C Schema.</p>
           </egXML>
         </p>


### PR DESCRIPTION
Acting upon @sydb [reminder](https://listserv.brown.edu/archives/cgi-bin/wa?A2=ind1809&L=TEI-L&P=26122) of https://github.com/TEIC/TEI/commit/56125fa173b3426c31fa64d655e0aa46842bfead