### PR TITLE
more purification of exemplar ODDS

### DIFF
--- a/P5/Exemplars/tei_allPlus.odd
+++ b/P5/Exemplars/tei_allPlus.odd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xml:lang="en" 
-  xmlns:xi="http://www.w3.org/2001/XInclude"
+<TEI xmlns:xi="http://www.w3.org/2001/XInclude"
      xmlns="http://www.tei-c.org/ns/1.0"
-  xmlns:rng="http://relaxng.org/ns/structure/1.0">
+     xmlns:rng="http://relaxng.org/ns/structure/1.0"
+     xml:lang="en">
   <teiHeader>
     <fileDesc>
       <titleStmt>
@@ -10,19 +10,19 @@
         <author>Sebastian Rahtz</author>
       </titleStmt>
       <publicationStmt>
-	<publisher>TEI Consortium</publisher>
+        <publisher>TEI Consortium</publisher>
         <availability status="free">
           <p>This template file is freely available and you are hereby
-            authorised to copy, modify, and redistribute it in any way without
-            further reference or permissions.</p>
+          authorised to copy, modify, and redistribute it in any way without
+          further reference or permissions.</p>
           <p>When making such modifications, you are strongly recommended to
-            change the present text to include an accurate statement of the
-            licencing conditions applicable to your modified text.</p>
+          change the present text to include an accurate statement of the
+          licencing conditions applicable to your modified text.</p>
         </availability>
       </publicationStmt>
       <sourceDesc>
         <p>This digital file is the original, although it is heavily based on the
-          file tei_all.odd.</p>
+        file tei_all.odd.</p>
       </sourceDesc>
     </fileDesc>
   </teiHeader>
@@ -30,25 +30,30 @@
     <body>
       <head>TEI Complete, Plus</head>
       <p>This TEI customization describes a schema that includes
-        <emph>all</emph> of the TEI (P5) modules, and all of the recommended
-        external schemas. This is a very useful starting place for manually
-        creating your own customizations — it is much easier to
-        delete the modules you do not want than to add the modules you do.
-        Furthermore this customization often provides helpful for testing TEI
-        software. </p>
+      <emph>all</emph> of the TEI (P5) modules, and all of the recommended
+      external schemas. This is a very useful starting place for manually
+      creating your own customizations — it is much easier to
+      delete the modules you do not want than to add the modules you do.
+      Furthermore this customization often provides helpful for testing TEI
+      software. </p>
       <p>However, this particular TEI customization is <emph>not
-        recommended</emph> for actual use for encoding documents. It produces
-        schemas and reference documentation that will be much larger, and
-        include many more elements, than almost anyone could conceivably ever
-        need. Tempting though it may be simply to have absolutely everything,
-        and <q>just ignore</q> elements not required, experience has shown that
-        their presence makes the documentation harder to read and use, and makes
-        a schema that is often more lax than desired.</p>
+      recommended</emph> for actual use for encoding documents. It produces
+      schemas and reference documentation that will be much larger, and
+      include many more elements, than almost anyone could conceivably ever
+      need. Tempting though it may be simply to have absolutely everything,
+      and <q>just ignore</q> elements not required, experience has shown that
+      their presence makes the documentation harder to read and use, and makes
+      a schema that is often more lax than desired.</p>
 
-      <schemaSpec ident="tei_allPlus" prefix="tei_" start="TEI teiCorpus" xmlns:teix="http://www.tei-c.org/ns/Examples"
-        defaultExceptions="http://www.tei-c.org/ns/1.0 http://www.w3.org/1998/Math/MathML http://www.w3.org/2000/svg teix:egXML">
-        <moduleRef key="tei"/>           <!-- required -->
-        <moduleRef key="core"/>          <!-- required -->
+      <schemaSpec xmlns:teix="http://www.tei-c.org/ns/Examples"
+                  ident="tei_allPlus"
+                  prefix="tei_"
+                  start="TEI teiCorpus"
+                  defaultExceptions="http://www.tei-c.org/ns/1.0 http://www.w3.org/1998/Math/MathML http://www.w3.org/2000/svg teix:egXML">
+        <moduleRef key="tei"/>           
+        <!-- required -->
+        <moduleRef key="core"/>          
+        <!-- required -->
         <moduleRef key="analysis"/>
         <moduleRef key="certainty"/>
         <moduleRef key="corpus"/>
@@ -57,47 +62,49 @@
         <moduleRef key="drama"/>
         <moduleRef key="figures"/>
         <moduleRef key="gaiji"/>
-        <moduleRef key="header"/>         <!-- required -->
+        <moduleRef key="header"/>         
+        <!-- required -->
         <moduleRef key="iso-fs"/>
         <moduleRef key="linking"/>
         <moduleRef key="msdescription"/>
         <moduleRef key="namesdates"/>
         <moduleRef key="nets"/>
         <moduleRef key="spoken"/>
-	<moduleRef key="tagdocs"/>
+        <moduleRef key="tagdocs"/>
         <moduleRef key="textcrit"/>
-        <moduleRef key="textstructure"/>  <!-- required -->
+        <moduleRef key="textstructure"/>  
+        <!-- required -->
         <moduleRef key="transcr"/>
         <moduleRef key="verse"/>
 
 
         <xi:include href="tei_svg.odd"
-          xpointer="xmlns(t=http://www.tei-c.org/ns/1.0)xpointer(//t:moduleRef[@url])">
+                    xpointer="xmlns(t=http://www.tei-c.org/ns/1.0)xpointer(//t:moduleRef[@url])">
           <xi:fallback> ERROR: cannot locate ODD changes for SVG </xi:fallback>
         </xi:include>
 
         <xi:include href="tei_math.odd"
-          xpointer="xmlns(t=http://www.tei-c.org/ns/1.0)xpointer(//t:moduleRef[@url]|//t:elementSpec[@ident='formula'])">
+                    xpointer="xmlns(t=http://www.tei-c.org/ns/1.0)xpointer(//t:moduleRef[@url]|//t:elementSpec[@ident='formula'])">
           <xi:fallback> ERROR: cannot locate ODD changes for MathML </xi:fallback>
         </xi:include>
 
-    <elementSpec ident="egXML" mode="change" module="tagdocs"
-     ns="http://www.tei-c.org/ns/Examples">
-      <content>
-	<oneOrMore xmlns="http://relaxng.org/ns/structure/1.0">
-	  <choice>
-	    <text/>
-	    <ref name="macro.anyThing"/>
-	  </choice>
-	</oneOrMore>
-      </content>
-    </elementSpec>
-  
-    <macroSpec ident="macro.anyThing" mode="add">
-      <content>
-	<?NameList?>
-      </content>
-    </macroSpec>
+        <elementSpec ident="egXML"
+                     mode="change"
+                     module="tagdocs"
+                     ns="http://www.tei-c.org/ns/Examples">
+          <content>
+            <alternate minOccurs="1" maxOccurs="unbounded">
+              <textNode/>
+              <macroRef key="macro.anyThing"/>
+            </alternate>
+          </content>
+        </elementSpec>
+        
+        <macroSpec ident="macro.anyThing" mode="add">
+          <content>
+            <?NameList?>
+          </content>
+        </macroSpec>
 
       </schemaSpec>
     </body>

--- a/P5/Exemplars/tei_allPlus.odd
+++ b/P5/Exemplars/tei_allPlus.odd
@@ -50,10 +50,8 @@
                   prefix="tei_"
                   start="TEI teiCorpus"
                   defaultExceptions="http://www.tei-c.org/ns/1.0 http://www.w3.org/1998/Math/MathML http://www.w3.org/2000/svg teix:egXML">
-        <moduleRef key="tei"/>           
-        <!-- required -->
-        <moduleRef key="core"/>          
-        <!-- required -->
+        <moduleRef key="tei"/>           <!-- required -->
+        <moduleRef key="core"/>          <!-- required -->
         <moduleRef key="analysis"/>
         <moduleRef key="certainty"/>
         <moduleRef key="corpus"/>
@@ -62,8 +60,7 @@
         <moduleRef key="drama"/>
         <moduleRef key="figures"/>
         <moduleRef key="gaiji"/>
-        <moduleRef key="header"/>         
-        <!-- required -->
+        <moduleRef key="header"/>        <!-- required -->
         <moduleRef key="iso-fs"/>
         <moduleRef key="linking"/>
         <moduleRef key="msdescription"/>
@@ -72,11 +69,9 @@
         <moduleRef key="spoken"/>
         <moduleRef key="tagdocs"/>
         <moduleRef key="textcrit"/>
-        <moduleRef key="textstructure"/>  
-        <!-- required -->
+        <moduleRef key="textstructure"/> <!-- required -->
         <moduleRef key="transcr"/>
         <moduleRef key="verse"/>
-
 
         <xi:include href="tei_svg.odd"
                     xpointer="xmlns(t=http://www.tei-c.org/ns/1.0)xpointer(//t:moduleRef[@url])">

--- a/P5/Exemplars/tei_enrich.odd
+++ b/P5/Exemplars/tei_enrich.odd
@@ -4,1192 +4,1273 @@
      xmlns:rng="http://relaxng.org/ns/structure/1.0"
      xmlns:xi="http://www.w3.org/2001/XInclude"
      xmlns:s="http://www.ascc.net/xml/schematron"
-     xml:lang="en" 
+     xml:lang="en"
      n="enrich">
   <teiHeader>
     <fileDesc>
       <titleStmt>
-	<title>TEI P5 schema for ENRICH</title>
+        <title>TEI P5 schema for ENRICH</title>
       </titleStmt>
       <editionStmt>
-	<edition>1.0. Last updated on 3rd October 2008</edition>
+        <edition>1.0. Last updated on 3rd October 2008</edition>
       </editionStmt>
       <publicationStmt>
-	<publisher>TEI Consortium</publisher>
-	<availability>
-     <licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a Creative
-      Commons Attribution-ShareAlike 3.0 Unported License </licence>
-     <licence target="http://www.opensource.org/licenses/BSD-2-Clause">
-      <p>Copyright 2013 TEI Consortium.</p>
-      <p>All rights reserved.</p>
-      <p>Redistribution and use in source and binary forms, with or without modification, are
-       permitted provided that the following conditions are met:</p>
-      <list>
-       <item>Redistributions of source code must retain the above copyright notice, this list of
-        conditions and the following disclaimer.</item>
-       <item>Redistributions in binary form must reproduce the above copyright notice, this list of
-        conditions and the following disclaimer in the documentation and/or other materials provided
-        with the distribution.</item>
-      </list>
-      <p>This software is provided by the copyright holders and contributors "as is" and any express
-       or implied warranties, including, but not limited to, the implied warranties of
-       merchantability and fitness for a particular purpose are disclaimed. In no event shall the
-       copyright holder or contributors be liable for any direct, indirect, incidental, special,
-       exemplary, or consequential damages (including, but not limited to, procurement of substitute
-       goods or services; loss of use, data, or profits; or business interruption) however caused
-       and on any theory of liability, whether in contract, strict liability, or tort (including
-       negligence or otherwise) arising in any way out of the use of this software, even if advised
-       of the possibility of such damage.</p>
-     </licence>
-     <p>TEI material can be licensed differently depending on the use you intend to make of it.
-      Hence it is made available under both the CC+BY and BSD-2 licences. The CC+BY licence is
-      generally appropriate for usages which treat TEI content as data or documentation. The BSD-2
-      licence is generally appropriate for usage of TEI content in a software environment. For
-      further information or clarification, please contact the <ref target="mailto:info@tei-c.org"
-       >TEI Consortium</ref>. </p>
-	</availability>
+        <publisher>TEI Consortium</publisher>
+        <availability>
+          <licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a Creative
+          Commons Attribution-ShareAlike 3.0 Unported License </licence>
+          <licence target="http://www.opensource.org/licenses/BSD-2-Clause">
+            <p>Copyright 2013 TEI Consortium.</p>
+            <p>All rights reserved.</p>
+            <p>Redistribution and use in source and binary forms, with or without modification, are
+            permitted provided that the following conditions are met:</p>
+            <list>
+              <item>Redistributions of source code must retain the above copyright notice, this list of
+              conditions and the following disclaimer.</item>
+              <item>Redistributions in binary form must reproduce the above copyright notice, this list of
+              conditions and the following disclaimer in the documentation and/or other materials provided
+              with the distribution.</item>
+            </list>
+            <p>This software is provided by the copyright holders and contributors "as is" and any express
+            or implied warranties, including, but not limited to, the implied warranties of
+            merchantability and fitness for a particular purpose are disclaimed. In no event shall the
+            copyright holder or contributors be liable for any direct, indirect, incidental, special,
+            exemplary, or consequential damages (including, but not limited to, procurement of substitute
+            goods or services; loss of use, data, or profits; or business interruption) however caused
+            and on any theory of liability, whether in contract, strict liability, or tort (including
+            negligence or otherwise) arising in any way out of the use of this software, even if advised
+            of the possibility of such damage.</p>
+          </licence>
+          <p>TEI material can be licensed differently depending on the use you intend to make of it.
+          Hence it is made available under both the CC+BY and BSD-2 licences. The CC+BY licence is
+          generally appropriate for usages which treat TEI content as data or documentation. The BSD-2
+          licence is generally appropriate for usage of TEI content in a software environment. For
+          further information or clarification, please contact the <ref target="mailto:info@tei-c.org">TEI Consortium</ref>. </p>
+        </availability>
       </publicationStmt>
       <sourceDesc>
-	<p>Edited from scratch by 
-	<address>
-	  <addrLine><email>sebastian.rahtz@oucs.ox.ac.uk</email></addrLine>
-	  <addrLine><email>lou.burnard@oucs.ox.ac.uk</email></addrLine>
-	  <addrLine><email>james.cummings@oucs.ox.ac.uk</email></addrLine>
-	</address>
-	</p>
+        <p>Edited from scratch by 
+        <address>
+          <addrLine>
+            <email>sebastian.rahtz@oucs.ox.ac.uk</email>
+          </addrLine>
+          <addrLine>
+            <email>lou.burnard@oucs.ox.ac.uk</email>
+          </addrLine>
+          <addrLine>
+            <email>james.cummings@oucs.ox.ac.uk</email>
+          </addrLine>
+        </address>
+        </p>
       </sourceDesc>
     </fileDesc>
     <revisionDesc>
       <change rend="subversion">
-	$LastChangedDate$
-	$LastChangedBy$
-	$LastChangedRevision$
+        $LastChangedDate$
+        $LastChangedBy$
+        $LastChangedRevision$
       </change>
     </revisionDesc>
   </teiHeader>
   <text>
 
     <body>
-<div><head>Introduction</head>
+      <div>
+        <head>Introduction</head>
 
-<p>This document defines an XML format for the structure of the data
-which all ENRICH partners will contribute to the Manuscriptorium,
-either directly or indirectly by means of a harvester or
-transformation process. The schema is a conformant subset of Release 1.1.0
-of TEI P5. </p>
+        <p>This document defines an XML format for the structure of the data
+        which all ENRICH partners will contribute to the Manuscriptorium,
+        either directly or indirectly by means of a harvester or
+        transformation process. The schema is a conformant subset of Release 1.1.0
+        of TEI P5. </p>
 
-<p>The schema defined by this document addresses three distinct
-aspects of a digitized manuscript:
-<list rend="ordered">
-<item>metadata describing the original source manuscript (<ptr
-target="#msdesc"/>) </item>
-<item>metadata describing digitized images of the original source
-manuscript (<ptr target="#facs"/>) </item>
-<item>a transcription of the text contained by the original source
-manuscript <!--(<ptr target="#transcr"/>) --></item>
-</list></p>
+        <p>The schema defined by this document addresses three distinct
+        aspects of a digitized manuscript:
+        <list rend="ordered">
+          <item>metadata describing the original source manuscript (<ptr target="#msdesc"/>) </item>
+          <item>metadata describing digitized images of the original source
+          manuscript (<ptr target="#facs"/>) </item>
+          <item>a transcription of the text contained by the original source
+          manuscript <!--(<ptr target="#transcr"/>) --></item>
+        </list>
+        </p>
 
-<p>Within Manuscriptorium, only the first two are required. However,
-the schema documented here also provides for the third, in the
-interest of completeness and for the assistance of ENRICH partners
-wishing to provide richer access facilities to  their holdings. </p>
+        <p>Within Manuscriptorium, only the first two are required. However,
+        the schema documented here also provides for the third, in the
+        interest of completeness and for the assistance of ENRICH partners
+        wishing to provide richer access facilities to  their holdings. </p>
 
-<p>The schema defined by this document is available in DTD, RELAX NG,
-and W3C Schema languages, downloadable from the address <ptr
-target="http://tei.oucs.ox.ac.uk/ENRICH/ODD/RomaResults/"/>. A PDF
-version of the present document (300 pages) is also available from 
-<ptr
-target="http://tei.oucs.ox.ac.uk/ENRICH/Deliverables/referenceManual.pdf"/>;
-this forms one of the key deliverables for Work Package 3 of the ENRICH project. </p>
-
-
-<p>The MASTER and MASTER-X specifications both defined comparatively
-unconstrained XML formats, which permitted a very wide range of
-possibilities and did not attempt to constrain (for example)
-values to any predefined set of values. While appropriate for an
-interchange format, this approach has some drawbacks. 
-<list>
-<item>there may be wide variation in approaches taken to represent
-essentially the same phenomenon (e.g.)</item>
-<item>the format appears over complex to novice users, who will only
-ever want to use a very small subset of the possible tags</item>
-<item>developing software (e.g. stylesheets) for the format becomes
-unnecessarily complex, since every possibility must be allowed for
-even though it is unlikely to appear</item>
-<item>accurate searching of the data may be needlessly complicated by
-the large number of ways of representing e.g. attribute values such as
-dates</item>
-</list>
-</p>
-<p>In the ENRICH schema  the number of choices
-and the possible values of several attributes to have been
-considerably constrained. Nevertheless, 
-<list>
-<item>the resulting schema  remains fully  TEI Conformant: we are only
-defining a subset</item>
-<item>all constraints introduced have the full consent of all
-partners in the project</item>
-</list></p>
-
-<p>The overall structure of an ENRICH-conformant XML document may be
-summarized as follows:
-<egXML xmlns="http://www.tei-c.org/ns/Examples" >
-<TEI >
-<teiHeader>
-<!-- ... metadata describing the manuscript  -->
-</teiHeader>
-<facsimile>
-<!-- ... metadata describing the digital images -->
-</facsimile>
-<text>
-<!-- (optional) transcription of the manuscript -->
-</text>
-</TEI>
-
-</egXML>
-
-</p>
-
-<p>The remainder of this document describes each of these aspects in
-more detail, using material derived from the P5 release of the TEI
-Guidelines.</p>
-
-</div>
-
-<div type="div2" xml:id="msdesc">
-
-<head>Manuscript Description Metadata</head>
-
-<p>Each distinct manuscript must be described using a distinct
-TEI-conformant <gi>teiHeader</gi> element, as specified in the <ref
-target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/HD.html">TEI
-Guidelines, chapter 2</ref>. This
-element may contain many components, depending on the needs of the
-creator, which may be provided in either structured or (relatively)
-unstructured form. For Manuscriptorium purposes, the following
-components of the TEI Header <emph>must</emph> be provided, and
-<emph>must</emph> conform to the constraints specified here.
-<specList>
-<specDesc key="fileDesc"/>
-<specDesc key="titleStmt"/>
-<specDesc key="publicationStmt"/>
-<specDesc key="sourceDesc"/>
-<specDesc key="revisionDesc"/>
-</specList>
-</p>
-
-<p>Other header components, if present, will be ignored by
-Manuscriptorium; they will be retained for storage in the system and
-returned on request, but their content is not processed for any
-purpose, including access.</p>
+        <p>The schema defined by this document is available in DTD, RELAX NG,
+        and W3C Schema languages, downloadable from the address <ptr target="http://tei.oucs.ox.ac.uk/ENRICH/ODD/RomaResults/"/>. A PDF
+        version of the present document (300 pages) is also available from 
+        <ptr target="http://tei.oucs.ox.ac.uk/ENRICH/Deliverables/referenceManual.pdf"/>;
+        this forms one of the key deliverables for Work Package 3 of the ENRICH project. </p>
 
 
+        <p>The MASTER and MASTER-X specifications both defined comparatively
+        unconstrained XML formats, which permitted a very wide range of
+        possibilities and did not attempt to constrain (for example)
+        values to any predefined set of values. While appropriate for an
+        interchange format, this approach has some drawbacks. 
+        <list>
+          <item>there may be wide variation in approaches taken to represent
+          essentially the same phenomenon (e.g.)</item>
+          <item>the format appears over complex to novice users, who will only
+          ever want to use a very small subset of the possible tags</item>
+          <item>developing software (e.g. stylesheets) for the format becomes
+          unnecessarily complex, since every possibility must be allowed for
+          even though it is unlikely to appear</item>
+          <item>accurate searching of the data may be needlessly complicated by
+          the large number of ways of representing e.g. attribute values such as
+          dates</item>
+        </list>
+        </p>
+        <p>In the ENRICH schema  the number of choices
+        and the possible values of several attributes to have been
+        considerably constrained. Nevertheless, 
+        <list>
+          <item>the resulting schema  remains fully  TEI Conformant: we are only
+          defining a subset</item>
+          <item>all constraints introduced have the full consent of all
+          partners in the project</item>
+        </list>
+        </p>
 
-<p>The following example shows the minimal required structure:
-<egXML xmlns="http://www.tei-c.org/ns/Examples" >
-<teiHeader>
-<fileDesc>
-<titleStmt>
-<title>[Title of manuscript]</title>
-</titleStmt>
-<publicationStmt>
-<distributor>[name of data provider]</distributor>
-<idno>[project-specific identifier]</idno>
-</publicationStmt>
-<sourceDesc>
-<msDesc xml:id="ex5" xml:lang="en"> <!-- [full manuscript description ]--></msDesc>
-</sourceDesc>
-</fileDesc>
-<revisionDesc>
-<change when="2008-01-01">
-  <!--  [revision information] -->
-</change>
-</revisionDesc>
-</teiHeader>
-</egXML>
-</p>
-<p>Taking these in turn,
-<list>
+        <p>The overall structure of an ENRICH-conformant XML document may be
+        summarized as follows:
+        <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <TEI>
+            <teiHeader>
+              <!-- ... metadata describing the manuscript  -->
+            </teiHeader>
+            <facsimile>
+              <!-- ... metadata describing the digital images -->
+            </facsimile>
+            <text>
+              <!-- (optional) transcription of the manuscript -->
+            </text>
+          </TEI>
 
-<item>the title of the manuscript is used to identify it in short
-summary displays; it should correspond with the information used for
-the same purpose in the <gi>head</gi> element within the
-<gi>msDesc</gi> element below.</item>
+        </egXML>
 
-<item>the name of the data provider may be given in any conventional
-form but should be consistent across all data provided.</item>
+        </p>
 
-<item>the project-specific identifier has two parts: it consists of
-the short alphabetic code used to identify the partner (e.g. OCS for
-OUCS), followed by a four digit sequence number. For example,
-<code>OCS0002</code> would be the second digital record contributed to
-the Manuscriptorium project by partner OCS. Note that this identifier
-has nothing to do with the manuscript shelfmark or other
-identifier. When ingesting records, Manuscriptorium will assume that
-if a record with this identifier already exists, the intention is to
-replace it.</item>
+        <p>The remainder of this document describes each of these aspects in
+        more detail, using material derived from the P5 release of the TEI
+        Guidelines.</p>
 
-<item>the manuscript description provided must follow the
-specification given in the remainder of this section.</item>
+      </div>
 
-<item>at least one <gi>change</gi> element must be provided, providing
-the date that this record was last revised before being submitted. As
-elsewhere, dates must be provided in the ISO format
-<code>yyyy-mm-dd</code>. The content of the <gi>change</gi> element
-is free text, which may be used to indicate the scope of any revision
-and the person/s responsible for it. </item>
-</list>
-</p>
+      <div type="div2" xml:id="msdesc">
 
-<p>
-<specList>
-<specDesc key="msDesc" atts="xml:id xml:lang"/>
-</specList>
- 
-The <gi>msDesc</gi> element is used to provide detailed information
-about a single manuscript. For ENRICH purposes, this must carry the
-attributes mentioned above, to supply a unique internal identifier for the
-manuscript, and to specify the language of its description
-respectively. </p>
-<p>The value for <att>xml:id</att> may be the same as the value
-supplied for the <gi>idno</gi> element in the <gi>teiHeader</gi>, or
-it may be some other project-specific identifier used for
-cross-reference. It should however be prefixed by an identifier for
-the partner concerned, so as to avoid possible identifier
-collisions. </p>
-<p>The value for <att>xml:lang</att>, as elsewhere, must be supplied
-in the form of a valid language identifier (see below). If no value is
-supplied, the assumption is that the language of the description is
-English.</p>
-<p>The <gi>msDesc</gi> element  has the following component elements,
-each of which is further described in the
-remainder of this section. 
-<specList>
-<specDesc key="msIdentifier"/>
-<specDesc key="msContents"/>
-<specDesc key="physDesc"/>
-<specDesc key="history"/>
-<specDesc key="additional"/>
-<specDesc key="msPart"/>
-</specList></p>
+        <head>Manuscript Description Metadata</head>
 
-<p>The first of these components, <gi>msIdentifier</gi>, is mandatory;
-it is described in more detail in <ptr target="#msid"/> below. It is
-followed by either one or more paragraphs, marked up as a series of
-<gi>p</gi> elements, or one or more of the specialized elements
-<gi>msContents</gi> (<ptr target="#msco"/>), <gi>physDesc</gi> (<ptr
-target="#msph"/>), <gi>history</gi> (<ptr target="#mshy"/>), and
-<gi>additional</gi> (<ptr target="#msad"/>).  These elements are all
-optional, but if used they must appear in the order given here.
-Finally, in the case of a composite manuscript, a full description may
-also contain one or more <gi>msPart</gi> elements (<ptr
-target="#mspt"/>).</p>
+        <p>Each distinct manuscript must be described using a distinct
+        TEI-conformant <gi>teiHeader</gi> element, as specified in the <ref target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/HD.html">TEI
+        Guidelines, chapter 2</ref>. This
+        element may contain many components, depending on the needs of the
+        creator, which may be provided in either structured or (relatively)
+        unstructured form. For Manuscriptorium purposes, the following
+        components of the TEI Header <emph>must</emph> be provided, and
+        <emph>must</emph> conform to the constraints specified here.
+        <specList>
+          <specDesc key="fileDesc"/>
+          <specDesc key="titleStmt"/>
+          <specDesc key="publicationStmt"/>
+          <specDesc key="sourceDesc"/>
+          <specDesc key="revisionDesc"/>
+        </specList>
+        </p>
+
+        <p>Other header components, if present, will be ignored by
+        Manuscriptorium; they will be retained for storage in the system and
+        returned on request, but their content is not processed for any
+        purpose, including access.</p>
 
 
-<p>To demonstrate the variety of records which may be produced,
-consider the following sample manuscript description, chosen more or
-less at random from the Bodleian Library's <title level="m">Summary
-catalogue</title>
-<figure >
-<graphic width="450px" url="images/MSadda61.png"/>
-<head>Entry for Bodleian MS. Add. A. 61 in Madan et al.
-    1895-1953</head>
-</figure>
-</p>
 
-<p>The simplest way of digitizing this catalogue entry would simply be
-to key in the text, tagging the relevant parts of it which make up
-the mandatory <gi>msIdentifier</gi> element, as follows:
+        <p>The following example shows the minimal required structure:
+        <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <teiHeader>
+            <fileDesc>
+              <titleStmt>
+                <title>[Title of manuscript]</title>
+              </titleStmt>
+              <publicationStmt>
+                <distributor>[name of data provider]</distributor>
+                <idno>[project-specific identifier]</idno>
+              </publicationStmt>
+              <sourceDesc>
+                <msDesc xml:id="ex5" xml:lang="en"> <!-- [full manuscript description ]--></msDesc>
+              </sourceDesc>
+            </fileDesc>
+            <revisionDesc>
+              <change when="2008-01-01">
+                <!--  [revision information] -->
+              </change>
+            </revisionDesc>
+          </teiHeader>
+        </egXML>
+        </p>
+        <p>Taking these in turn,
+        <list>
 
-<egXML xmlns="http://www.tei-c.org/ns/Examples" >
-<msDesc xml:id="ex4" xml:lang="en">
-<msIdentifier>
-<settlement>Oxford</settlement>
-<repository>Bodleian Library</repository>
-<idno>MS. Add. A. 61</idno>
-<altIdentifier type="former"><idno>28843</idno></altIdentifier>
-</msIdentifier>
-<p>In Latin, on parchment: written in more than one hand of the 13th
-cent. in England: 7¼ x 5⅜ in., i + 55 leaves, in double columns: with
-a few coloured capitals.</p>
-<p>'Hic incipit Bruitus Anglie,' the De origine et gestis Regum
-Angliae of Geoffrey of Monmouth (Galfridus Monumetensis: beg. 'Cum
-mecum multa &amp; de multis.'</p>
-<p>On fol. 54v very faint is 'Iste liber est fratris guillelmi de
-buria de ... Roberti ordinis fratrum Pred[icatorum],' 14th cent. (?):
-'hanauilla' is written at the foot of the page (15th cent.).  Bought
-from the rev. W. D. Macray on March 17, 1863, for £1 10s.</p>
-</msDesc></egXML>
-With a suitable stylesheet, this encoding would be as readable as the
-original; it would not, however, be very useful for search purposes
-since only shelfmarks and other identifiers are distinguished by the markup. To
-improve on this, one might wrap the paragraphs in the appropriate
-special-purpose first-child-level elements of <gi>msDesc</gi> and use
-some additional phrase-level elements:
-<egXML xmlns="http://www.tei-c.org/ns/Examples" >
-<msDesc xml:id="ex1" xml:lang="en">
-<msIdentifier>
- <settlement>Oxford</settlement>
- <repository>Bodleian Library</repository>
- <idno>MS. Add. A. 61</idno>
- <altIdentifier type="former">
-  <idno>28843</idno>
- </altIdentifier>
-</msIdentifier>
-<msContents>
- <p><quote xml:lang="lat">Hic incipit Bruitus  Anglie,</quote> the 
-<title xml:lang="lat">De origine et gestis Regum Angliae</title> 
-of Geoffrey of Monmouth (Galfridus Monumetensis): 
-beg. <quote xml:lang="lat">Cum mecum multa &amp; de multis.</quote> 
-In Latin.</p>
-</msContents>
-<physDesc>
- <p><material>Parchment</material>: written in 
-more than one hand: 7¼ x 5⅜ in., i + 55 leaves, in double
-columns: with a few coloured capitals.</p>
-</physDesc>
-<history>
- <p>Written in
-<origPlace>England</origPlace> in the
-   <origDate>13th cent.</origDate> On fol. 54v very faint is
-<quote xml:lang="lat">Iste liber est fratris guillelmi de buria de ... Roberti
-   ordinis fratrum Pred[icatorum],</quote> 14th cent. (?):
-<quote>hanauilla</quote> is written at the foot of the page
-   (15th cent.). Bought from the rev. W. D. Macray on March 17, 1863, for
-   £1 10s.</p>
-</history>
-   </msDesc>
-</egXML>
-Such an encoding allows the user to search for such features as title,
-material, and date and place of origin; it is also possible to
-distinguish quoted material and Latin material from descriptive
-passages and to search within distinct parts of the description, for
-example, the manuscript history as distinct from its materials.</p>
+          <item>the title of the manuscript is used to identify it in short
+          summary displays; it should correspond with the information used for
+          the same purpose in the <gi>head</gi> element within the
+          <gi>msDesc</gi> element below.</item>
+
+          <item>the name of the data provider may be given in any conventional
+          form but should be consistent across all data provided.</item>
+
+          <item>the project-specific identifier has two parts: it consists of
+          the short alphabetic code used to identify the partner (e.g. OCS for
+          OUCS), followed by a four digit sequence number. For example,
+          <code>OCS0002</code> would be the second digital record contributed to
+          the Manuscriptorium project by partner OCS. Note that this identifier
+          has nothing to do with the manuscript shelfmark or other
+          identifier. When ingesting records, Manuscriptorium will assume that
+          if a record with this identifier already exists, the intention is to
+          replace it.</item>
+
+          <item>the manuscript description provided must follow the
+          specification given in the remainder of this section.</item>
+
+          <item>at least one <gi>change</gi> element must be provided, providing
+          the date that this record was last revised before being submitted. As
+          elsewhere, dates must be provided in the ISO format
+          <code>yyyy-mm-dd</code>. The content of the <gi>change</gi> element
+          is free text, which may be used to indicate the scope of any revision
+          and the person/s responsible for it. </item>
+        </list>
+        </p>
+
+        <p>
+          <specList>
+            <specDesc key="msDesc" atts="xml:id xml:lang"/>
+          </specList>
+          
+          The <gi>msDesc</gi> element is used to provide detailed information
+          about a single manuscript. For ENRICH purposes, this must carry the
+          attributes mentioned above, to supply a unique internal identifier for the
+          manuscript, and to specify the language of its description
+        respectively. </p>
+        <p>The value for <att>xml:id</att> may be the same as the value
+        supplied for the <gi>idno</gi> element in the <gi>teiHeader</gi>, or
+        it may be some other project-specific identifier used for
+        cross-reference. It should however be prefixed by an identifier for
+        the partner concerned, so as to avoid possible identifier
+        collisions. </p>
+        <p>The value for <att>xml:lang</att>, as elsewhere, must be supplied
+        in the form of a valid language identifier (see below). If no value is
+        supplied, the assumption is that the language of the description is
+        English.</p>
+        <p>The <gi>msDesc</gi> element  has the following component elements,
+        each of which is further described in the
+        remainder of this section. 
+        <specList>
+          <specDesc key="msIdentifier"/>
+          <specDesc key="msContents"/>
+          <specDesc key="physDesc"/>
+          <specDesc key="history"/>
+          <specDesc key="additional"/>
+          <specDesc key="msPart"/>
+        </specList>
+        </p>
+
+        <p>The first of these components, <gi>msIdentifier</gi>, is mandatory;
+        it is described in more detail in <ptr target="#msid"/> below. It is
+        followed by either one or more paragraphs, marked up as a series of
+        <gi>p</gi> elements, or one or more of the specialized elements
+        <gi>msContents</gi> (<ptr target="#msco"/>), <gi>physDesc</gi> (<ptr target="#msph"/>), <gi>history</gi> (<ptr target="#mshy"/>), and
+        <gi>additional</gi> (<ptr target="#msad"/>).  These elements are all
+        optional, but if used they must appear in the order given here.
+        Finally, in the case of a composite manuscript, a full description may
+        also contain one or more <gi>msPart</gi> elements (<ptr target="#mspt"/>).</p>
+
+
+        <p>To demonstrate the variety of records which may be produced,
+        consider the following sample manuscript description, chosen more or
+        less at random from the Bodleian Library's <title level="m">Summary
+        catalogue</title>
+        <figure>
+          <graphic width="450px" url="images/MSadda61.png"/>
+          <head>Entry for Bodleian MS. Add. A. 61 in Madan et al.
+          1895-1953</head>
+        </figure>
+        </p>
+
+        <p>The simplest way of digitizing this catalogue entry would simply be
+        to key in the text, tagging the relevant parts of it which make up
+        the mandatory <gi>msIdentifier</gi> element, as follows:
+
+        <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <msDesc xml:id="ex4" xml:lang="en">
+            <msIdentifier>
+              <settlement>Oxford</settlement>
+              <repository>Bodleian Library</repository>
+              <idno>MS. Add. A. 61</idno>
+              <altIdentifier type="former">
+                <idno>28843</idno>
+              </altIdentifier>
+            </msIdentifier>
+            <p>In Latin, on parchment: written in more than one hand of the 13th
+            cent. in England: 7¼ x 5⅜ in., i + 55 leaves, in double columns: with
+            a few coloured capitals.</p>
+            <p>'Hic incipit Bruitus Anglie,' the De origine et gestis Regum
+            Angliae of Geoffrey of Monmouth (Galfridus Monumetensis: beg. 'Cum
+            mecum multa &amp; de multis.'</p>
+            <p>On fol. 54v very faint is 'Iste liber est fratris guillelmi de
+            buria de ... Roberti ordinis fratrum Pred[icatorum],' 14th cent. (?):
+            'hanauilla' is written at the foot of the page (15th cent.).  Bought
+            from the rev. W. D. Macray on March 17, 1863, for £1 10s.</p>
+          </msDesc>
+        </egXML>
+        With a suitable stylesheet, this encoding would be as readable as the
+        original; it would not, however, be very useful for search purposes
+        since only shelfmarks and other identifiers are distinguished by the markup. To
+        improve on this, one might wrap the paragraphs in the appropriate
+        special-purpose first-child-level elements of <gi>msDesc</gi> and use
+        some additional phrase-level elements:
+        <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <msDesc xml:id="ex1" xml:lang="en">
+            <msIdentifier>
+              <settlement>Oxford</settlement>
+              <repository>Bodleian Library</repository>
+              <idno>MS. Add. A. 61</idno>
+              <altIdentifier type="former">
+                <idno>28843</idno>
+              </altIdentifier>
+            </msIdentifier>
+            <msContents>
+              <p>
+                <quote xml:lang="lat">Hic incipit Bruitus  Anglie,</quote> the 
+                <title xml:lang="lat">De origine et gestis Regum Angliae</title> 
+                of Geoffrey of Monmouth (Galfridus Monumetensis): 
+                beg. <quote xml:lang="lat">Cum mecum multa &amp; de multis.</quote> 
+              In Latin.</p>
+            </msContents>
+            <physDesc>
+              <p>
+                <material>Parchment</material>: written in 
+                more than one hand: 7¼ x 5⅜ in., i + 55 leaves, in double
+              columns: with a few coloured capitals.</p>
+            </physDesc>
+            <history>
+              <p>Written in
+              <origPlace>England</origPlace> in the
+              <origDate>13th cent.</origDate> On fol. 54v very faint is
+              <quote xml:lang="lat">Iste liber est fratris guillelmi de buria de ... Roberti
+              ordinis fratrum Pred[icatorum],</quote> 14th cent. (?):
+              <quote>hanauilla</quote> is written at the foot of the page
+              (15th cent.). Bought from the rev. W. D. Macray on March 17, 1863, for
+              £1 10s.</p>
+            </history>
+          </msDesc>
+        </egXML>
+        Such an encoding allows the user to search for such features as title,
+        material, and date and place of origin; it is also possible to
+        distinguish quoted material and Latin material from descriptive
+        passages and to search within distinct parts of the description, for
+        example, the manuscript history as distinct from its materials.</p>
         
-<p>This process could be continued further, restructuring the whole
-entry so as to take full advantage of many more  encoding
-possibilities:
+        <p>This process could be continued further, restructuring the whole
+        entry so as to take full advantage of many more  encoding
+        possibilities:
 
-<egXML xmlns="http://www.tei-c.org/ns/Examples" >
-<msDesc  xml:id="ex2" xml:lang="en">
-<msIdentifier>
- <settlement>Oxford</settlement>
- <repository>Bodleian Library</repository>
- <idno>MS. Add. A. 61</idno>
- <altIdentifier type="former">
-  <idno>28843</idno>
- </altIdentifier>
-</msIdentifier>
-<msContents>
- <msItem>
-  <author xml:lang="en">Geoffrey of Monmouth</author>
-  <author xml:lang="la">Galfridus Monumetensis</author>
-  <title type="uniform" xml:lang="la">De origine et
-   gestis Regum Angliae</title>
-  <rubric xml:lang="la">Hic incipit Bruitus Anglie</rubric>
-  <incipit xml:lang="la">Cum mecum multa &amp; de multis</incipit>
-  <textLang mainLang="la">Latin</textLang>
- </msItem>
-</msContents>
-<physDesc>
- <objectDesc form="codex">
-  <supportDesc material="perg">
-   <support>
-    <p>Parchment.</p>
-   </support>
-   <extent>i + 55 leaves
-<dimensions scope="all" type="leaf" unit="in">
-     <height>7¼</height>
-     <width>5⅜</width>
-    </dimensions>
-   </extent>
-  </supportDesc>
-  <layoutDesc>
-   <layout columns="2">
-    <p>In double columns.</p>
-   </layout>
-  </layoutDesc>
- </objectDesc>
- <handDesc>
-  <p>Written in more than one  hand.</p>
- </handDesc>
- <decoDesc>
-  <p>With a few coloured capitals.</p>
- </decoDesc>
-</physDesc>
-<history>
- <origin>
-  <p>Written in <origPlace>England</origPlace> in the <origDate notAfter="1300" notBefore="1200">13th cent.</origDate></p>
- </origin>
- <provenance>
-  <p>On fol. 54v very faint is
-   <quote xml:lang="la">Iste liber est fratris guillelmi de buria de
-   <gap reason="illegible"/>
-   Roberti ordinis fratrum
-   Pred<ex>icatorum</ex></quote>, 14th cent. (?):
-<quote>hanauilla</quote> is written at the foot of the page
-   (15th cent.).</p>
- </provenance>
- <acquisition>
-  <p>Bought from the rev. <name type="person" key="MCRAYWD">W. D. Macray</name> on 
-<date when="1863-03-17">March 17, 1863</date>, for £1 10s.</p>
- </acquisition>
-</history>
-</msDesc>
-</egXML>
-</p>
+        <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <msDesc xml:id="ex2" xml:lang="en">
+            <msIdentifier>
+              <settlement>Oxford</settlement>
+              <repository>Bodleian Library</repository>
+              <idno>MS. Add. A. 61</idno>
+              <altIdentifier type="former">
+                <idno>28843</idno>
+              </altIdentifier>
+            </msIdentifier>
+            <msContents>
+              <msItem>
+                <author xml:lang="en">Geoffrey of Monmouth</author>
+                <author xml:lang="la">Galfridus Monumetensis</author>
+                <title type="uniform" xml:lang="la">De origine et
+                gestis Regum Angliae</title>
+                <rubric xml:lang="la">Hic incipit Bruitus Anglie</rubric>
+                <incipit xml:lang="la">Cum mecum multa &amp; de multis</incipit>
+                <textLang mainLang="la">Latin</textLang>
+              </msItem>
+            </msContents>
+            <physDesc>
+              <objectDesc form="codex">
+                <supportDesc material="perg">
+                  <support>
+                    <p>Parchment.</p>
+                  </support>
+                  <extent>i + 55 leaves
+                  <dimensions scope="all" type="leaf" unit="in">
+                    <height>7¼</height>
+                    <width>5⅜</width>
+                  </dimensions>
+                  </extent>
+                </supportDesc>
+                <layoutDesc>
+                  <layout columns="2">
+                    <p>In double columns.</p>
+                  </layout>
+                </layoutDesc>
+              </objectDesc>
+              <handDesc>
+                <p>Written in more than one  hand.</p>
+              </handDesc>
+              <decoDesc>
+                <p>With a few coloured capitals.</p>
+              </decoDesc>
+            </physDesc>
+            <history>
+              <origin>
+                <p>Written in <origPlace>England</origPlace> in the <origDate notAfter="1300" notBefore="1200">13th cent.</origDate>
+                </p>
+              </origin>
+              <provenance>
+                <p>On fol. 54v very faint is
+                <quote xml:lang="la">Iste liber est fratris guillelmi de buria de
+                <gap reason="illegible"/>
+                Roberti ordinis fratrum
+                Pred<ex>icatorum</ex>
+                </quote>, 14th cent. (?):
+                <quote>hanauilla</quote> is written at the foot of the page
+                (15th cent.).</p>
+              </provenance>
+              <acquisition>
+                <p>Bought from the rev. <name type="person" key="MCRAYWD">W. D. Macray</name> on 
+                <date when="1863-03-17">March 17, 1863</date>, for £1 10s.</p>
+              </acquisition>
+            </history>
+          </msDesc>
+        </egXML>
+        </p>
 
-<div type="div2" xml:id="msphrase">
+        <div type="div2" xml:id="msphrase">
 
-<head>Phrase-level Elements</head>
-<p>Phrase-level elements are XML elements that can appear at the same
-hierarchic level as text in many parts of the digital
-record. Some of these are specialized, in that they may be used only
-within particular contexts; others may be used in any context (see <ptr target="#globalphrase"/>).
+          <head>Phrase-level Elements</head>
+          <p>Phrase-level elements are XML elements that can appear at the same
+          hierarchic level as text in many parts of the digital
+          record. Some of these are specialized, in that they may be used only
+          within particular contexts; others may be used in any context (see <ptr target="#globalphrase"/>).
 
-Within the components of the <gi>msDesc</gi> element, the
-following specialized phrase level elements are available:
+          Within the components of the <gi>msDesc</gi> element, the
+          following specialized phrase level elements are available:
 
-<specList>
-<specDesc key="catchwords"/>
-<specDesc key="dimensions"/>
-<specDesc key="heraldry"/>
-<specDesc key="locus"/>
-<specDesc key="material"/>
-<specDesc key="watermark"/>
-<specDesc key="origDate"/>
-<specDesc key="origPlace"/>
-<specDesc key="secFol"/>
-<specDesc key="signatures"/>
-</specList></p>
+          <specList>
+            <specDesc key="catchwords"/>
+            <specDesc key="dimensions"/>
+            <specDesc key="heraldry"/>
+            <specDesc key="locus"/>
+            <specDesc key="material"/>
+            <specDesc key="watermark"/>
+            <specDesc key="origDate"/>
+            <specDesc key="origPlace"/>
+            <specDesc key="secFol"/>
+            <specDesc key="signatures"/>
+          </specList>
+          </p>
 
-<div type="div3" xml:id="msdates">
-<head>Origination</head>
-<p>The following elements may be used to provide information about the
-origins of any aspect of a manuscript:
-<specList><specDesc key="origDate"/>
-<specDesc key="origPlace"/>
-</specList></p>
-<p>The <gi>origDate</gi> and <gi>origPlace</gi> elements are
-used to indicate  the date and
-place of origin of a manuscript or manuscript part. Such information
-will usually appear  within the <gi>history</gi> element,
-discussed in section <ptr target="#mshy"/>, but can also appear within
-other parts of the  manuscript description, such as its decoration or
-binding, when these are not of the same date as the manuscript
-itself. Both these elements are members of the
-<ident type="class">att.editLike</ident> class, from which they inherit the
-following attributes:
-<specList><specDesc key="att.editLike" atts="cert resp evidence"/></specList></p>
-<p>The <gi>origDate</gi> element is a member of the <ident
-type="class">att.datable</ident> class, and may thus also carry the
-following attributes: <specList><specDesc
-key="att.datable.w3c" atts="notBefore notAfter when from to"/></specList></p>
+          <div type="div3" xml:id="msdates">
+            <head>Origination</head>
+            <p>The following elements may be used to provide information about the
+            origins of any aspect of a manuscript:
+            <specList>
+              <specDesc key="origDate"/>
+              <specDesc key="origPlace"/>
+            </specList>
+            </p>
+            <p>The <gi>origDate</gi> and <gi>origPlace</gi> elements are
+            used to indicate  the date and
+            place of origin of a manuscript or manuscript part. Such information
+            will usually appear  within the <gi>history</gi> element,
+            discussed in section <ptr target="#mshy"/>, but can also appear within
+            other parts of the  manuscript description, such as its decoration or
+            binding, when these are not of the same date as the manuscript
+            itself. Both these elements are members of the
+            <ident type="class">att.editLike</ident> class, from which they inherit the
+            following attributes:
+            <specList>
+              <specDesc key="att.editLike" atts="cert resp evidence"/>
+            </specList>
+            </p>
+            <p>The <gi>origDate</gi> element is a member of the <ident type="class">att.datable</ident> class, and may thus also carry the
+            following attributes: <specList>
+            <specDesc key="att.datable.w3c" atts="notBefore notAfter when from to"/>
+          </specList>
+            </p>
 
-</div>
-<div type="div3" xml:id="msmat">
-<head>Material</head>
-<p>The <gi>material</gi> element can be used to tag any specific term
-used for the physical material of which a manuscript (or binding, seal, etc.)
-is composed.
-<specList>
-<specDesc key="material"/>
-</specList></p>
-<p>The element may appear wherever a term regarded as significant by
-the encoder occurs, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<binding>
-<p>Brown <material>calfskin</material>, previously with two clasps.</p>
-</binding>
-</egXML>
+          </div>
+          <div type="div3" xml:id="msmat">
+            <head>Material</head>
+            <p>The <gi>material</gi> element can be used to tag any specific term
+            used for the physical material of which a manuscript (or binding, seal, etc.)
+            is composed.
+            <specList>
+              <specDesc key="material"/>
+            </specList>
+            </p>
+            <p>The element may appear wherever a term regarded as significant by
+            the encoder occurs, as in the following example:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <binding>
+                <p>Brown <material>calfskin</material>, previously with two clasps.</p>
+              </binding>
+            </egXML>
 
-</p>
-</div>
-<div type="div3" xml:id="mswat"><head>Watermarks and Stamps</head>
-<p>Two further elements are provided to
-mark up other decorative features characteristic of manuscript leaves and
-bindings:
-<specList>
-<specDesc key="watermark"/>
-<specDesc key="stamp"/>
-</specList></p>
-<p>These elements may appear
-wherever a term regarded as significant by the encoder occurs. The
-<gi>watermark</gi> element is most likely to be of use within the
-<gi>support</gi> element discussed in <ptr target="#msph1sup"/>
-below. We give a simple example here: <egXML xmlns="http://www.tei-c.org/ns/Examples"><support><material>Rag
-paper</material> with <watermark>anchor</watermark>
-watermark</support></egXML></p>
-<p>The <gi>stamp</gi> element will typically appear when text from the source
-is being transcribed, for example within a rubric in the following case:
-<egXML xmlns="http://www.tei-c.org/ns/Examples"><rubric>Apologyticu TTVLLIANI AC IGNORATIA IN XPO IHV<lb/>
-SI NON LICET<lb/>
-NOBIS RO<lb/>
-manii imperii <stamp>Bodleian stamp</stamp><lb/></rubric></egXML>
-</p>
-<p>It may also appear as part of the detailed description of a binding:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<binding><p>Modern calf recasing with original armorial stamp <stamp>Ex
-Bibliotheca J. Richard D.M.</stamp></p></binding>
-</egXML>
-</p>
-</div>
-<div type="div3" xml:id="msdim">
-<head>Dimensions</head>
-<p>The <gi>dimensions</gi> element can be used to specify the size of
-some aspect of the manuscript.
-<specList>
-<specDesc key="dimensions" atts="type"/>
-</specList></p>
+            </p>
+          </div>
+          <div type="div3" xml:id="mswat">
+            <head>Watermarks and Stamps</head>
+            <p>Two further elements are provided to
+            mark up other decorative features characteristic of manuscript leaves and
+            bindings:
+            <specList>
+              <specDesc key="watermark"/>
+              <specDesc key="stamp"/>
+            </specList>
+            </p>
+            <p>These elements may appear
+            wherever a term regarded as significant by the encoder occurs. The
+            <gi>watermark</gi> element is most likely to be of use within the
+            <gi>support</gi> element discussed in <ptr target="#msph1sup"/>
+            below. We give a simple example here: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <support>
+              <material>Rag
+              paper</material> with <watermark>anchor</watermark>
+            watermark</support>
+          </egXML>
+            </p>
+            <p>The <gi>stamp</gi> element will typically appear when text from the source
+            is being transcribed, for example within a rubric in the following case:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <rubric>Apologyticu TTVLLIANI AC IGNORATIA IN XPO IHV<lb/>
+              SI NON LICET<lb/>
+              NOBIS RO<lb/>
+              manii imperii <stamp>Bodleian stamp</stamp>
+              <lb/>
+              </rubric>
+            </egXML>
+            </p>
+            <p>It may also appear as part of the detailed description of a binding:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <binding>
+                <p>Modern calf recasing with original armorial stamp <stamp>Ex
+                Bibliotheca J. Richard D.M.</stamp>
+                </p>
+              </binding>
+            </egXML>
+            </p>
+          </div>
+          <div type="div3" xml:id="msdim">
+            <head>Dimensions</head>
+            <p>The <gi>dimensions</gi> element can be used to specify the size of
+            some aspect of the manuscript.
+            <specList>
+              <specDesc key="dimensions" atts="type"/>
+            </specList>
+            </p>
 
-<p>The <gi>dimensions</gi> element will normally occur within the
-element describing the particular feature or aspect of a manuscript
-whose dimensions are being given; thus the size of the leaves would be
-specified within the <gi>support</gi> or <gi>extent</gi> element (part
-of the <gi>physDesc</gi> element discussed in <ptr target="#msph1"/>),
-while the dimensions of other specific parts of a manuscript, such as
-accompanying materials, binding, etc., would be given in other parts
-of the description, as appropriate. </p>
-<p>The <att>type</att> attribute on the <gi>dimensions</gi> element is
-used to specify more exactly the item being measured. For ENRICH
-purposes, this attribute must take one of the following values:
-<val>leaf</val>,
-<val>binding</val>,
-<val>slip</val>,
-<val>written</val>,
-<val>boxed</val>. </p>
-<p>The following three elements are available within the <gi>dimensions</gi> element:
-<specList>
-<specDesc key="height"/>
-<specDesc key="width"/>
-<specDesc key="depth"/>
-</specList>
-Each of these elements, if present, must be given in the order
-specified.</p>
-<p>These three elements, as well as <gi>dimensions</gi> itself, are
-all members of the <ident type="class">att.dimensions</ident> class,
-and thus all carry the following attributes: <specList><specDesc
-key="att.dimensions" atts="extent unit quantity atLeast atMost min max scope">
-</specDesc></specList></p>
-<p>Attributes <att>min</att>,  <att>max</att>, and <att>scope</att> are used only when the
-measurement applies to several items, for example the size of many or
-all the leaves in a manuscript; attributes <att>atLeast</att> and
-<att>atMost</att> are used when the measurement applies to a single
-item, for example the size of a  specific codex,  but has had to be
-estimated. Attribute <gi>quantity</gi> is used when the measurement
-can be given exactly, and applies to a single item; this is the usual
-situation.  The units in which dimensions are measured should always
-be specified using the <att>unit</att> attribute, which will normally
-be taken from a closed set of values appropriate to the project, using
-standard units of measurement wherever possible. In the ENRICH project
-the  following values are permitted:
-<val>cm</val>, 
-<val>mm</val>,
-<val>in</val>,
-<val>line</val>,
-<val>char</val>. If the only data available for the measurement uses
-some other unit, or it is preferred to normalize it in some other way,
-then it may be supplied as a string value using the
-<att>extent</att> attribute.
-</p>
-<p>The content of these elements, if present, simply copies the way
-that the measurement is presented in some source text; it may be
-omitted.
-</p>
-<p>In the simplest case, only the <att>extent</att> attribute may be
-supplied: 
-<egXML xmlns="http://www.tei-c.org/ns/Examples"><width
-extent="6 cubit">six cubits</width></egXML> 
-More usually, the measurement will be normalised into a value 
-and an appropriate SI unit: 
-<egXML xmlns="http://www.tei-c.org/ns/Examples"><width quantity="270" unit="cm">six cubits</width></egXML>
-Where the exact value is uncertain, the attributes <att>atLeast</att>
-and <att>atMost</att> may be used to indicate the upper and lower
-bounds of an estimated value:
-<egXML xmlns="http://www.tei-c.org/ns/Examples"><width atLeast="250"
-						       atMost="300" unit="cm">six cubits</width></egXML>
-</p>
+            <p>The <gi>dimensions</gi> element will normally occur within the
+            element describing the particular feature or aspect of a manuscript
+            whose dimensions are being given; thus the size of the leaves would be
+            specified within the <gi>support</gi> or <gi>extent</gi> element (part
+            of the <gi>physDesc</gi> element discussed in <ptr target="#msph1"/>),
+            while the dimensions of other specific parts of a manuscript, such as
+            accompanying materials, binding, etc., would be given in other parts
+            of the description, as appropriate. </p>
+            <p>The <att>type</att> attribute on the <gi>dimensions</gi> element is
+            used to specify more exactly the item being measured. For ENRICH
+            purposes, this attribute must take one of the following values:
+            <val>leaf</val>,
+            <val>binding</val>,
+            <val>slip</val>,
+            <val>written</val>,
+            <val>boxed</val>. </p>
+            <p>The following three elements are available within the <gi>dimensions</gi> element:
+            <specList>
+              <specDesc key="height"/>
+              <specDesc key="width"/>
+              <specDesc key="depth"/>
+            </specList>
+            Each of these elements, if present, must be given in the order
+            specified.</p>
+            <p>These three elements, as well as <gi>dimensions</gi> itself, are
+            all members of the <ident type="class">att.dimensions</ident> class,
+            and thus all carry the following attributes: <specList>
+            <specDesc key="att.dimensions"
+                      atts="extent unit quantity atLeast atMost min max scope">
+            </specDesc>
+          </specList>
+            </p>
+            <p>Attributes <att>min</att>,  <att>max</att>, and <att>scope</att> are used only when the
+            measurement applies to several items, for example the size of many or
+            all the leaves in a manuscript; attributes <att>atLeast</att> and
+            <att>atMost</att> are used when the measurement applies to a single
+            item, for example the size of a  specific codex,  but has had to be
+            estimated. Attribute <gi>quantity</gi> is used when the measurement
+            can be given exactly, and applies to a single item; this is the usual
+            situation.  The units in which dimensions are measured should always
+            be specified using the <att>unit</att> attribute, which will normally
+            be taken from a closed set of values appropriate to the project, using
+            standard units of measurement wherever possible. In the ENRICH project
+            the  following values are permitted:
+            <val>cm</val>, 
+            <val>mm</val>,
+            <val>in</val>,
+            <val>line</val>,
+            <val>char</val>. If the only data available for the measurement uses
+            some other unit, or it is preferred to normalize it in some other way,
+            then it may be supplied as a string value using the
+            <att>extent</att> attribute.
+            </p>
+            <p>The content of these elements, if present, simply copies the way
+            that the measurement is presented in some source text; it may be
+            omitted.
+            </p>
+            <p>In the simplest case, only the <att>extent</att> attribute may be
+            supplied: 
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <width extent="6 cubit">six cubits</width>
+            </egXML> 
+            More usually, the measurement will be normalised into a value 
+            and an appropriate SI unit: 
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <width quantity="270" unit="cm">six cubits</width>
+            </egXML>
+            Where the exact value is uncertain, the attributes <att>atLeast</att>
+            and <att>atMost</att> may be used to indicate the upper and lower
+            bounds of an estimated value:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <width atLeast="250" atMost="300" unit="cm">six cubits</width>
+            </egXML>
+            </p>
 
-<p>It is often convenient to supply a measurement which applies to a
-number of discrete observations: for example, the number of ruled
-lines on the pages of a manuscript (which may not all be the same), or
-the diameter of an object like a bell, which will differ depending
-where it is measured. In such cases, the <att>scope</att> attribute
-may be used to specify the observations for which this measurement is
-applicable:
-<egXML xmlns="http://www.tei-c.org/ns/Examples"><height unit="lines"
-							scope="most"
-							atLeast="20"/>
-</egXML>
-This indicates that most pages have at least 20 lines. The attributes
-<att>min</att> and <att>max</att> can also be used to specify the possible
-range of values: for example, to show that  all pages have between 12 
-and 30 lines: 
-<egXML xmlns="http://www.tei-c.org/ns/Examples"><height unit="lines"
-scope="all" min="12" max="30"/>
-</egXML>
-</p>
-<p>The <gi>dimensions</gi> element may be repeated as often as
-necessary, with appropriate attribute values to indicate the nature
-and scope of the measurement concerned. For example, in the following
-case the leaf size and ruled space of the leaves of the manuscript are
-specified:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<dimensions type="written" unit="mm">
- <height scope="most"  quantity="90" unit="mm"/>
- <width scope="most" quantity="48" unit="mm"/>
-</dimensions>
-<dimensions type="leaf">
- <height min="157" max="160" unit="mm"/>
- <width quantity="105" unit="mm"/>
-</dimensions>
-</egXML>
-This indicates that for most leaves of the manuscript being described
-the ruled space is 90 mm high and 48 mm wide, while the leaves throughout 
-are between 157 and 160 mm in height and 105 mm in width.</p>
+            <p>It is often convenient to supply a measurement which applies to a
+            number of discrete observations: for example, the number of ruled
+            lines on the pages of a manuscript (which may not all be the same), or
+            the diameter of an object like a bell, which will differ depending
+            where it is measured. In such cases, the <att>scope</att> attribute
+            may be used to specify the observations for which this measurement is
+            applicable:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <height unit="lines" scope="most" atLeast="20"/>
+            </egXML>
+            This indicates that most pages have at least 20 lines. The attributes
+            <att>min</att> and <att>max</att> can also be used to specify the possible
+            range of values: for example, to show that  all pages have between 12 
+            and 30 lines: 
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <height unit="lines" scope="all" min="12" max="30"/>
+            </egXML>
+            </p>
+            <p>The <gi>dimensions</gi> element may be repeated as often as
+            necessary, with appropriate attribute values to indicate the nature
+            and scope of the measurement concerned. For example, in the following
+            case the leaf size and ruled space of the leaves of the manuscript are
+            specified:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <dimensions type="written" unit="mm">
+                <height scope="most" quantity="90" unit="mm"/>
+                <width scope="most" quantity="48" unit="mm"/>
+              </dimensions>
+              <dimensions type="leaf">
+                <height min="157" max="160" unit="mm"/>
+                <width quantity="105" unit="mm"/>
+              </dimensions>
+            </egXML>
+            This indicates that for most leaves of the manuscript being described
+            the ruled space is 90 mm high and 48 mm wide, while the leaves throughout 
+            are between 157 and 160 mm in height and 105 mm in width.</p>
 
-</div>
-<div type="div3" xml:id="msloc"><head>References to Locations within a Manuscript</head>
-<p>The <gi>locus</gi> element is a specialized form of the <gi>ref</gi> element.
-<specList>
-<specDesc key="locus" atts="from to scheme"/>
-</specList></p>
-<p>The <gi>locus</gi> element is used to specify the location in the
-manuscript occupied by the element within which it appears. It should
-be supplied  as the first component of an <gi>msItem</gi> element, or of any of the more specific elements appearing within one
-(see further section <ptr target="#msco"/> below, in order to  specify the location of that item within the manuscript being
-described.</p>
-<p>A <gi>locus</gi> element can be used to identify any reference to
-one or more folios within a manuscript, wherever such a reference is
-appropriate. Locations are conventionally specified as a sequence of
-folio or page numbers, but may also be a discontinuous list, or a
-combination of the two. This specification should be given as the
-content of the <gi>locus</gi> element, using the conventions
-appropriate to the individual scholar or holding institution, as in
-the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msItem n="1"><locus>ff. 1-24r</locus>
-<title>Apocalypsis beati Ioannis Apostoli</title>
-</msItem>
-</egXML></p>
-<p>A normalized form of the location can also be
-supplied, using special purpose attributes on the <gi>locus</gi>
-element, as in the following revision of the above example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msItem n="1"><locus from="1r" to="24r">ff. 1-24r</locus>
-<title>Apocalypsis beati Ioannis Apostoli</title>
-</msItem>
-</egXML></p>
-<p>If a digital image is available for the locus described by the
-<gi>locus</gi> element, then the  <att>facs</att> attribute should be
-used  to  associate it
-with that  image, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<decoDesc>
-<p>Several of the miniatures in this section have been damaged and 
-overpainted at a later date (e.g. the figure of Christ on 
-<locus facs="#F33R">fol. 33r</locus>; the face of the 
-Shepherdess on <locus facs="#F59V">fol. 59v</locus>, 
-etc.).</p>
-</decoDesc>
-</egXML>
-Usually, the <att>facs</att> attribute  points
-directly to a <gi>surface</gi> element within the <gi>facsimile</gi>
-element associated with the manuscript description, as further
-discussed in section <ptr target="#facs"/> below. It is also possible,
-but not recommended, to use this attribute to point to images of the
-relevant pages held in some other external image archive.</p>
+          </div>
+          <div type="div3" xml:id="msloc">
+            <head>References to Locations within a Manuscript</head>
+            <p>The <gi>locus</gi> element is a specialized form of the <gi>ref</gi> element.
+            <specList>
+              <specDesc key="locus" atts="from to scheme"/>
+            </specList>
+            </p>
+            <p>The <gi>locus</gi> element is used to specify the location in the
+            manuscript occupied by the element within which it appears. It should
+            be supplied  as the first component of an <gi>msItem</gi> element, or of any of the more specific elements appearing within one
+            (see further section <ptr target="#msco"/> below, in order to  specify the location of that item within the manuscript being
+            described.</p>
+            <p>A <gi>locus</gi> element can be used to identify any reference to
+            one or more folios within a manuscript, wherever such a reference is
+            appropriate. Locations are conventionally specified as a sequence of
+            folio or page numbers, but may also be a discontinuous list, or a
+            combination of the two. This specification should be given as the
+            content of the <gi>locus</gi> element, using the conventions
+            appropriate to the individual scholar or holding institution, as in
+            the following example:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <msItem n="1">
+                <locus>ff. 1-24r</locus>
+                <title>Apocalypsis beati Ioannis Apostoli</title>
+              </msItem>
+            </egXML>
+            </p>
+            <p>A normalized form of the location can also be
+            supplied, using special purpose attributes on the <gi>locus</gi>
+            element, as in the following revision of the above example:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <msItem n="1">
+                <locus from="1r" to="24r">ff. 1-24r</locus>
+                <title>Apocalypsis beati Ioannis Apostoli</title>
+              </msItem>
+            </egXML>
+            </p>
+            <p>If a digital image is available for the locus described by the
+            <gi>locus</gi> element, then the  <att>facs</att> attribute should be
+            used  to  associate it
+            with that  image, as in the following example:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <decoDesc>
+                <p>Several of the miniatures in this section have been damaged and 
+                overpainted at a later date (e.g. the figure of Christ on 
+                <locus facs="#F33R">fol. 33r</locus>; the face of the 
+                Shepherdess on <locus facs="#F59V">fol. 59v</locus>, 
+                etc.).</p>
+              </decoDesc>
+            </egXML>
+            Usually, the <att>facs</att> attribute  points
+            directly to a <gi>surface</gi> element within the <gi>facsimile</gi>
+            element associated with the manuscript description, as further
+            discussed in section <ptr target="#facs"/> below. It is also possible,
+            but not recommended, to use this attribute to point to images of the
+            relevant pages held in some other external image archive.</p>
 
-<p>Where a transcription of the relevant pages is also available, this
-may be pointed to using the <att>target</att> attribute, as in the
-following example:
+            <p>Where a transcription of the relevant pages is also available, this
+            may be pointed to using the <att>target</att> attribute, as in the
+            following example:
 
-	<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<!-- within ms description -->
-            <msItem n="1">
-              <locus target="#f1r #f1v #f2r">ff. 1r-2r</locus>
-              <author>Ben Jonson</author>
-              <title>Ode to himself</title>
-              <rubric rend="italics">
-               An Ode<lb/> to him selfe.</rubric>
-              <incipit>Com leaue the loathed stage</incipit>
-              <explicit>And see his chariot triumph ore his wayne.</explicit>
-              <bibl><name type="person">Beal</name>, <title>Index 1450-1625</title>, JnB 380</bibl>
-            </msItem>
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <!-- within ms description -->
+              <msItem n="1">
+                <locus target="#f1r #f1v #f2r">ff. 1r-2r</locus>
+                <author>Ben Jonson</author>
+                <title>Ode to himself</title>
+                <rubric rend="italics">
+                An Ode<lb/> to him selfe.</rubric>
+                <incipit>Com leaue the loathed stage</incipit>
+                <explicit>And see his chariot triumph ore his wayne.</explicit>
+                <bibl>
+                <name type="person">Beal</name>, <title>Index 1450-1625</title>, JnB 380</bibl>
+              </msItem>
 
-	    <!-- within transcription ... -->
-	    <pb xml:id="f1r"/>
-	    <!-- ... -->
-	    <pb xml:id="f1v"/>
-	    <!-- ... -->
-	    <pb xml:id="f2r"/>
-	    <!-- ... -->
-	</egXML>
-</p>
+              <!-- within transcription ... -->
+              <pb xml:id="f1r"/>
+              <!-- ... -->
+              <pb xml:id="f1v"/>
+              <!-- ... -->
+              <pb xml:id="f2r"/>
+              <!-- ... -->
+            </egXML>
+            </p>
 
 
-<p>Where a manuscript contains more than one foliation, the
-<att>scheme</att> attribute may be used to distinguish them. For
-example, MS 65 Corpus Christi College, Cambridge contains two fly
-leaves bearing music. These leaves have modern foliation 135 and
-136 respectively, but are also marked with an older foliation. This
-may be preserved in an encoding such as the following:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<locus scheme="#original">XCIII</locus>
-<locus scheme="#modern">135</locus>
-</egXML> Here the <att>scheme</att> attribute points to a
-<gi>foliation</gi> element providing more details about the scheme
-used, as further discussed in <ptr target="#msphfo"/> below.</p>
-</div>
-<div type="div3" xml:id="msnames">
-<head>Names of Persons, Places, and Organizations</head>
-<p>The standard TEI element <gi>name</gi> may be used to identify
-names of any kind occurring within a description:
-<specList>
-<specDesc key="name" atts="type"/>
-</specList>
-As further discussed in <ptr target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/CO.html#CONARS"/>, this element is a member of
-the TEI class <ident type="class">att.canonical</ident>, from which it
-inherits the  following attributes:
-<specList><specDesc key="att.canonical" atts="key ref"/></specList>
-</p>
-<p>Here are some examples of the use of the <gi>name</gi> element:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<name type="person">Thomas Hoccleve</name>
-<name type="place">Villingaholt</name>
-<name type="org">Vetus Latina Institut</name>
-<name type="person" ref="#HOC001">Occleve</name>
-</egXML></p>
-<p>Note that the <gi>name</gi> element is defined as providing
-information about a <emph>name</emph>, not the person, place, or organization to which that name refers. In the last example above, the <att>ref</att> attribute is used to
-associate the name with a more detailed description of the person
-named. This is provided by means of the <gi>person</gi> element, which
-is also available in the ENRICH schema. An element such as the following might then be used to provide
-detailed information about the person indicated by the name:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<person xml:id="HOC001" sex="1">
-<persName><surname>Hoccleve</surname>
-<forename>Thomas</forename>
-</persName>
-<birth notBefore="1368"/>
-<occupation>poet</occupation>
-<!-- other personal data -->
-</person></egXML>
+            <p>Where a manuscript contains more than one foliation, the
+            <att>scheme</att> attribute may be used to distinguish them. For
+            example, MS 65 Corpus Christi College, Cambridge contains two fly
+            leaves bearing music. These leaves have modern foliation 135 and
+            136 respectively, but are also marked with an older foliation. This
+            may be preserved in an encoding such as the following:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <locus scheme="#original">XCIII</locus>
+              <locus scheme="#modern">135</locus>
+              </egXML> Here the <att>scheme</att> attribute points to a
+              <gi>foliation</gi> element providing more details about the scheme
+            used, as further discussed in <ptr target="#msphfo"/> below.</p>
+          </div>
+          <div type="div3" xml:id="msnames">
+            <head>Names of Persons, Places, and Organizations</head>
+            <p>The standard TEI element <gi>name</gi> may be used to identify
+            names of any kind occurring within a description:
+            <specList>
+              <specDesc key="name" atts="type"/>
+            </specList>
+            As further discussed in <ptr target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/CO.html#CONARS"/>, this element is a member of
+            the TEI class <ident type="class">att.canonical</ident>, from which it
+            inherits the  following attributes:
+            <specList>
+              <specDesc key="att.canonical" atts="key ref"/>
+            </specList>
+            </p>
+            <p>Here are some examples of the use of the <gi>name</gi> element:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <name type="person">Thomas Hoccleve</name>
+              <name type="place">Villingaholt</name>
+              <name type="org">Vetus Latina Institut</name>
+              <name type="person" ref="#HOC001">Occleve</name>
+            </egXML>
+            </p>
+            <p>Note that the <gi>name</gi> element is defined as providing
+            information about a <emph>name</emph>, not the person, place, or organization to which that name refers. In the last example above, the <att>ref</att> attribute is used to
+            associate the name with a more detailed description of the person
+            named. This is provided by means of the <gi>person</gi> element, which
+            is also available in the ENRICH schema. An element such as the following might then be used to provide
+            detailed information about the person indicated by the name:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <person xml:id="HOC001" sex="1">
+                <persName>
+                  <surname>Hoccleve</surname>
+                  <forename>Thomas</forename>
+                </persName>
+                <birth notBefore="1368"/>
+                <occupation>poet</occupation>
+                <!-- other personal data -->
+              </person>
+            </egXML>
 
-<!--<specList>
-<specDesc key="person"/>
-</specList>-->
-Note that an instance of the 
-<gi>person</gi> element must be provided for each distinct
-<att>ref</att> value specified. In the example above, the value
-<val>HOC001</val> must be found as the <att>xml:id</att> attribute of
-some <gi>person</gi>; the same
-value will be used as the <att>ref</att> attribute of every reference
-to Hoccleve in the document (however spelled), but there will only be
-one <gi>person</gi> element with this identifier.</p>
-<p>Alternatively, the <att>key</att> attribute may be used to supply
-an identifying code for the person referenced by the name
-independently of both the existence of  a <gi>person</gi> element and
-the use of the standard URI reference mechanism. If, for example, a
-project maintains as its authority file some non-digital resource, or
-uses  a database which cannot readily be
-integrated with other digital resources for this purpose, the unique
-codes used by such <soCalled>offline</soCalled> resources may be used
-as values for the <att>key</att> attribute. Although such practices clearly
-reduce the interchangeability of the resulting encoded texts, they may
-be judged more convenient or practical in certain situations.
-</p>
+            <!--<specList>
+                <specDesc key="person"/>
+                </specList>-->
+            Note that an instance of the 
+            <gi>person</gi> element must be provided for each distinct
+            <att>ref</att> value specified. In the example above, the value
+            <val>HOC001</val> must be found as the <att>xml:id</att> attribute of
+            some <gi>person</gi>; the same
+            value will be used as the <att>ref</att> attribute of every reference
+            to Hoccleve in the document (however spelled), but there will only be
+            one <gi>person</gi> element with this identifier.</p>
+            <p>Alternatively, the <att>key</att> attribute may be used to supply
+            an identifying code for the person referenced by the name
+            independently of both the existence of  a <gi>person</gi> element and
+            the use of the standard URI reference mechanism. If, for example, a
+            project maintains as its authority file some non-digital resource, or
+            uses  a database which cannot readily be
+            integrated with other digital resources for this purpose, the unique
+            codes used by such <soCalled>offline</soCalled> resources may be used
+            as values for the <att>key</att> attribute. Although such practices clearly
+            reduce the interchangeability of the resulting encoded texts, they may
+            be judged more convenient or practical in certain situations.
+            </p>
 
-<p>All the <gi>person</gi> elements referenced by a particular
-document set should be collected together within a <gi>listPerson</gi>
-<!-- need xref -->
-element, located in the TEI Header. This functions as a kind
-of prosopography for all the people referenced by the set of
-manuscripts being described, in much the same way as a
-<gi>listBibl</gi> element in the back matter may be used to hold
-bibliographic information for all the works referenced.</p>
+            <p>All the <gi>person</gi> elements referenced by a particular
+            document set should be collected together within a <gi>listPerson</gi>
+            <!-- need xref -->
+            element, located in the TEI Header. This functions as a kind
+            of prosopography for all the people referenced by the set of
+            manuscripts being described, in much the same way as a
+            <gi>listBibl</gi> element in the back matter may be used to hold
+            bibliographic information for all the works referenced.</p>
 
-<p>Similar mechanisms are used to maintain and reference canonical
-lists of places or organizations.</p>
-</div>
-<div type="div3" xml:id="msmisc">
-<head>Catchwords, Signatures, Secundo Folio</head>
-<p>The <gi>catchwords</gi> element is used to describe one method by
-which correct ordering of the quires of a codex is ensured. Typically,
-this takes the form of a word or phrase written in the lower margin of
-the last leaf verso of a gathering, which provides a preview of the
-first recto leaf of the successive gathering. This may be a simple
-phrase such as the following:
-<egXML xmlns="http://www.tei-c.org/ns/Examples"><catchwords>Quires signed on the last leaf verso in roman numerals.</catchwords>
-</egXML>
-Alternatively, it may contain more details:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<catchwords>Vertical catchwords in the hand of the scribe placed along 
-the inner bounding line, reading from top to bottom.</catchwords>
-</egXML></p>
-<p>The <soCalled>Signatures</soCalled> element is used, in a similar
-way, to describe a similar  system in which quires or leaves are
-marked  progressively  in order to facilitate arrangement during
-binding. For example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples"><signatures>At the bottom of the first four leaves of quires 1-14 are 
-  the remains of a series of quire signatures a-o plus roman figures in 
-  a cursive hand of the fourteenth century.</signatures>
-</egXML></p>
-<p>The <gi>signatures</gi> element can be used for either leaf
-signatures, or a combination of quire and leaf signatures, whether the
-marking is alphabetic, alphanumeric, or some ad hoc system, as in the
-following more complex example:
+            <p>Similar mechanisms are used to maintain and reference canonical
+            lists of places or organizations.</p>
+          </div>
+          <div type="div3" xml:id="msmisc">
+            <head>Catchwords, Signatures, Secundo Folio</head>
+            <p>The <gi>catchwords</gi> element is used to describe one method by
+            which correct ordering of the quires of a codex is ensured. Typically,
+            this takes the form of a word or phrase written in the lower margin of
+            the last leaf verso of a gathering, which provides a preview of the
+            first recto leaf of the successive gathering. This may be a simple
+            phrase such as the following:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <catchwords>Quires signed on the last leaf verso in roman numerals.</catchwords>
+            </egXML>
+            Alternatively, it may contain more details:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <catchwords>Vertical catchwords in the hand of the scribe placed along 
+              the inner bounding line, reading from top to bottom.</catchwords>
+            </egXML>
+            </p>
+            <p>The <soCalled>Signatures</soCalled> element is used, in a similar
+            way, to describe a similar  system in which quires or leaves are
+            marked  progressively  in order to facilitate arrangement during
+            binding. For example:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <signatures>At the bottom of the first four leaves of quires 1-14 are 
+              the remains of a series of quire signatures a-o plus roman figures in 
+              a cursive hand of the fourteenth century.</signatures>
+            </egXML>
+            </p>
+            <p>The <gi>signatures</gi> element can be used for either leaf
+            signatures, or a combination of quire and leaf signatures, whether the
+            marking is alphabetic, alphanumeric, or some ad hoc system, as in the
+            following more complex example:
 
-<egXML xmlns="http://www.tei-c.org/ns/Examples"><signatures>Quire and leaf signatures in letters, [b]-v, and roman numerals; 
-those in quires 10 (1) and 17 (s) in red ink and different from others; 
-every third quire also signed with red crayon in arabic numerals in the 
-centre lower margin of the first leaf recto: "2" for quire 4 (f. 19), 
-"3" for quire 7 (f. 43); "4", barely visible, for quire 10 (f. 65), "5", 
-in a later hand, for quire 13 (f. 89), "6", in a later hand, for quire 
-16 (f. 113).</signatures>
-</egXML></p>
-<p>The <gi>secFol</gi> element (for <soCalled>secundo
-folio</soCalled>) is used to record an identifying phrase (also
-called <foreign>dictio probatoria</foreign>)  taken from a
-specific known point in a codex (for example the first few words on
-the second leaf). Since these words will differ from one copy of
-a text to another, the practice originated in the middle ages of using
-them when cataloguing a manuscript in order to distinguish individual
-copies of a work in a way which its opening words could not.
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<secFol>(ando-)ssene in una villa</secFol>
-</egXML>
-<!-- better example needed --></p></div>
-<div type="div3" xml:id="mshera">
-<head>Heraldry</head><!-- rename as armsDesc? -->
-<p>Descriptions of heraldic arms, supporters, devices, and mottos may
-appear at various points in the description of a manuscript, usually in the context of ownership
-information, binding descriptions, or detailed accounts of
-illustrations. A full description may also contain a detailed account of the
-heraldic components of a manuscript independently considered. Frequently, however, heraldic descriptions will
-be cited as short phrases within other parts of the record. The phrase
-level element <gi>heraldry</gi> is provided to allow such phrases to
-be marked for further  analysis, as in the following
-examples:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<p>Ownership stamp (xvii cent.) on i recto with the arms <heraldry>A bull 
-passant within a bordure bezanty, in chief a crescent for difference</heraldry> 
-[Cole], crest, and the legend <quote>Cole Deum</quote>.</p>
-<!-- ... -->
-<p>A c. 8r fregio su due lati, <heraldry>stemma e imprese medicee</heraldry> 
-racchiudono l'inizio dell'epistolario di Paolino.</p>
-</egXML></p>
-</div>
-</div>
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <signatures>Quire and leaf signatures in letters, [b]-v, and roman numerals; 
+              those in quires 10 (1) and 17 (s) in red ink and different from others; 
+              every third quire also signed with red crayon in arabic numerals in the 
+              centre lower margin of the first leaf recto: "2" for quire 4 (f. 19), 
+              "3" for quire 7 (f. 43); "4", barely visible, for quire 10 (f. 65), "5", 
+              in a later hand, for quire 13 (f. 89), "6", in a later hand, for quire 
+              16 (f. 113).</signatures>
+            </egXML>
+            </p>
+            <p>The <gi>secFol</gi> element (for <soCalled>secundo
+            folio</soCalled>) is used to record an identifying phrase (also
+            called <foreign>dictio probatoria</foreign>)  taken from a
+            specific known point in a codex (for example the first few words on
+            the second leaf). Since these words will differ from one copy of
+            a text to another, the practice originated in the middle ages of using
+            them when cataloguing a manuscript in order to distinguish individual
+            copies of a work in a way which its opening words could not.
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <secFol>(ando-)ssene in una villa</secFol>
+            </egXML>
+            <!-- better example needed -->                  </p>
+          </div>
+          <div type="div3" xml:id="mshera">
+            <head>Heraldry</head>
+            <!-- rename as armsDesc? -->
+            <p>Descriptions of heraldic arms, supporters, devices, and mottos may
+            appear at various points in the description of a manuscript, usually in the context of ownership
+            information, binding descriptions, or detailed accounts of
+            illustrations. A full description may also contain a detailed account of the
+            heraldic components of a manuscript independently considered. Frequently, however, heraldic descriptions will
+            be cited as short phrases within other parts of the record. The phrase
+            level element <gi>heraldry</gi> is provided to allow such phrases to
+            be marked for further  analysis, as in the following
+            examples:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <p>Ownership stamp (xvii cent.) on i recto with the arms <heraldry>A bull 
+              passant within a bordure bezanty, in chief a crescent for difference</heraldry> 
+              [Cole], crest, and the legend <quote>Cole Deum</quote>.</p>
+              <!-- ... -->
+              <p>A c. 8r fregio su due lati, <heraldry>stemma e imprese medicee</heraldry> 
+              racchiudono l'inizio dell'epistolario di Paolino.</p>
+            </egXML>
+            </p>
+          </div>
+        </div>
 
-<div type="div2" xml:id="msid">
-<head>The Manuscript Identifier</head>
-<p>The <gi>msIdentifier</gi> element is intended to provide an
-unambiguous means of uniquely identifying a particular
-manuscript. This may be done in a structured way, by providing
- information about the holding institution and the call number,
-shelfmark, or other identifier used to indicate its location within
-that institution. Alternatively, or in addition, a manuscript may be
-identified simply by a commonly used name.
-<specList>
-<specDesc key="msIdentifier"/>
-</specList></p>
-<p>A manuscript's actual physical location may occasionally be
-different from its place of ownership; at Cambridge University, for
-example, manuscripts owned by various colleges are kept in the central
-University Library. Normally, it is the ownership of the manuscript which should
-be specified in the manuscript identifier, while additional or more
-precise information on the physical location of the manuscript can be
-given within the <gi>adminInfo</gi> element, discussed in section <ptr target="#msadad"/> below.</p>
-<p>The following elements are available within <gi>msIdentifier</gi>
-to identify the holding institution:
-<specList>
-<specDesc key="country"/>
-<specDesc key="region"/>
-<specDesc key="settlement"/>
-<specDesc key="institution"/>
-<specDesc key="repository"/>
-</specList></p>
-<p>Only one of each of the elements listed above
-may appear within the <gi>msIdentifier</gi> and they must, if present,
-appear in the order given.</p>
-<note rend="query">Should we make country mandatory? </note>
-<p>These elements are all also members of the  attribute class
-<ident type="class">att.naming</ident>, from which they inherit the following
-attribute:
-<specList><specDesc key="att.naming"/></specList></p>
-<p>The following elements are used within <gi>msIdentifier</gi> to
-provide different ways of identifying the manuscript within its holding institution:
-<specList>
-<specDesc key="collection"/>
-<specDesc key="idno"/>
-<specDesc key="altIdentifier" atts="type"/>
-<specDesc key="msName"/>
-</specList></p>
-<p>Major manuscript repositories will usually have a preferred
-form of citation for manuscript shelfmarks, including rules
-about punctuation, spacing, abbreviation, etc., which should be
-adhered to. Where such a format also contains information which might
-additionally be supplied as a distinct subcomponent of the
-<gi>msIdentifier</gi>, for example a collection name,
-a decision must be taken as to whether to use the more specific
-element, or to include such information within the <gi>idno</gi> element. For
-example, the manuscript formally identified as <q>El 26 C 0</q> forms
-a part of the Ellesmere (<q>El</q>) collection. Either of the
-following encodings is therefore feasible:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msIdentifier>
-<country>USA</country>
-<region type="state">California</region>
-<settlement>San Marino</settlement>
-<repository>Huntington Library</repository>
-<collection>El</collection>
-<idno>26 C 9</idno>
-<msName>The Ellesmere Chaucer</msName>
-</msIdentifier>
-</egXML>
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msIdentifier>
-<country>USA</country>
-<region type="state">California</region>
-<settlement>San Marino</settlement>
-<repository>Huntington Library</repository>
-<idno>El 26 C 9</idno>
-<msName>The Ellesmere Chaucer</msName>
-</msIdentifier>
-</egXML></p>
-<p>In the former example, the preferred form of the identifier can be
-retrieved by prefixing the content of the <gi>idno</gi> element with
-that of the  <gi>collection</gi> element, while in the latter it is
-given explicitly. The advantage of the former is that it it simplifies
-accurate retrieval of all manuscripts from a given collection; the
-disadvantage is that encoded abbreviations of this kind may not be as
-immediately comprehensible. Care should be taken to avoid redundancy:
-for example <egXML xmlns="http://www.tei-c.org/ns/Examples">
-<collection>El</collection>
-<idno>El 26 C 9</idno>
-</egXML> would clearly be inappropriate. Equally clearly, 
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<collection>Ellesmere</collection>
-<idno>El 26 C 9</idno>
-</egXML> might be considered helpful in some circumstances (if, for
-example, some of the items in the Ellsemere collection had shelfmarks
-which did not begin <q>El</q>)</p>
-<p>In cases where the shelfmark  contains no information about the
-collection, it may be necessary to provide this explicitly, as in
-the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msIdentifier>
-<country>USA</country>
-<region type="state">New Jersey</region>
-<settlement>Princeton</settlement>
-<repository>Princeton University Library</repository>
-<collection>Scheide Library</collection>
-<idno>MS 71</idno>
-<msName>Blickling Homiliary</msName>
-</msIdentifier>
-</egXML></p>
-<p>In these examples, <gi>msName</gi> has been used to provide
-a common name other than the shelfmark by which a manuscript is
-known. Where a manuscript has several such names, more than one of these elements may be used, as in the following
-example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msIdentifier>
-<country>Danmark</country>
-<settlement>København</settlement>
-<repository>Det Arnamagnæanske Institut</repository>
-<idno>AM 45 fol.</idno>
-<msName xml:lang="la">Codex Frisianus</msName>
-<msName xml:lang="is">Fríssbók</msName>
-</msIdentifier>
-</egXML>
-Here the globally available <att>xml:lang</att> attribute has been
-used to specify the language of the alternative names. <!--This is a
-standard TEI facility, which may be found useful in certain
-environments (for example, when compiling a single catalogue from a
-variety of originally different sources), but which may safely be
-ignored in others. --><!-- is this second sentence necessary? --></p>
-<p>In very rare cases a repository may have only one manuscript (or
-only one of any significance), which will have no shelfmark as such
-but will be known by a particular name or names. In such
-circumstances, the <gi>idno</gi> element may be omitted, and the
-manuscript identified by  the name or names used for it, using
-one or more <gi>msName</gi> elements, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msIdentifier>
-<settlement>Rossano</settlement>
-<repository xml:lang="it">Biblioteca arcivescovile</repository>
-<msName xml:lang="la">Codex Rossanensis</msName>
-<msName xml:lang="la">Codex purpureus</msName> 
-<msName xml:lang="en">The Rossano Gospels</msName> 
-</msIdentifier>
-</egXML></p>
-<p>Where manuscripts have moved from one institution to another, or
-even within the same institution, they may have identifiers additional
-to the ones currently used, such as former shelfmarks, which are
-sometimes retained even after they have been officially superseded. In
-such cases it may be useful to supply an alternative identifier using the
-<gi>altIdentifier</gi> element, which has a detailed structure similar
-to that of the <gi>msIdentifier</gi> element, and an additional
-attribute <att>type</att> to indicate what kind of alternative
-identifier this is. Only the following possibilities are envisaged:
-<list type="gloss">
-<label>former</label><item>former catalogue or shelf number</item>
-<label>partial</label><item>identifier of a previously distinct
-item</item>
-<label>internal</label><item>internal project identifier</item>
-<label>other</label><item>other unspecified identifier</item>
-</list>
+        <div type="div2" xml:id="msid">
+          <head>The Manuscript Identifier</head>
+          <p>The <gi>msIdentifier</gi> element is intended to provide an
+          unambiguous means of uniquely identifying a particular
+          manuscript. This may be done in a structured way, by providing
+          information about the holding institution and the call number,
+          shelfmark, or other identifier used to indicate its location within
+          that institution. Alternatively, or in addition, a manuscript may be
+          identified simply by a commonly used name.
+          <specList>
+            <specDesc key="msIdentifier"/>
+          </specList>
+          </p>
+          <p>A manuscript's actual physical location may occasionally be
+          different from its place of ownership; at Cambridge University, for
+          example, manuscripts owned by various colleges are kept in the central
+          University Library. Normally, it is the ownership of the manuscript which should
+          be specified in the manuscript identifier, while additional or more
+          precise information on the physical location of the manuscript can be
+          given within the <gi>adminInfo</gi> element, discussed in section <ptr target="#msadad"/> below.</p>
+          <p>The following elements are available within <gi>msIdentifier</gi>
+          to identify the holding institution:
+          <specList>
+            <specDesc key="country"/>
+            <specDesc key="region"/>
+            <specDesc key="settlement"/>
+            <specDesc key="institution"/>
+            <specDesc key="repository"/>
+          </specList>
+          </p>
+          <p>Only one of each of the elements listed above
+          may appear within the <gi>msIdentifier</gi> and they must, if present,
+          appear in the order given.</p>
+          <note rend="query">Should we make country mandatory? </note>
+          <p>These elements are all also members of the  attribute class
+          <ident type="class">att.naming</ident>, from which they inherit the following
+          attribute:
+          <specList>
+            <specDesc key="att.naming"/>
+          </specList>
+          </p>
+          <p>The following elements are used within <gi>msIdentifier</gi> to
+          provide different ways of identifying the manuscript within its holding institution:
+          <specList>
+            <specDesc key="collection"/>
+            <specDesc key="idno"/>
+            <specDesc key="altIdentifier" atts="type"/>
+            <specDesc key="msName"/>
+          </specList>
+          </p>
+          <p>Major manuscript repositories will usually have a preferred
+          form of citation for manuscript shelfmarks, including rules
+          about punctuation, spacing, abbreviation, etc., which should be
+          adhered to. Where such a format also contains information which might
+          additionally be supplied as a distinct subcomponent of the
+          <gi>msIdentifier</gi>, for example a collection name,
+          a decision must be taken as to whether to use the more specific
+          element, or to include such information within the <gi>idno</gi> element. For
+          example, the manuscript formally identified as <q>El 26 C 0</q> forms
+          a part of the Ellesmere (<q>El</q>) collection. Either of the
+          following encodings is therefore feasible:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <msIdentifier>
+              <country>USA</country>
+              <region type="state">California</region>
+              <settlement>San Marino</settlement>
+              <repository>Huntington Library</repository>
+              <collection>El</collection>
+              <idno>26 C 9</idno>
+              <msName>The Ellesmere Chaucer</msName>
+            </msIdentifier>
+          </egXML>
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <msIdentifier>
+              <country>USA</country>
+              <region type="state">California</region>
+              <settlement>San Marino</settlement>
+              <repository>Huntington Library</repository>
+              <idno>El 26 C 9</idno>
+              <msName>The Ellesmere Chaucer</msName>
+            </msIdentifier>
+          </egXML>
+          </p>
+          <p>In the former example, the preferred form of the identifier can be
+          retrieved by prefixing the content of the <gi>idno</gi> element with
+          that of the  <gi>collection</gi> element, while in the latter it is
+          given explicitly. The advantage of the former is that it it simplifies
+          accurate retrieval of all manuscripts from a given collection; the
+          disadvantage is that encoded abbreviations of this kind may not be as
+          immediately comprehensible. Care should be taken to avoid redundancy:
+          for example <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <collection>El</collection>
+          <idno>El 26 C 9</idno>
+          </egXML> would clearly be inappropriate. Equally clearly, 
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <collection>Ellesmere</collection>
+            <idno>El 26 C 9</idno>
+            </egXML> might be considered helpful in some circumstances (if, for
+            example, some of the items in the Ellsemere collection had shelfmarks
+          which did not begin <q>El</q>)</p>
+          <p>In cases where the shelfmark  contains no information about the
+          collection, it may be necessary to provide this explicitly, as in
+          the following example:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <msIdentifier>
+              <country>USA</country>
+              <region type="state">New Jersey</region>
+              <settlement>Princeton</settlement>
+              <repository>Princeton University Library</repository>
+              <collection>Scheide Library</collection>
+              <idno>MS 71</idno>
+              <msName>Blickling Homiliary</msName>
+            </msIdentifier>
+          </egXML>
+          </p>
+          <p>In these examples, <gi>msName</gi> has been used to provide
+          a common name other than the shelfmark by which a manuscript is
+          known. Where a manuscript has several such names, more than one of these elements may be used, as in the following
+          example:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <msIdentifier>
+              <country>Danmark</country>
+              <settlement>København</settlement>
+              <repository>Det Arnamagnæanske Institut</repository>
+              <idno>AM 45 fol.</idno>
+              <msName xml:lang="la">Codex Frisianus</msName>
+              <msName xml:lang="is">Fríssbók</msName>
+            </msIdentifier>
+          </egXML>
+          Here the globally available <att>xml:lang</att> attribute has been
+          used to specify the language of the alternative names. <!--This is a
+          standard TEI facility, which may be found useful in certain
+          environments (for example, when compiling a single catalogue from a
+          variety of originally different sources), but which may safely be
+          ignored in others. --><!-- is this second sentence necessary? --></p>
+          <p>In very rare cases a repository may have only one manuscript (or
+          only one of any significance), which will have no shelfmark as such
+          but will be known by a particular name or names. In such
+          circumstances, the <gi>idno</gi> element may be omitted, and the
+          manuscript identified by  the name or names used for it, using
+          one or more <gi>msName</gi> elements, as in the following example:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <msIdentifier>
+              <settlement>Rossano</settlement>
+              <repository xml:lang="it">Biblioteca arcivescovile</repository>
+              <msName xml:lang="la">Codex Rossanensis</msName>
+              <msName xml:lang="la">Codex purpureus</msName> 
+              <msName xml:lang="en">The Rossano Gospels</msName> 
+            </msIdentifier>
+          </egXML>
+          </p>
+          <p>Where manuscripts have moved from one institution to another, or
+          even within the same institution, they may have identifiers additional
+          to the ones currently used, such as former shelfmarks, which are
+          sometimes retained even after they have been officially superseded. In
+          such cases it may be useful to supply an alternative identifier using the
+          <gi>altIdentifier</gi> element, which has a detailed structure similar
+          to that of the <gi>msIdentifier</gi> element, and an additional
+          attribute <att>type</att> to indicate what kind of alternative
+          identifier this is. Only the following possibilities are envisaged:
+          <list type="gloss">
+            <label>former</label>
+            <item>former catalogue or shelf number</item>
+            <label>partial</label>
+            <item>identifier of a previously distinct
+            item</item>
+            <label>internal</label>
+            <item>internal project identifier</item>
+            <label>other</label>
+            <item>other unspecified identifier</item>
+          </list>
 
-<specGrp xml:id="spec1">
-<elementSpec ident="altIdentifier" module="msdescription" mode="change">
-<attList>
-  <attDef ident="type" mode="change" usage="req">
-<valList type="closed" mode="replace">
-<valItem ident="former"><desc  xml:lang="en" versionDate="2014-01-12">former catalogue or shelf number</desc></valItem>
-<valItem ident="partial"><desc  xml:lang="en" versionDate="2014-01-12">identifier of a previously distinct
-item</desc></valItem>
-<valItem ident="internal"><desc  xml:lang="en" versionDate="2014-01-12">internal project identifier</desc></valItem>
-<valItem ident="other"><desc  xml:lang="en" versionDate="2014-01-12">unspecified</desc></valItem>
-</valList>
+          <specGrp xml:id="spec1">
+            <elementSpec ident="altIdentifier" module="msdescription" mode="change">
+              <attList>
+                <attDef ident="type" mode="change" usage="req">
+                  <valList type="closed" mode="replace">
+                    <valItem ident="former">
+                      <desc xml:lang="en" versionDate="2014-01-12">former catalogue or shelf number</desc>
+                    </valItem>
+                    <valItem ident="partial">
+                      <desc xml:lang="en" versionDate="2014-01-12">identifier of a previously distinct
+                      item</desc>
+                    </valItem>
+                    <valItem ident="internal">
+                      <desc xml:lang="en" versionDate="2014-01-12">internal project identifier</desc>
+                    </valItem>
+                    <valItem ident="other">
+                      <desc xml:lang="en" versionDate="2014-01-12">unspecified</desc>
+                    </valItem>
+                  </valList>
 
-  </attDef>
-</attList>
-</elementSpec>
-</specGrp>
-</p>
+                </attDef>
+              </attList>
+            </elementSpec>
+          </specGrp>
+          </p>
 
-<p>The following example shows a manuscript which had shelfmark
-<code>II-M-5</code> in the collection of the Duque de Osuna, but which
-now has the shelfmark <code>MS 10237</code> in the National Library in
-Madrid:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msIdentifier>
-<settlement>Madrid</settlement>
-<repository>Biblioteca Nacional</repository>
-<idno>MS 10237</idno>
-<altIdentifier type="former">
-<region type="state">Andalucia</region>
-<settlement>Osuna</settlement>
-<repository>Duque de Osuna</repository>
-<idno>II-M-5</idno>
-</altIdentifier>
-</msIdentifier>
-</egXML>
-Alternatively, such information may be dealt with under <gi>history</gi>
-or <gi>adminInfo</gi>, except in
-cases where a manuscript is likely still to be referred to or known by
-its former identifier. 
-<!-- For example, an institution may have changed
-its call number system but still wish to retain a record of the earlier
-number, perhaps because the manuscript concerned is frequently cited in print
-under its previous number:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msIdentifier>
-<settlement>Berkeley</settlement>
-<institution>University of California</institution>
-<repository>Bancroft Library</repository>
-<idno>UCB 16</idno>
-<altIdentifier type="former"><idno>2MS BS1145 I8</idno></altIdentifier>
-</msIdentifier>
-</egXML>
-Where (as in this example) no repository is specified for the
-<gi>altIdentifier</gi>, it is assumed to be the same as that of the
-parent <gi>msIdentifier</gi>. Where the holding institution has only
-one preferred form of citation but wishes to retain the other for
-internal administrative purposes, the secondary could be given within
-<gi>altIdentifier</gi> with an appropriate value on the
-<att>type</att> attribute:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msIdentifier>
-<settlement>Oxford</settlement>
-<repository>Bodleian Library</repository>
-<idno>MS. Bodley 406</idno>
-<altIdentifier type="former"><idno>2297</idno></altIdentifier>
-</msIdentifier>
-</egXML>
-It might, however, be preferable to include such information within
-the <gi>adminInfo</gi> element discussed in section <ptr
-target="#msadad"/> below.-->
-</p>
+          <p>The following example shows a manuscript which had shelfmark
+          <code>II-M-5</code> in the collection of the Duque de Osuna, but which
+          now has the shelfmark <code>MS 10237</code> in the National Library in
+          Madrid:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <msIdentifier>
+              <settlement>Madrid</settlement>
+              <repository>Biblioteca Nacional</repository>
+              <idno>MS 10237</idno>
+              <altIdentifier type="former">
+                <region type="state">Andalucia</region>
+                <settlement>Osuna</settlement>
+                <repository>Duque de Osuna</repository>
+                <idno>II-M-5</idno>
+              </altIdentifier>
+            </msIdentifier>
+          </egXML>
+          Alternatively, such information may be dealt with under <gi>history</gi>
+          or <gi>adminInfo</gi>, except in
+          cases where a manuscript is likely still to be referred to or known by
+          its former identifier. 
+          <!-- For example, an institution may have changed
+               its call number system but still wish to retain a record of the earlier
+               number, perhaps because the manuscript concerned is frequently cited in print
+               under its previous number:
+               <egXML xmlns="http://www.tei-c.org/ns/Examples">
+               <msIdentifier>
+               <settlement>Berkeley</settlement>
+               <institution>University of California</institution>
+               <repository>Bancroft Library</repository>
+               <idno>UCB 16</idno>
+               <altIdentifier type="former"><idno>2MS BS1145 I8</idno></altIdentifier>
+               </msIdentifier>
+               </egXML>
+               Where (as in this example) no repository is specified for the
+               <gi>altIdentifier</gi>, it is assumed to be the same as that of the
+               parent <gi>msIdentifier</gi>. Where the holding institution has only
+               one preferred form of citation but wishes to retain the other for
+               internal administrative purposes, the secondary could be given within
+               <gi>altIdentifier</gi> with an appropriate value on the
+               <att>type</att> attribute:
+               <egXML xmlns="http://www.tei-c.org/ns/Examples">
+               <msIdentifier>
+               <settlement>Oxford</settlement>
+               <repository>Bodleian Library</repository>
+               <idno>MS. Bodley 406</idno>
+               <altIdentifier type="former"><idno>2297</idno></altIdentifier>
+               </msIdentifier>
+               </egXML>
+               It might, however, be preferable to include such information within
+               the <gi>adminInfo</gi> element discussed in section <ptr
+               target="#msadad"/> below.-->
+          </p>
 
-<p>Cases of such changed or alternative identifiers should be clearly
-distinguished from cases of <soCalled>scattered</soCalled>
-manuscripts, that is to say manuscripts which although physically
-disjoint are nevertheless generally treated as single units. One
-well-known example is the Old Church Slavonic manuscript known as
-<title>Codex Suprasliensis</title>, substantial parts of which are to
-be found in three separate repositories, in Ljubljana, Warsaw, and
-St. Petersburg. This should be represented using three distinct
-<gi>altIdentifier</gi> elements, using the value <val>partial</val> on the
-type attribute to indicate that these three identifiers are not
-alternate ways of referring to the same physical object, but three
-parts of the same entity.
+          <p>Cases of such changed or alternative identifiers should be clearly
+          distinguished from cases of <soCalled>scattered</soCalled>
+          manuscripts, that is to say manuscripts which although physically
+          disjoint are nevertheless generally treated as single units. One
+          well-known example is the Old Church Slavonic manuscript known as
+          <title>Codex Suprasliensis</title>, substantial parts of which are to
+          be found in three separate repositories, in Ljubljana, Warsaw, and
+          St. Petersburg. This should be represented using three distinct
+          <gi>altIdentifier</gi> elements, using the value <val>partial</val> on the
+          type attribute to indicate that these three identifiers are not
+          alternate ways of referring to the same physical object, but three
+          parts of the same entity.
 
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msIdentifier>
-  <msName xml:lang="la">Codex Suprasliensis</msName>
-    <altIdentifier type="partial">
-    <settlement>Ljubljana</settlement>
-    <repository>Narodna in univerzitetna knjiznica</repository>
-    <idno>MS Kopitar 2</idno>
-    <note>Contains ff. 10 to 42 only</note>
-  </altIdentifier>
-  <altIdentifier type="partial">
-    <settlement>Warszawa</settlement>
-    <repository>Biblioteka Narodowa</repository>
-    <idno>BO 3.201</idno>
-  </altIdentifier>
-  <altIdentifier type="partial">
-    <settlement>Sankt-Peterburg</settlement>
-    <repository>Rossiiskaia natsional'naia biblioteka</repository>
-    <idno>Q.p.I.72</idno>
-  </altIdentifier>
-</msIdentifier>
-</egXML></p>
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <msIdentifier>
+              <msName xml:lang="la">Codex Suprasliensis</msName>
+              <altIdentifier type="partial">
+                <settlement>Ljubljana</settlement>
+                <repository>Narodna in univerzitetna knjiznica</repository>
+                <idno>MS Kopitar 2</idno>
+                <note>Contains ff. 10 to 42 only</note>
+              </altIdentifier>
+              <altIdentifier type="partial">
+                <settlement>Warszawa</settlement>
+                <repository>Biblioteka Narodowa</repository>
+                <idno>BO 3.201</idno>
+              </altIdentifier>
+              <altIdentifier type="partial">
+                <settlement>Sankt-Peterburg</settlement>
+                <repository>Rossiiskaia natsional'naia biblioteka</repository>
+                <idno>Q.p.I.72</idno>
+              </altIdentifier>
+            </msIdentifier>
+          </egXML>
+          </p>
 
-<p>As mentioned above, the smallest possible description is one that
-contains only the element <gi>msIdentifier</gi>; good practice in all
-but exceptional circumstances requires the presence within it of the
-three sub-elements <gi>settlement</gi>, <gi>repository</gi>, and
-<gi>idno</gi>, since they provide what is, by common consent, the
-minimum amount of information necessary to identify a manuscript.</p>
-</div>
-<!--
-<div type="div2" xml:id="msdo">
-<head>The Manuscript Heading</head>
-<p>Historically, the briefest possible meaningful description of a
-manuscript consists of no more than a title,
-e.g. <mentioned>Polychronicon</mentioned>. This will often have been
-enough to identify a manuscript in a small collection because the
-identity of the author is implicit. Where a title does not imply the
-author, and is thus insufficient to identify the main text of a
-manuscript, the author should be stated explicitly
-(e.g. <mentioned>Augustinus, Sermones</mentioned> or <mentioned>Cicero,
-Letters</mentioned>). Many inventories of manuscripts consist of no
-more than an author and title, with some form of copy-specific
-identifier, such as a shelfmark or <soCalled>secundo folio</soCalled> reference
-(e.g. <mentioned>Arch. B. 3. 2: Evangelium Matthei cum
-glossa</mentioned>, <mentioned>126. Isidori Originum libri
-octo</mentioned>, <mentioned>Biblia Hieronimi, 2o fo. opus
-est</mentioned>); information on date and place of writing will
-sometimes also be included. 
-The standard TEI element <gi>head</gi>
-element can be used to provide a brief description of this kind.
-<specList>
-<specDesc key="head"/>
-</specList>
-In this way the cataloguer or scholar can supply in one place a
-minimum of essential information, such as might be displayed or
-printed as the heading of a full description. </p>
-<p>For ENRICH purposes, a <gi>head</gi> element is required, and must
-contain the following summary elements:
-<specList>
-<specDesc key="author"/>
-<specDesc key="title"/>
-<specDesc key="origDate"/>
-<specDesc key="origPlace"/>
-</specList>
+          <p>As mentioned above, the smallest possible description is one that
+          contains only the element <gi>msIdentifier</gi>; good practice in all
+          but exceptional circumstances requires the presence within it of the
+          three sub-elements <gi>settlement</gi>, <gi>repository</gi>, and
+          <gi>idno</gi>, since they provide what is, by common consent, the
+          minimum amount of information necessary to identify a manuscript.</p>
+        </div>
+        <!--
+            <div type="div2" xml:id="msdo">
+            <head>The Manuscript Heading</head>
+            <p>Historically, the briefest possible meaningful description of a
+            manuscript consists of no more than a title,
+            e.g. <mentioned>Polychronicon</mentioned>. This will often have been
+            enough to identify a manuscript in a small collection because the
+            identity of the author is implicit. Where a title does not imply the
+            author, and is thus insufficient to identify the main text of a
+            manuscript, the author should be stated explicitly
+            (e.g. <mentioned>Augustinus, Sermones</mentioned> or <mentioned>Cicero,
+            Letters</mentioned>). Many inventories of manuscripts consist of no
+            more than an author and title, with some form of copy-specific
+            identifier, such as a shelfmark or <soCalled>secundo folio</soCalled> reference
+            (e.g. <mentioned>Arch. B. 3. 2: Evangelium Matthei cum
+            glossa</mentioned>, <mentioned>126. Isidori Originum libri
+            octo</mentioned>, <mentioned>Biblia Hieronimi, 2o fo. opus
+            est</mentioned>); information on date and place of writing will
+            sometimes also be included. 
+            The standard TEI element <gi>head</gi>
+            element can be used to provide a brief description of this kind.
+            <specList>
+            <specDesc key="head"/>
+            </specList>
+            In this way the cataloguer or scholar can supply in one place a
+            minimum of essential information, such as might be displayed or
+            printed as the heading of a full description. </p>
+            <p>For ENRICH purposes, a <gi>head</gi> element is required, and must
+            contain the following summary elements:
+            <specList>
+            <specDesc key="author"/>
+            <specDesc key="title"/>
+            <specDesc key="origDate"/>
+            <specDesc key="origPlace"/>
+            </specList>
 
 For example:
 <egXML xmlns="http://www.tei-c.org/ns/Examples">
@@ -1217,1985 +1298,2236 @@ summary information:
 which should be supported by a more detailed description using the
 <gi>msContents</gi> element described in the next section.</p>
 </div>
--->
-
-<!-- in Reykjavik, we removed head; I expect it will return though -->
-
-<div type="div2" xml:id="msco">
-<head>Intellectual Content</head>
-<p>The <gi>msContents</gi> element is used to describe the
-intellectual content of a manuscript or manuscript part. It comprises
-<emph>either</emph> a series of informal prose paragraphs
-<emph>or</emph> a series of <gi>msItem</gi> 
-elements, each of which provides a more detailed description of a
-single item contained within the manuscript. These may be prefaced, if
-desired, by a <gi>summary</gi> element, which is especially useful
-where one wishes to provide an overview of a manuscript's contents and
-describe only some of the items in detail.
-<specList>
-<specDesc key="msContents"/>
-<specDesc key="msItem"/>
-</specList></p>
-<p>In the simplest case, only a brief description may be provided, as
-in the following examples:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msContents>
-<p>A collection of Lollard sermons</p>
-</msContents>
-<msContents>
-<p>Atlas of the world from Western Europe and Africa to Indochina, 
-containing 27 maps and 26 tables</p>
-</msContents>
-<msContents>
-<p>Biblia sacra: Antiguo y Nuevo Testamento, con prefacios, prólogos 
-y argumentos de san Jerónimo y de otros. Interpretaciones de los 
-nombres hebreos.</p>
-</msContents>
-</egXML></p>
-<p>This description may of course be expanded to include any of the
-TEI elements generally available within a <gi>p</gi> element, such as
-<gi>title</gi>, <gi>bibl</gi>, or <gi>list</gi>. More usually,
-however, each individual work within a manuscript will be given its
-own description, using the <gi>msItem</gi>
-element described in the next section, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msContents>
-<msItem n="1"><locus>fols. 5r -7v</locus>
-<title>An ABC</title> 
-<bibl><title>IMEV</title> <biblScope unit="pages">239</biblScope></bibl></msItem>
-<msItem n="2"><locus>fols. 7v -8v</locus>
-<title xml:lang="fr">Lenvoy de Chaucer a Scogan</title>
-<bibl><title>IMEV</title>
-<biblScope unit="pages">3747</biblScope></bibl></msItem>
-<msItem n="3"><locus>fol. 8v</locus><title>Truth</title> 
-<bibl><title>IMEV</title> <biblScope unit="pages">809</biblScope></bibl></msItem>
-<msItem n="4"><locus>fols. 8v-10v</locus>
-<title>Birds Praise of Love</title>
-<bibl><title>IMEV</title> <biblScope unit="pages">1506</biblScope></bibl></msItem>
-<msItem n="5"><locus>fols. 10v -11v</locus>
-<title xml:lang="la">De amico ad amicam</title>
-<title xml:lang="la">Responcio</title> 
-<bibl><title>IMEV</title> <biblScope unit="pages">16 &amp; 19</biblScope></bibl></msItem>
-<msItem n="6"><locus>fols. 14r-126v</locus>
-<title>Troilus and Criseyde</title> 
-<note>Bk. 1:71-Bk. 5:1701, with additional losses due to
-mutilation throughout</note>
-</msItem>
-</msContents>
-</egXML></p>
-<div type="div3" xml:id="mscoit"><head>The <gi>msItem</gi> <!--and <gi>msItemStruct</gi> -->Element<!--s--></head>
-<!-- I'm for killing off msItemStruct, personally -->
-<p>Each discrete item in a manuscript or manuscript part can be described within a distinct <gi>msItem</gi> <!--or <gi>msItemStruct</gi>--> element, and may be classified using the <att>class</att> attribute.</p>
-<p>These are the possible component elements of <gi>msItem</gi> <!--and <gi>msItemStruct</gi>-->.
-<specList>
-<specDesc key="author"/>
-<specDesc key="respStmt"/>
-<specDesc key="title" />
-<specDesc key="rubric"/>
-<specDesc key="incipit"/>
-<specDesc key="quote"/>
-<specDesc key="explicit"/>
-<specDesc key="finalRubric"/>
-<specDesc key="colophon"/>
-<specDesc key="decoNote"/>
-<specDesc key="listBibl"/>
-<specDesc key="bibl"/>
-<specDesc key="filiation"/>
-<specDesc key="note" />
-<specDesc key="textLang"/>
-</specList></p>
-<p>If early printed material or incunables are described using this
-schema, the <gi>msItem</gi> should be used to record details of each
-distinct work contained by the incunable. In this situation, the
-following extra elements may be found useful to transcribe relevant
-details from the original titlepage:
-<specList>
-<specDesc key="docAuthor"/>
-<specDesc key="docTitle"/>
-<specDesc key="docImprint"/>
-</specList>
-These elements are also available within the <gi>msItem</gi> element.
-</p>
-
-
-<p>In addition,<!-- a <gi>msItemStruct</gi> may contain nested
-<gi>msItemStruct</gi> elements, just as--> an <gi>msItem</gi> may contain
-nested <gi>msItem</gi> elements.</p>
-<!--<p>The main difference between <gi>msItem</gi> and <gi>msItemStruct</gi> is
-that in the former, the order and number of child elements is not
-constrained; any element, in other words, may be given in any order,
-and repeated as often as is judged necessary. In the latter, however, the
-sub-elements, if used, must be given in the order specified above and
-only some of  them may be repeated; specifically,  <gi>rubric</gi>,
-<gi>finalRubric</gi>.  <gi>incipit</gi>, <gi>textLang</gi> and
-<gi>explicit</gi> can appear only once.</p>
-<p>While  neither
-<gi>msItem</gi> nor <gi>msItemStruct</gi> -->
-<p>Untagged running
-text is not permitted directly within an <gi>msItem</gi>, unless it is
-given within a <gi>p</gi> element, in which case 
-none of the other component elements listed above is permitted.
-</p>
-<p>The elements <gi>msContents</gi>, <gi>msItem</gi>,
-<!--<gi>msItemStruct</gi>, --><gi>incipit</gi>, and <gi>explicit</gi> are all
-members of the class <ident type="class">att.msExcerpt</ident> from
-which they inherit the <att>defective</att> attribute.
-<specList>
-<specDesc key="att.msExcerpt" atts="defective"/>
-</specList>
-This attribute can be used for example with collections
-of fragments, where each fragment is given as a separate
-<gi>msItem</gi> and the first and last words of each fragment are transcribed as
-defective incipits and explicits <!--, as in the following example, a
-manuscript containing four fragments of a single work:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msContents>
-<msItem defective="true"><locus from="1r" to="9v">1r-9v</locus>
-<title>Knýtlinga saga</title>
-<msItem n="1.1"><locus from="1r:1" to="2v:30">1r:1-2v:30</locus>
-<incipit defective="true">dan<ex>n</ex>a a 
-engl<ex>an</ex>di</incipit>
-<explicit defective="true">en meðan <expan>haraldr</expan> 
-hein hafði k<ex>onung</ex>r v<am><g ref="http://www.examples.com/abbrevs.xml#er"/></am>it 
-yf<ex>ir</ex> danmork</explicit>
-</msItem>
-</msItem>
-</msContents>
-</egXML></p>
-<p>The elements <gi>ex</gi>, <gi>am</gi>, and
-<gi>expan</gi> used in the above example are further discussed in
-section <ptr target="#PHAB"/>; they are available  only when the <ident type="module">transcr</ident> module defined by that chapter is
-selected. Similarly, the <gi>g</gi> element used in this example to
-represent the abbreviation mark is defined by the <ident type="module">gaiji</ident> module documented in chapter <ptr target="#WD"/>-->. </p>
-</div>
-<div type="div3" xml:id="msat"><head>Authors and Titles</head>
-<p>When used within a manuscript description, the <gi>title</gi> element should be used to supply a regularized
-form of the item's title, as distinct from any rubric quoted from the
-manuscript. If the item concerned has a standardized distinctive
-title, e.g. <mentioned>Roman de la Rose</mentioned>, then this should
-be the form given as content of the <gi>title</gi> element, with the
-value of the <att>type</att> attribute given as
-<code>uniform</code>. If no uniform title exists for an item, or none
-has been yet identified, or if one wishes to provide a general
-designation of the contents, then a <soCalled>supplied</soCalled>
-title can be given, e.g. <mentioned>missal</mentioned>, in which case
-the <att>type</att> attribute on the <gi>title</gi> should be given
-the value <code>supplied</code>.</p>
-
-<p>Similarly, if used within a manuscript description, the
-<gi>author</gi> element should always contain the normalized form of
-an author's name, irrespective of how (or whether) this form of the
-name is cited in the manuscript. If it is desired to retain the form
-of the author's name as given in the manuscript, this should be given
-in the <gi>docAuthor</gi> element, or  as
-a distinct <gi>name</gi> element, within the text at the point where
-it occurs. </p>
-<!-- an example would be nice here -->
-<p>Note that the <att>key</att> or <att>ref</att> attributes can be
-used, on titles and on author names as on names in general, to link
-the name to a more detailed description of the person or work
-concerned (see further <ptr target="#msnames"/>).</p>
-<p>The <gi>respStmt</gi> element can be used to supply the name and role of a person other than the author who is responsible for some aspect of the intellectual content of the manuscript:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<author>Diogenes Laertius</author>
-<respStmt>
-<resp>in the translation of</resp>
-<name type="person">Ambrogio Traversari</name>
-</respStmt>
-</egXML></p>
-<p>The <gi>resp</gi> element is also a member of the
-<ident>att.canonical</ident> class, from which it inherits the
-<att>key</att> attribute. For ENRICH purposes, this may be used to
-supply a standard relationship code for the kind of
-responsibility concerned, as defined in the
-list maintained at <ptr
-target="http://www.loc.gov/marc/relators/relacode.html"/>:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<respStmt>
- <resp key="trl">přeložil</resp>
- <name type="person">John Enrich</name>
-</respStmt>
-</egXML>
-</p>
-<p>The <gi>respStmt</gi> element can also be used where there is a discrepancy between the author of an item as given in the manuscript and the accepted scholarly view, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<title type="supplied">Sermons on the Epistles and the Gospels</title>
-<respStmt>
-<resp>here erroneously attributed to</resp>
-<name type="person">St. Bonaventura</name>
-</respStmt>
-</egXML>
-Note that such attributions of authorship, both correct and incorrect, are frequently found in the rubric or final rubric (and occasionally also elsewhere in the text), and can therefore be transcribed and included in the description, if desired, using the <gi>rubric</gi>, <gi>finalRubric</gi>, or <gi>quote</gi> elements, as appropriate.
-</p>
-</div>
-<div type="div3" xml:id="mscorie"><head>Rubrics, Incipits, Explicits, and Other Quotations from the Text</head>
-<p>It is customary in a manuscript description to record the opening
-and closing words of a text as well as any headings or colophons it
-might have, and the specialised elements <gi>rubric</gi>,
-<gi>incipit</gi>, <gi>explicit</gi>, <gi>finalRubric</gi>, and
-<gi>colophon</gi> are available within <gi>msItem</gi> for doing so,
-along with the more general <gi>quote</gi>, for recording other bits of
-the text not covered by these elements. Each of these elements has the
-same substructure, containing a mixture of phrase-level elements and
-plain text. A <gi>locus</gi> element can be included within each, in
-order to specify the location of the component, as in the following
-example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msContents>
-<msItem><locus>f. 1-223</locus>
-<author>Radulphus Flaviacensis</author>
-<title>Expositio super Leviticum </title>
-<incipit><locus>f. 1r</locus>
-Forte Hervei monachi</incipit>
-<explicit><locus>f. 223v</locus>
-Benedictio salis et aquae</explicit>
-</msItem>
-</msContents>
-</egXML></p>
-<p>In the following example, standard TEI elements for the transcription of primary
-sources have been used to mark
-the expansion of abbreviations and other features present in the original:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msItem defective="true">
-<locus>ff. 1r-24v</locus>
-<title type="uniform">Ágrip af Noregs konunga sǫgum</title>
-<incipit defective="true">regi oc h<ex>ann</ex> seti 
-ho<gap reason="illegible" quantity="7" unit="mm"/><lb/>sc heim se<ex>m</ex> þio</incipit>
-<explicit defective="true">h<ex>on</ex> hev<ex>er</ex>
-<ex>oc</ex> þa buit hesta .ij. <lb/>annan viþ fé en
-h<ex>on</ex>o<ex>m</ex> annan til reiþ<ex>ar</ex></explicit>
-</msItem>
-</egXML>
-Note here also the use of the <att>defective</att> attribute on <gi>incipit</gi> and <gi>explicit</gi> to indicate that the text begins and ends defectively.
-</p>
-<p>The <att>xml:lang</att> attribute for <gi>colophon</gi>, <gi>explicit</gi>, <gi>incipit</gi>, <gi>quote</gi>, and <gi>rubric</gi> may always be used to identify the language of the text quoted, if this is different from the default language specified by the <att>mainLang</att> attribute on <gi>textLang</gi>.</p>
-</div>
-<div type="div3" xml:id="msfil">
-<head>Filiation</head>
-<p>The <gi>filiation</gi> element can be used to provide information on the relationship between the manuscript and other surviving manuscripts of the same text, either specifically or in a general way, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msItem>
-  <locus>118rb</locus>
-  <incipit>Ecce morior cum nichil horum ... <ref>[Dn 13, 43]</ref>. Verba ista dixit Susanna de illis</incipit>
-  <explicit>ut bonum comune conservatur.</explicit>
-  <bibl>Schneyer 3, 436 (Johannes Contractus OFM)</bibl>
-  <filiation>weitere Überl. Uppsala C 181, 35r.</filiation>
-</msItem>
-</egXML>
-</p>
-</div>
-<div type="div3" xml:id="msclass"><head>Text Classification</head>
-<p>One or more text classification or text-type codes may be
-specified, either for the whole of the <gi>msContents</gi> element, or
-for one or more of its constituent <gi>msItem</gi> elements, using the
-<att>class</att> attribute as specified above:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msContents>
-<msItem n="1" defective="false" class="#law">
-<locus from="1v" to="71v">1v-71v</locus>
-<title type="uniform">Jónsbók</title>
-<incipit>Magnus m<ex>ed</ex> guds miskun Noregs 
-k<ex>onungu</ex>r</incipit>
-<explicit>en<ex>n</ex> u<ex>ir</ex>da 
-þo t<ex>il</ex> fullra aura</explicit>
-</msItem>
-</msContents></egXML>
-The value of the <att>class</att> attribute
-should specify the identifier used for the appropriate classification
-within a <gi>taxonomy</gi> element, defined in the <gi>classDecl</gi>
-element of the TEI Header (<ptr target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/HD.html#HD55"/>), as
-shown here:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<classDecl><taxonomy>
-<!-- -->
-<category xml:id="law">
-<catDesc>Laws</catDesc>
-</category>
-<!-- -->
-</taxonomy></classDecl>
-</egXML></p>
-<p><note rend="query">Should  ENRICH
- define its own taxonomy for this purpose, or re-use an
-existing one?</note></p>
-</div>
-<div type="div3" xml:id="mslangs">
-<head>Languages and Writing Systems</head>
-<p>The <gi>textLang</gi> element should be used to provide
-information about the languages used within a manuscript item. It may take
-the form of a simple note, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<textLang mainLang="chu">Old Church Slavonic, written in Cyrillic script.</textLang>
-</egXML></p>
-
-<specGrp xml:id="spec2">
-<elementSpec ident="textLang" mode="change" module="msdescription">
-<attList>
-  <attDef ident="mainLang" mode="change" usage="req"/>
-</attList>
-</elementSpec>
-</specGrp>
-
-<p>For validation and indexing purposes, the <att>mainLang</att>
-attribute muse be supplied:  it takes
-the same range of values as the global <att>xml:lang</att> attribute,
-on which see further <ptr target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/CH.html#CHSH"/>. 
-When a manuscript item  contains material in more than one language, the
-<att>mainLang</att> attribute should be used only for the chief language. 
-Other languages used may be specified using the <att>otherLangs</att>
-attribute as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<textLang mainLang="chu" otherLangs="RUS HEL">Mostly Old Church 
-Slavonic, with some Russian and Greek material</textLang>
-</egXML>
-</p>
-<p>Since Old Church Slavonic may be written in either
-Cyrillic or Glagolitic scripts, and even occasionally in both within the
-same manuscript, it might be preferable to use a more explicit
-identifier:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<textLang mainLang="chu-Cyrs">Old Church Slavonic in Cyrillic script</textLang>
-</egXML></p>
-<p>The form and scope of language identifiers recommended by these
-Guidelines is based on the IANA standard described at <ptr
-target="http://www.tei-c.org/release/doc/tei-p5-doc/html/CH.html#CHSH"/> and
-should be followed throughout. Where additional detail is needed
-correctly to describe a language, or to discuss its deployment in a
-given text, this should be done using the <gi>langUsage</gi> element
-in the TEI Header, within which individual <gi>language</gi> elements
-document the languages used: see <ptr target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/HD.html#HD41"/>.  </p>
-<p>Note that the <gi>language</gi> element defines a particular
-combination of human language and writing system. Only one
-<gi>language</gi> element may be supplied for each such
-combination. Standard TEI practice also allows this element to be
-referenced by any element using the global <att>xml:lang</att>
-attribute in order to specify the language applicable to the content
-of that element. For example, assuming that <gi>language</gi>
-elements have been defined with the identifiers <ident>fr</ident> (for
-French), <ident>la</ident> (for Latin), and <ident>de</ident> (for
-German), a manuscript description written in French which specifies
-that a particular manuscript contains predominantly German but also
-some Latin material, might
-have a <gi>textLang</gi> element like the following:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<textLang xml:lang="fr" mainLang="de" otherLangs="la">allemand et latin</textLang>
-</egXML></p>
-</div></div>
-<div type="div2" xml:id="msph">
-<head>Physical Description</head>
-<p>Under the general heading <soCalled>physical description</soCalled>
-we subsume a large number of different aspects generally regarded as
-useful in the description of a given manuscript. These include:
-<list>
-<item>aspects
-of the form, support, extent, and quire structure of the manuscript
-object and of the way in which the text is laid out on the page (<ptr target="#msph1"/>);</item>
-<item>the styles of writing, such as the way it is laid out on the
-page, the styles of writing, decorative features, any musical notation
-employed and any annotations or marginalia (<ptr
-target="#msph2"/>);</item>
-<item> and discussion of its binding, seals, and any
-accompanying material (<ptr target="#msph3"/>).</item>
-</list></p>
-<p>Most manuscript descriptions touch on several of these categories
-of information though few include them all, and not all distinguish
-them as clearly as we propose here. In particular, it is often the
-case that an existing description will include within a single
-paragraph, or even
-sentence, information for which
-we propose distinct elements. In this case, if rewriting is not an option, the
-existing prose must be marked up simply as a series of <gi>p</gi> elements,
-directly within the <gi>physDesc</gi> element.</p>
-<p>The <gi>physDesc</gi> element may thus be used in either of two
-distinct ways. It may contain a series of paragraphs addressing topics
-listed above and similar ones. Alternatively, it may act as a container for any
-choice of the more specialized elements described in the remainder of
-this section, each of which itself contains a series of paragraphs,
-and may also have more specific attributes. If the two ways
-are  combined in a single description, care should be taken to avoid
-duplication and all paragraphs of generic description must precede the first
-of the more specialised elements.</p>
-<div type="div3" xml:id="msph1"><head>Object Description</head>
-<p>The <gi>objectDesc</gi> element is used to group together those
-parts of the physical description which relate specifically to the
-text-bearing object, its format, constitution, layout, etc. The
-<att>form</att> attribute is used to indicate the specific type of
-writing vehicle being described: it must be supplied, and its
-value must be one of <val>codex</val>, <val>scroll</val>,
-<val>leaf</val>, or <val>other</val>. If no value is
-supplied, the value <val>codex</val> will be assumed.
-
-<specGrp xml:id="spec3">
-<elementSpec ident="objectDesc" mode="change" module="msdescription">
-<attList>
-  <attDef ident="form" mode="change" usage="req">
-<valList type="closed" mode="replace">
-<valItem ident="codex"><desc  xml:lang="en" versionDate="2014-01-12">a bound codex</desc></valItem>
-<valItem ident="leaf"><desc  xml:lang="en" versionDate="2014-01-12">a loose leaf</desc></valItem>
-<valItem ident="scroll"><desc  xml:lang="en" versionDate="2014-01-12">a scroll</desc></valItem>
-<valItem ident="other"><desc  xml:lang="en" versionDate="2014-01-12">any other format</desc></valItem>
-</valList>
-
-</attDef></attList>
-</elementSpec>
-</specGrp>
-
-The <gi>objectDesc</gi> element has two parts: a description of the
-<term>support</term>, i.e. the physical carrier on which the text is
-inscribed; and a description of the <term>layout</term>, i.e. the way
-text is organized on the carrier.</p>
-<p>Taking these in turn, the description of the support is tagged
-using the following elements, each of which is discussed in more
-detail below:
-<specList>
-<specDesc key="supportDesc" atts="material"/>
-<specDesc key="support"/>
-<specDesc key="extent"/>
-<specDesc key="collation"/>
-<specDesc key="foliation"/>
-<specDesc key="condition"/>
-</specList></p>
-<p>Each of these elements contains paragraphs relating to the topic
-concerned. Within these paragraphs, phrase-level elements (in
-particular those discussed above at <ptr target="#msphrase"/>),
-may be used to tag specific terms of interest if so
-desired.</p>
-<p>The <att>form</att> attribute on <gi>supportDesc</gi> is used to
-summarize briefly the materials used for the support. For ENRICH
-purposes, it must have one of the following values:
-<val>perg</val> (parchment), 
-<val>chart</val> (paper), 
-<val>mixed</val>, <val>unknown</val>.
-
-<specGrp xml:id="spec4">
-<elementSpec ident="supportDesc" mode="change" module="msdescription">
-<attList>
-  <attDef ident="material" mode="change" usage="req">
-    <valList type="closed" mode="replace">
-<valItem ident="perg"><desc  xml:lang="en" versionDate="2014-01-12">parchment</desc></valItem>
-<valItem ident="chart"><desc  xml:lang="en" versionDate="2014-01-12">paper</desc></valItem>
-<valItem ident="mixed"><desc  xml:lang="en" versionDate="2014-01-12">mixture of paper and parchment, or other materials</desc></valItem>  
-<valItem ident="unknown"/> 
-    </valList>
-  </attDef>
-</attList>
-</elementSpec>
-</specGrp>
-</p>
-<p>Here is a simple example:
-
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<objectDesc form="codex">
-<supportDesc material="mixed">
-<p>Mostly <material>paper</material>, with watermarks 
-<watermark>unicorn</watermark> (<ref>Briquet 9993</ref>) and 
-<watermark>ox</watermark> (close to <ref>Briquet 2785</ref>). 
-The first and last leaf of each quire, with the exception of 
-quires xvi and xviii, are constituted by bifolia of parchment, 
-and all seven miniatures have been painted on inserted 
-singletons of parchment.</p>
-</supportDesc>
-</objectDesc>
-</egXML></p>
-
-<p>This example combines information which might alternatively be more
-precisely tagged using the more specific elements described in the
-following subsections.</p>
-<div type="div4" xml:id="msph1sup">
-<head>Support</head>
-<p>The <gi>support</gi> element groups together information about the
-physical carrier. Typically, for western manuscripts, this will entail
-discussion of the material (parchment, paper, or a combination of the
-two) written on. For paper, a discussion of any watermarks present may
-also be useful.  If this discussion makes reference to standard
-catalogues of such items, these may be tagged using the standard
-<gi>ref</gi> element as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<support><p>
-<material>Paper</material> with watermark: <watermark>anchor in a circle 
-with star on top</watermark>, <watermark>countermark B-B with 
-trefoil</watermark> similar to <ref>Moschin, Anchor N 1680</ref>
-<date>1570-1585</date>.</p></support>
-</egXML></p>
-</div>
-<div type="div4" xml:id="msph1ext">
-<head>Extent</head>
-<p>The <gi>extent</gi> element, defined in the TEI header, may also be
-used in a manuscript description to specify the number of
-leaves a manuscript contains, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<extent>ii + 97 + ii</extent>
-</egXML>
-Information regarding the size of the leaves may be
-specifically marked using the phrase level <gi>dimensions</gi>
-element, as in the following example, or left as plain prose.
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<extent>ii + 321 leaves 
-<dimensions type="leaf" unit="cm">
-<height>35</height>
-<width>27</width>
-</dimensions>
-</extent>
-</egXML></p>
-<!--
-<p>Alternatively, the generic <gi>measure</gi> element might be used within <gi>extent</gi>, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<extent>
-  <measure type="composition" unit="leaf" quantity="10">10 Bl.</measure>
-  <measure type="height" quantity="37" unit="cm">37</measure> x
-  <measure type="width" quantity="29" unit="cm">29</measure> cm
-</extent>
-</egXML></p>
--->
-</div>
-<div type="div4" xml:id="msph1col">
-<head>Collation</head>
-<p>The <gi>collation</gi> element should be used to provide a
-description of a book's current and original structure, that is, the
-arrangement of its leaves and quires. This information may be conveyed
-using informal prose, or any appropriate notational
-convention. Although no specific notation is defined here, an
-appropriate element to enclose such an expression would be the <gi>formula</gi>
-element, which is provided when the <ident type="module">figures</ident> module is included in a schema. Here are some examples of different ways of treating collation:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<collation><p><formula>1-3:8, 4:6, 5-13:8</formula></p></collation>
-<collation>
-<p>There are now four gatherings, the first, second and fourth originally consisting of 
-eight leaves, the third of seven. A fifth gathering thought to have followed has left no trace.
-<list>
-<item>Gathering I consists of 7 leaves, a first leaf, originally conjoint with <locus>fol. 7</locus>, 
-having been cut away leaving only a narrow strip along the gutter; the others, <locus>fols 1</locus> 
-and <locus>6</locus>, <locus>2</locus> and <locus>5</locus>, and <locus>3</locus> and <locus>4</locus>, 
-are bifolia.</item>
-<item>Gathering II consists of 8 leaves, 4 bifolia.</item>
-<item>Gathering III consists of 7 leaves; <locus>fols 16</locus> and <locus>22</locus> are conjoint, 
-the others singletons.</item>
-<item>Gathering IV consists of 2 leaves, a bifolium.</item>
-</list></p>
-</collation>
-<collation><p>I (1, 2+9, 3+8, 4+7, 5+6, 10); II (11, 12+17, 13, 14, 15, 16, 18, 19).</p></collation>
-<collation>
-<p><formula>1-5.8 6.6 (catchword, f. 46, does not match following 
-text) 7-8.8 9.10, 11.2 (through f. 82) 12-14.8 15.8(-7)</formula>
-</p>
-</collation>
-</egXML></p>
-</div>
-<div type="div4" xml:id="msphfo">
-<head>Foliation</head>
-<p>The <gi>foliation</gi> element may be used to indicate the scheme,
-medium or location of folio, page, column, or line numbers written in
-the manuscript, frequently including a statement about when and, if
-known, by whom, the numbering was done.
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<foliation><p>Neuere Foliierung, die auch das Vorsatzblatt mitgezählt hat.</p></foliation>
-<foliation><p>Folio numbers were added in brown ink by Árni Magnússon 
-ca. 1720-1730 in the upper right corner of all recto-pages.</p></foliation>
-</egXML>
-</p>
-<p>Where a manuscript contains traces of more than
-one foliation, each should be recorded as a distinct
-<gi>foliation</gi> element and optionally given a distinct value for
-its <att>xml:id</att> attribute. The <gi>locus</gi> element discussed in
-<ptr target="#msloc"/> can then indicate which foliation scheme is being cited
-by means of its <att>scheme</att> attribute, which points to this
-identifier:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<foliation xml:id="original"><p>Original foliation in red roman numerals in the middle of 
-the outer margin of each recto</p></foliation>
-<foliation xml:id="modern"><p>Foliated in pencil in the top right
-corner of each recto page.</p></foliation>
-<!-- ... -->
-<locus scheme="#modern">ff 1-20</locus>
-</egXML>
-</p>
-</div>
-<div type="div4" xml:id="msphco">
-<head>Condition</head>
-<p>The <gi>condition</gi> element is used to summarize the overall
-physical state of a manuscript, in particular where such information
-is not recorded elsewhere in the description. It should not, however, be
-used to describe changes or repairs to a manuscript, as these are more
-appropriately described as a part of its custodial history (see <ptr
-target="#msadch"/>). When used solely to describe the condition of
-the binding, it should appear within the <gi>bindingDesc</gi> element
-(<ptr target="#msphbi"/>).
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<condition><p>The manuscript shows signs of damage from water and mould on its outermost leaves.</p></condition>
-<condition><p>Despite tears on many of the leaves the codex is reasonably well preserved. 
-The top and the bottom of f. 1 is damaged, and only a thin slip is left of the original second 
-leaf (now foliated as 1bis). The lower margin of f. 92 has been cut away. There is a lacuna of 
-one leaf between ff. 193 and 194. The manuscript ends defectively (there are approximately six 
-leaves missing).</p></condition>
-</egXML></p>
-</div>
-<div type="div4" xml:id="msphla"><head>Layout Description</head>
-
-<p>The second part of the <gi>objectDesc</gi> element is the
-<gi>layoutDesc</gi> element, which is used to describe and document
-the <foreign>mise-en-page</foreign> of the manuscript, that is the way
-in which text and illumination are arranged on the page, specifying
-for example the number of written, ruled, or pricked lines and columns
-per page, size of margins, distinct blocks such as glosses,
-commentaries, etc. This may be given as a simple series of
-paragraphs. Alternatively, one or more different layouts may be
-identified within a single manuscript, each described by its own
-<gi>layout</gi> element.
-<specList>
-<specDesc key="layoutDesc"/>
-<specDesc key="layout"/>
-</specList></p>
-<p>Where the <gi>layout</gi> element is used, the layout will often be
-sufficiently regular for the attributes on this element to convey all
-that is necessary; more usually however a more detailed treatment will
-be required. The attributes are provided as a convenient shorthand for
-commonly occurring cases, and should not be used except where the
-layout is regular. The value <code>NA</code> (not-applicable) should
-be used for cases where the layout is either very irregular, or where
-it cannot be characterized simply in terms of lines and columns, for
-example, where blocks of commentary and text are arranged in a regular
-but complex pattern on each page</p>
-<p>The following examples indicate the range of possibilities:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<layout ruledLines="25 32" columns="1">
-<p>Most pages have between 25 and 32 long lines ruled in lead.</p>
-</layout>
-<layout columns="1" writtenLines="24">
-<p>Written in one column throughout; 24 lines per page.</p>
-</layout>
-<layout columns="1"><p>Written in a single column, with 8 lines of text and interlinear glosses in 
-the centre, and up to 26 lines of gloss in the outer two columns. Double 
-vertical bounding lines ruled in hard point on hair side. Text lines ruled 
-faintly in lead. Remains of prickings in upper, lower, and outer (for 8 lines 
-of text only) margins.</p></layout>
-</egXML></p>
-<p>Note that if (as in the last example above) no value is given for
-the <att>columns</att> attribute, the assumption is that there is a
-single column of writing on each page.
-<specGrp xml:id="spec5">
-<elementSpec ident="layout" mode="change" module="msdescription">
-<attList>
-  <attDef ident="columns" mode="change" usage="req"/>
-</attList>
-</elementSpec>
-</specGrp></p>
-<p>Where multiple <gi>layout</gi> elements are supplied, the scope for
-each specification can be indicated by means of <gi>locus</gi>
-elements within the content of the element, as in the following
-example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<layoutDesc>
-<layout ruledLines="25 32" columns="1">
-<p>On <locus from="1r" to="202v">fols 1r-200v</locus> and 
-<locus from="210r" to="212v">fols 210r-212v</locus> there are
- between 25 and 32 ruled lines.</p>
-</layout>
-<layout ruledLines="34 50" columns="1">
-<p>On <locus from="203r" to="209v">fols 203r-209v</locus> there are between 34 
-and 50 ruled lines.</p>
-</layout></layoutDesc>
-</egXML></p>
-</div>
-</div>
-<div type="div3" xml:id="msph2"><head>Writing, Decoration, and Other Notations</head>
-
-<p>The second group of elements within a structured physical
-description concerns aspects of the writing, illumination, or other
-notation (notably, music) found in a manuscript, including additions
-made in later hands — the <soCalled>text</soCalled>, as it were, as
-opposed to the carrier.
-<specList>
-<specDesc key="handDesc" atts="hands"/>
-<specDesc key="handNote" atts="script scope"/>
-<specDesc key="typeDesc" />
-<specDesc key="typeNote" />
-
-<specDesc key="decoDesc"/>
-<specDesc key="decoNote"/>
-<specDesc key="musicNotation"/>
-<specDesc key="additions"/>
-</specList></p>
-<div type="div4" xml:id="msphwr">
-<head>Writing</head>
-
-<p>The <gi>handDesc</gi> element can contain a short description of
-the general characteristics of the writing observed in a manuscript,
-as in the following example:
-
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<handDesc>
-<p>Written in a <term>late Caroline minuscule</term>; versals in a 
-form of <term>rustic capitals</term>; although the marginal and 
-interlinear gloss is written in varying shades of ink that are 
-not those of the main text, text and gloss appear to have been 
-copied during approximately the same time span.</p>
-</handDesc>
-</egXML></p>
-<p>Note the use of the <gi>term</gi> element to mark specific technical
-terms within the context of the <gi>handDesc</gi> element.</p>
-<p>Where several distinct hands have been identified, this fact can be registered by using the <att>hands</att> attribute, as in
-the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<handDesc hands="2">
-<p>The manuscript is written in two contemporary hands, otherwise
-unknown, but clearly those of practised scribes. Hand I writes
-ff. 1r-22v and hand II ff. 23 and 24. Some scholars, notably
-Verner Dahlerup and Hreinn Benediktsson, have argued for a third hand
-on f. 24, but the evidence for this is insubstantial.</p>
-</handDesc>
-</egXML></p>
-<p>Where more specific
-information about one or more of the hands identified is to be recorded,
-the <gi>handNote</gi> element should
-be used, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<handDesc hands="3">
-<handNote xml:id="Eirsp-1" scope="minor" script="textualis">
-<p>The first part of the manuscript, 
-<locus from="1v" to="72v:4">fols 1v-72v:4</locus>, is written in a practised 
-Icelandic Gothic bookhand. This hand is not found elsewhere.</p></handNote>
-<handNote xml:id="Eirsp-2" scope="major" script="textualis">
-<p>The second part of the manuscript, <locus from="72v:4" to="194v">fols 
-72v:4-194</locus>, is written in a hand contemporary with the first; it can 
-also be found in a fragment of <title>Knýtlinga saga</title>, 
-<ref>AM 20b II fol.</ref>.</p></handNote>
-<handNote xml:id="Eirsp-3" scope="minor" script="cursiva">
-<p>The third hand has written the majority of the chapter headings. 
-This hand has been identified as the one also found in <ref>AM 
-221 fol.</ref>.</p></handNote>
-</handDesc>
-</egXML>
-</p>
-<p>As the above example shows, the attributes <att>script</att> and
-<att>scope</att> are both required on <gi>handNote</gi>. For ENRICH
-purposes, the <att>script</att> attribute must take one of the following values:
-<val>carolmin</val>, 
-<val>textualis</val>, 
-<val>cursiva</val>, 
-<val>hybrida</val>, 
-<val>humbook</val>, 
-<val>humcursiva</val>, or <val>other</val>, and the <att>scope</att>
-attribute must take one of the following values:
-<val>sole</val>, 
-<val>major</val>, 
-<val>minor</val>.</p>
-
-<p>If early printed material or incunables are described using this
-schema, the <gi>typeDesc</gi> and <gi>typeNote</gi> elements may be
-used (in the same way as <gi>handDesc</gi> and <gi>handNote</gi>) to
-record information about the typefaces etc. of interest in the source.
-<!-- example needed --> 
-Both <gi>typeDesc</gi> and <gi>handDesc</gi> may be supplied, for
-example in the case where a printed work has been annotated by a
-number of hands. </p>
-
-<p>The <gi>locus</gi> element, discussed in
-section <ptr target="#msloc"/>, may be used to specify which parts of a
-manuscript are written by a given hand.</p>
-
-<p>In addition, when a full or partial transcription of a manuscript
-is available in addition to the manuscript description, the
-<gi>handShift</gi> element described in <ptr
-target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/PH.html#PHDH"/>
-can be used to link the relevant parts of the transcription to the
-appropriate <gi>handNote</gi> or <gi>typeNote</gi> element in the
-description: for example, at the point in the transcript where the
-second hand listed above starts (i.e. at folio 72v:4), we might insert
-<code>&lt;handShift new="#Eirsp-2"/></code>.</p>
-<p>No <gi>typeShift</gi> element is proposed; if it is felt
-inappropriate to use <gi>handShift</gi> for this purpose, the generic
-<gi>mileStone</gi> may be used.
-<!-- example needed --></p>
-</div>
-<div type="div4" xml:id="msphdec">
-<head>Decoration</head>
-<p>It can be difficult to draw a clear distinction between aspects of
-a manuscript which are purely physical and those which form part of
-its intellectual content. This is particularly true of illuminations
-and other forms of decoration in a manuscript. We propose the
-following elements for the purpose of delimiting discussion of these
-aspects within a manuscript description, and for convenience locate
-them all within the physical description, despite the fact that the
-illustrative features of a manuscript will in many cases also be seen
-as constitutiing part of its intellectual content.</p>
-<p>The <gi>decoDesc</gi> element may contain simply one or more
-paragraphs summarizing the overall nature of the decorative features
-of the manuscript, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<decoDesc>
-<p>The decoration comprises two full page miniatures, perhaps added 
-by the original owner, or slightly later; the original major decoration
-consists of twenty-three large miniatures, illustrating the divisions of 
-the Passion narrative and the start of the major texts, and the major 
-divisions of the Hours; seventeen smaller miniatures, illustrating the 
-suffrages to saints; and seven historiated initials, illustrating
-the pericopes and major prayers.</p>
-</decoDesc>
-</egXML>
-Alternatively, it may contain a series of more specific typed
-<gi>decoNote</gi> elements, each summarizing a particular aspect or
-individual instance of the decoration present, for example the use of
-miniatures, initials (historiated or otherwise), borders, diagrams,
-etc. The scope of the description is indicated by the <att>type</att>
-attribute which, for ENRICH purposes, must take one of the following
-values:
-<val>border</val>, 
-<val>diagram</val>, 
-<val>initial</val>, 
-<val>marginal</val>, 
-<val>miniature</val>, 
-<val>mixed</val>, 
-<val>paratext</val>, 
-<val>secondary</val>, 
-<val>other</val>.
-
-<specGrp xml:id="spec7">
-<elementSpec ident="decoNote" mode="change" module="msdescription">
-<attList>
-  <attDef ident="type" mode="change">
-<defaultVal>other</defaultVal>
-    <valList type="closed" mode="replace">
-<valItem ident="border"/>
-<valItem ident="diagram"/>
-<valItem ident="initial"/>
-<valItem ident="marginal"/>
-<valItem ident="miniature"/>
-<valItem ident="mixed"/>
-<valItem ident="paratext"/>
-<valItem ident="secondary"/>
-<valItem ident="other"/>
-    </valList>
-  </attDef>
-</attList>
-</elementSpec>
-</specGrp></p>
-<p>Here is a simple example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<decoDesc>
-<decoNote type="miniature">
-<p>One full-page miniature, facing the beginning of the first 
-Penitential Psalm.</p>
-</decoNote> 
-<decoNote type="initial">
-<p>One seven-line historiated initial, commencing the first 
-Penitential Psalm.</p>
-</decoNote>
-<decoNote type="initial">
-<p>Six four-line decorated initials, commencing the second through the 
-seventh Penitential Psalm.</p>
-</decoNote>
-<decoNote type="initial">
-<p>Some three hundred two-line versal initials with pen-flourishes, 
-commencing the psalm verses.</p>
-</decoNote>
-<decoNote type="border">
-<p>Four-sided border decoration surrounding the miniatures and three-sided 
-border decoration accompanying the historiated and decorated initials.</p>
-</decoNote>
-</decoDesc>
-</egXML></p>
-<p>Where more exact indexing of the decorative content of a manuscript
-is required, the standard TEI elements <gi>term</gi> or <gi>index</gi>
-may be used within the prose description to supply or delimit
-appropriate iconographic terms, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<decoDesc>
-<decoNote type="miniature">
-<p>Fourteen large miniatures with arched tops, above five lines of text:
-<list>
-<item><locus>fol. 14r</locus>Pericopes. <term>St. John writing on
-Patmos</term>, with the Eagle holding his ink-pot and pen-case; some 
-flaking of pigment, especially in the sky</item>
-<item><locus>fol. 26r</locus>Hours of the Virgin, Matins.
-<term>Annunciation</term>; Gabriel and the Dove to the right</item>
-<item><locus>fol. 60r</locus>Prime. <term>Nativity</term>; the
-<term>Virgin and Joseph adoring the Child</term></item>
-<item><locus>fol. 66r</locus>Terce. <term>Annunciation to the
-Shepherds</term>, one with <term>bagpipes</term></item>
-<!-- ... -->
-</list></p>
-</decoNote>
-</decoDesc>
-</egXML></p>
-</div>
-<div type="div4" xml:id="msphmu"><head>Musical Notation</head>
-<p>Where a manuscript contains music, the <gi>musicNotation</gi>
-element may be used to describe the form of notation employed, as in
-the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<musicNotation>
-<p>Square notation on 4-line red staves.</p>
-</musicNotation>
-<musicNotation>
-<p>Neumes in campo aperto of the St. Gall type.</p>
-</musicNotation>
-</egXML></p>
-</div>
-<div type="div4" xml:id="mspham"><head>Additions and Marginalia</head>
-<p>The <gi>additions</gi> element can be used to list or describe any
-additions to the manuscript, such as marginalia, scribblings, doodles,
-etc., which are considered to be of interest or importance. Such
-topics may also be discussed or referenced elsewhere in a description,
-for example in the <gi>history</gi> element, in cases where the
-marginalia provide evidence of ownership. Some examples follow:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<additions><p>Doodles on most leaves, possibly by children, and often quite amusing.</p></additions>
-<additions><p xml:lang="fr">Quelques annotations marginales des XVIe et XVIIe s.</p></additions>
-<additions>
-<p>The text of this manuscript is not interpolated with sentences from 
-Royal decrees promulgated in 1294, 1305 and 1314. In the margins, however, 
-another somewhat later scribe has added the relevant paragraphs of these 
-decrees, see pp. 8, 24, 44, 47 etc.</p>
-<p>As a humorous gesture the scribe in one opening of the manuscript, pp. 36 
-and 37, has prolonged the lower stems of one letter f and five letters þ 
-and has them drizzle down the margin.</p>
-</additions>
-<additions>
-<p>Spaces for initials and chapter headings were left by the scribe but not filled in. 
-A later, probably fifteenth-century, hand has added initials and chapter headings in 
-greenish-coloured ink on fols <locus>8r</locus>, <locus>8v</locus>, <locus>9r</locus>, 
-<locus>10r</locus> and <locus>11r</locus>. Although a few of these chapter headings are 
-now rather difficult to read, most can be made out, e.g. fol. <locus>8rb</locus> 
-<quote xml:lang="is">floti ast<ex>ri</ex>d<ex>ar</ex></quote>; fol. <locus>9rb</locus> 
-<quote xml:lang="is">v<ex>m</ex> olaf conung</quote>, and fol. <locus>10ra</locus> 
-<quote xml:lang="is">Gipti<ex>n</ex>g ol<ex>a</ex>fs k<ex>onun</ex>gs</quote>.</p>
-<p>The manuscript contains the following marginalia:
-<list>
-<item>Fol. <locus>4v</locus>, left margin: <quote xml:lang="is">hialmadr <ex>ok</ex> <lb/>brynjadr</quote>, 
-in a fifteenth-cenury hand, imitating an addition made to the text by the scribe at this point.</item>
-<item>Fol. <locus>5r</locus>, lower margin: <quote xml:lang="is">þ<ex>e</ex>tta þiki 
-m<ex>er</ex> v<ex>er</ex>a gott blek en<ex>n</ex>da kan<ex>n</ex> ek icki 
-betr sia</quote>, in a fifteenth-century hand, probably the same as that on the previous page.</item>
-<item>Fol. <locus>9v</locus>, bottom margin: <quote xml:lang="is">þessa bok uilda eg <sic>gæt</sic> 
-lært med <lb/>an Gud gefe myer Gott ad <lb/>læra</quote>; seventeenth-century hand.</item>
-</list></p>
-<p>There are in addition a number of illegible scribbles in a later hand (or hands) on fols 
-<locus>2r</locus>, <locus>3r</locus>, <locus>5v</locus> and <locus>19r</locus>.</p>
-</additions>
-</egXML></p>
-</div>
-</div>
-<div type="div3" xml:id="msph3"><head>Bindings, Seals, and Additional Material</head>
-<p>The third major component of the physical description relates to
-supporting but distinct physical components, such as bindings, 
-seals and accompanying material. These may be described using the following specialist elements:
-<specList>
-<specDesc key="bindingDesc"/>
-<specDesc key="binding"/>
-<specDesc key="condition"/>
-<specDesc key="sealDesc"/>
-<specDesc key="seal"/>
-<specDesc key="accMat"/>
-</specList></p>
-<div type="div4" xml:id="msphbi"><head>Binding Descriptions</head>
-<p>The <gi>bindingDesc</gi> element contains a description of the state of
-the present and former bindings of a manuscript, including information
-about its material, any distinctive marks, and provenance information. This may
-be given as a series of paragraphs, if only one binding is being described, or
-as a series of distinct <gi>binding</gi> elements, each describing a distinct
-binding, where these are separately described. For example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<bindingDesc>
-<p>Sewing not visible; tightly rebound over 19th-century pasteboards, reusing 
-panels of 16th-century brown leather with gilt tooling à la fanfare, Paris 
-c. 1580-90, the centre of each cover inlaid with a 17th-century oval medallion 
-of red morocco tooled in gilt (perhaps replacing the identifying mark of a 
-previous owner); the spine similarly tooled, without raised bands or title-piece; 
-coloured endbands; the edges of the leaves and boards gilt. Boxed.</p>
-</bindingDesc>
-</egXML>
-</p>
-<p>Within a binding description, the element <gi>decoNote</gi> is
-available, as an alternative to <gi>p</gi>, for paragraphs dealing
-exclusively with information about decorative features of a binding,
-as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<binding><p>Bound, s. XVIII (?), in <material>diced russia leather</material>
-retaining most of the original 15th century metal ornaments (but with 
-some replacements) as well as the heavy wooden boards.</p>
-<decoNote><p>On each cover: alternating circular stamps of the Holy Monogram, 
-a sunburst, and a flower.</p></decoNote> 
-<decoNote><p>On the cornerpieces, one of which is missing, a rectangular stamp 
-of the Agnus Dei.</p></decoNote> 
-<p>Rebacked during the 19th century.</p>
-</binding>
-</egXML></p>
-</div>
-<div type="div4" xml:id="msphse">
-<head>Seals</head>
-<p>The <gi>sealDesc</gi> element supplies information about the
-seal(s) attached to documents to guarantee their integrity, or to show
-authentication of the issuer or consent of the participants. It may
-contain one or more paragraphs summarizing the overall nature of the
-seals, or may contain one or more <gi>seal</gi> elements.
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<sealDesc>
-<seal n="1" type="pendant" subtype="cauda_duplex">
-<p>Round seal of <name type="person">Anders Olufsen</name> in black wax: 
-<bibl><ref>DAS 930</ref></bibl>. Parchment tag, on which is written: 
-<quote>pertinere nos predictorum placiti nostri iusticarii precessorum dif</quote>.</p></seal>
-<seal n="2" type="pendant" subtype="cauda_duplex">
-<p>The seal of <name type="person">Jens Olufsen</name> in black wax: 
-<bibl><ref>DAS 1061</ref></bibl>. Legend: <quote>S IOHANNES OLAVI</quote>.
-Parchment tag on which is written: <quote>Woldorp Iohanne G</quote>.</p>
-</seal>
-</sealDesc>
-</egXML>
-</p>
-</div>
-<div type="div4" xml:id="msadac"><head>Accompanying Material</head>
-<p>The circumstance may arise where material not originally part of a
-manuscript is bound into or otherwise kept with a manuscript. In some
-cases this material would best be treated in a separate
-<gi>msPart</gi> element (see <ptr target="#mspt"/> below).  There are,
-however, cases where the additional matter is not self-evidently a
-distinct manuscript: it might, for example, be a set of notes by a
-later scholar, or a file of correspondence relating to the
-manuscript. The <gi>accMat</gi> element is provided as a holder for
-this kind of information.
-<specList>
-<specDesc key="accMat"/>
-</specList></p>
-<p>Here is an example of the use of this element, describing a note by
-the Icelandic manuscript collector Árni Magnússon which
-has been bound with the manuscript:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<accMat>
-<p>A slip in Árni Magnússon's hand has been stuck to the
-pastedown on the inside front cover; the text reads:
-<quote xml:lang="is">Þidreks Søgu þessa hefi eg 
-feiged af Sekreterer Wielandt Anno 1715 i Kaupmanna høfn. Hun er, 
-sem eg sie, Copia af Austfirda bókinni (Eidagás) en<ex>n</ex> 
-ecki progenies Brædratungu bokarinnar. Og er þar fyrer eigi i
-allan<ex>n</ex> máta samhlioda þ<ex>eir</ex>re er 
-Sr Jon Erlendz son hefer ritad fyrer Mag. Bryniolf. Þesse Þidreks 
-Saga mun vera komin fra Sr Vigfuse á Helgafelle.</quote></p>
-</accMat>
-</egXML></p>
-
-</div></div>
-</div><div type="div2" xml:id="mshy">
-<head>History</head>
-<p>The following elements are used to record information about the history of a manuscript:
-<specList>
-<specDesc key="history"/>
-<specDesc key="origin"/>
-<specDesc key="provenance"/>
-<specDesc key="acquisition"/>
-</specList></p>
-<p>The three components of the <gi>history</gi> element all have the
-same substructure, consisting of one or more paragraphs marked as
-<gi>p</gi> elements. Each of these three elements is also a member of
-the <ident type="class">att.datable</ident> attribute class, itself a
-member of the <ident type="class">att.datable.w3c</ident> class, and
-thus also carries the following optional attributes:
-<specList><specDesc key="att.datable.w3c" atts="notBefore notAfter
-						from to when">
-</specDesc></specList></p>
-<p>Information about the origins of the manuscript, its place and date
-of writing, should be given as one or more paragraphs contained by a
-single <gi>origin</gi> element; following this, any available
-information on distinct stages in the history of the manuscript before
-its acquisition by its current holding institution should be included
-as paragraphs within one or more <gi>provenance</gi>
-elements. Finally, any information specific to the means by which the
-manuscript was acquired by its present owners should be given as
-paragraphs within the <gi>acquisition</gi> element.</p>
-<p>Here is a fairly simple example of the use of this element:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<history>
-<origin><p>Written in <origPlace>Durham</origPlace> during <origDate notBefore="1125" notAfter="1175">the 
-mid-twelfth century</origDate>.</p></origin> 
-<provenance><p>Recorded in two medieval catalogues of the books belonging 
-to <name type="org">Durham Priory</name>, made in <date>1391</date> and 
-<date>1405</date>.</p>
-<p>Given to <name type="person">W. Olleyf</name> by <name type="person">William 
-Ebchester, Prior (1446-56)</name> and later belonged to <name type="person">Henry 
-Dalton</name>, Prior of Holy Island (<name type="place">Lindisfarne</name>) 
-according to inscriptions on ff. 4v and 5.</p>
-</provenance>
-<acquisition><p>Presented to <name type="org">Trinity College</name> in 
-<date>1738</date> by <name type="person">Thomas Gale</name> and 
-his son <name type="person">Roger</name>.</p></acquisition>
-</history>
-</egXML></p>
-<p>Here is a fuller example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<history>
-<origin notBefore="1225" notAfter="1275">
-<p>Written in Spain or Portugal in the middle of the 13th century 
-(the date 1042, given in a marginal note on f. 97v, cannot be correct.)</p></origin>
-<provenance><p>The Spanish scholar <name type="person">Benito Arias
-Montano</name> (1527-1598) has written his name on f. 97r, and may be
-presumed to have owned the manuscript. It came somehow into the
-possession of <foreign xml:lang="da">etatsråd</foreign> <name type="person">Holger Parsberg</name> (1636-1692), who has written his 
-name twice, once on the front pastedown and once on f. 1r, the former dated
-<date>1680</date> and the latter <date>1682</date>. Following Parsberg's 
-death the manuscript was bought by <foreign>etatsråd</foreign>
-<name type="person">Jens Rosenkrantz</name> (1640-1695) when Parsberg's
-library was auctioned off (23 October 1693).</p></provenance>
-<acquisition notBefore="1696" notAfter="1697"><p>The manuscript was acquired by Árni
-Magnússon from the estate of Jens Rosenkrantz, presumably at
-auction (the auction lot number 468 is written in red chalk on the
-flyleaf), either in 1696 or 97.</p></acquisition>
-</history>
-</egXML></p>
-</div>
-<div type="div2" xml:id="msad">
-<head>Additional information</head>
-<p>Three categories of additional information are provided for by the
-scheme described here, grouped together within the <gi>additional</gi>
-element described in this section.
-<specList>
-<specDesc key="additional"/>
-<specDesc key="adminInfo"/>
-<specDesc key="surrogates"/>
-<specDesc key="listBibl"/>
-</specList></p>
-<p>The <gi>surrogates</gi> element should not be used to describe
-digital images of the manuscript  since the
-<gi>facsimile</gi> element described in <ptr target="#facs"/> is
-provided for this purpose.</p>
-<p>None of the constituent elements of <gi>additional</gi> is
-required. If any is supplied, it may appear once only; furthermore,
-the order in which elements are supplied should be as specified above.</p>
-<div type="div3" xml:id="msadad">
-<head>Administrative information</head>
-<p>The <gi>adminInfo</gi> element is used to hold information relating to the curation and management of
-a manuscript.  This may be supplied  using
-<gi>note</gi> element. Alternatively, different aspects of this
-information may be presented grouped within one<!-- or more-->
-of the following specialized elements:
-<specList>
-<specDesc key="recordHist"/>
-<specDesc key="availability" atts="status"/>
-<specDesc key="custodialHist"/>
-</specList></p>
-<p>The <att>status</att> attribute of <gi>availability</gi> must take
-one of the following values: <val>free</val>, <val>restricted</val>,  <val>unknown</val>.
-</p>
-<div type="div4" xml:id="msrh"><head>Record History</head>
-<p>The <gi>recordHist</gi> element may contain either a series of
-paragraphs or a single <gi>source</gi> element. It is used to document
-the primary source of information for the record containing it, in a
-similar way to the standard TEI <gi>sourceDesc</gi> element within a
-TEI Header. If the record is a new one, made without reference to
-anything other than the manuscript itself, then it may be omitted, or
-simply contain a <gi>p</gi> element, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<source><p>Directly catalogued from the original manuscript.</p></source>
-</egXML></p>
-<p>Frequently, however, the record will be derived from some
-previously existing description, which may be specified using the
- <gi>bibl</gi> element, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<recordHist>
-<source><p>Information transcribed from <bibl><title>The index of
-Middle English verse</title><biblScope unit="pages">123</biblScope></bibl>.</p></source>
-</recordHist>
-</egXML></p>
-<p>If, as is likely, a full bibliographic description of the source
-from which cataloguing information was taken is included within the
-<gi>listBibl</gi> element contained by the current <gi>additional</gi>
-element, or elsewhere in the current document, then it need not be
-repeated here. Instead, it should be referenced using the standard TEI
-<gi>ref</gi> element, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples"><additional>
-  <adminInfo>
-    <recordHist>
-    <source>
-      <p>Information transcribed from 
-        <bibl><ref target="#IMEV">IMEV</ref> 123</bibl>.</p>
-    </source>
-    </recordHist>
-  </adminInfo>
-  <listBibl>
-    <bibl xml:id="IMEV">
-      <author>Carleton Brown</author> and <author>Rossell Hope Robbins</author>
-      <title level="m">The index of Middle English verse</title>
-      <pubPlace>New York</pubPlace>
-      <date>1943</date>
-    </bibl>
-    <!-- other bibliographic records relating to this manuscript here -->
-  </listBibl>
-</additional>
-</egXML></p>
-<p>The <gi>change</gi> element 
-within the <gi>revisionDesc</gi> element of the
- TEI Header should be used to document the revision history of the
-record. It should <emph>not</emph> be given within the
-<gi>recordHist</gi> element. </p>
-
-</div><div type="div4" xml:id="msadch"><head>Availability and Custodial History</head>
-<p>The <gi>availability</gi> element is another element also available
-in  the TEI Header,
-which should be used here to supply any information concerning
-access to the current manuscript, such as its physical location (where this
-is not implicit in its identifier), any restrictions on access, information
-about copyright, etc.
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<availability status="restricted">
-<p>Viewed by appointment only, to be arranged with curator.</p>
-</availability>
-<availability  status="unknown">
-<p>In conservation, Jan. - Mar., 2002. On loan to the 
-Bayerische Staatsbibliothek, April - July, 2002.</p>
-</availability>
-<availability status="restricted">
-<p>The manuscript is in poor condition, due to many of the leaves being 
-brittle and fragile and the poor quality of a number of earlier repairs; 
-it should therefore not be used or lent out until it has been conserved.</p>
-</availability>
-</egXML></p>
-<p>The <gi>custodialHist</gi> record is used to describe the custodial
-history of a manuscript, recording any significant events noted during
-the period that it has been located within its holding institution. It
-may contain either a series of 
-<gi>p</gi> elements, or a series of <gi>custEvent</gi> elements, each
-describing a distinct incident or event, further specified by a
-<att>type</att> attribute, and carrying dating information by virtue
-of its membership in the <ident type="class">att.datable</ident> class, as noted above.
-<specList>
-<specDesc key="custEvent"/>
-</specList></p>
-<p>For ENRICH purposes, the values of this attribute must be one of
-the following: <val>check</val>, <val>conservation</val>,
-<val>description</val>, <val>exhibition</val>, <val>loan</val>,
-<val>photography</val>, <val>other</val>.
-
-<specGrp xml:id="spec8">
-<elementSpec ident="custEvent" mode="change" module="msdescription">
-<attList>
-  <attDef ident="type" mode="change" usage="req">
-    <valList type="closed" mode="replace">
-<valItem ident="check"/>  
-<valItem ident="conservation"/>
-<valItem ident="description"/>
-<valItem ident="exhibition"/>
-<valItem ident="loan"/>
-<valItem ident="photography"/>
-<valItem ident="other"/>
-    </valList>
-
-  </attDef>
-
-</attList>
-</elementSpec>
-</specGrp>
-</p>
-
-<p>Here is an example of the use of this element:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<custodialHist>
-<custEvent type="conservation" notBefore="1961-03-01" notAfter="1963-02-28">
-<p>Conserved between March 1961 and February 1963 at Birgitte Dalls 
-Konserveringsværksted.</p></custEvent>
-<custEvent type="photography" notBefore="1988-05-01" notAfter="1988-05-30">
-<p>Photographed in May 1988 by AMI/FA.</p></custEvent>
-<custEvent type="loan" notBefore="1989-11-13" notAfter="1989-11-13">
-<p>Dispatched to Iceland 13 November 1989.</p></custEvent>
-</custodialHist>
-</egXML></p>
-</div>
-</div>
-<div type="div3" xml:id="msadsu">
-<head>Surrogates</head>
-<p>The <gi>surrogates</gi> element is used
-to provide information about any digital or photographic
-representations of the manuscript which may exist within the holding
-institution or elsewhere. 
-<specList>
-<specDesc key="surrogates"/>
-</specList></p>
-<p>The <gi>surrogates</gi> element should not be used to repeat
-information about representations of the manuscript available within
-published works; this should normally be documented within the
-<gi>listBibl</gi> element within the <gi>additional</gi>
-element. However, it is often also convenient to record information
-such as negative numbers or digital identifiers for unpublished
-collections of manuscript images maintained within the holding
-institution, as well as to provide more detailed descriptive
-information about the surrogate itself. Such information may be provided
-as prose paragraphs, within which identifying information about particular
-surrogates may be presented using the standard TEI <gi>bibl</gi> element,
-as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<surrogates>
-<p>
-<bibl><title type="gmd">microfilm (master)</title><idno>G.neg. 160</idno> n.d.</bibl>
-<bibl><title type="gmd">microfilm (archive)</title><idno>G.pos. 186</idno> n.d.</bibl>
-<bibl><title type="gmd">b/w prints</title><idno>AM 795 4to</idno>
-<date when="1999-01-27">27 January 1999</date><note>copy of G.pos. 186</note></bibl>
-<bibl><title type="gmd">b/w prints</title><idno>reg.nr. 75</idno>
-<date when="1999-01-25">25 January 1999</date>
-<note>photographs of the spine, outside covers, stitching etc.</note>
-</bibl>
-</p>
-</surrogates>
-</egXML>
-Note the use of the specialized form of title (<term>general material designation</term>) to specify the kind of surrogate being documented.</p>
-<p>For ENRICH purposes, information about digital
-images of the manuscript being described should be provided within the
-<gi>facsimile</gi> element discussed in section <ptr target="#facs"/>
-below rather than within the  <gi>surrogates</gi> element.</p>
-</div>
-</div>
-<div type="div2" xml:id="mspt">
-<head>Manuscript Parts</head>
-<p>The <gi>msPart</gi> element may be used in cases where what were
-originally physically separate manuscripts or parts of manuscripts
-have been bound together and/or share the same call number.
-<specList>
-<specDesc key="msPart"/>
-</specList></p>
-<p>Since each component of such a composite manuscript will in all
-likelihood have its own content, physical description, history, and so
-on, the structure of <gi>msPart</gi> is in the main identical to that
-of <gi>msDesc</gi>, allowing one to retain the top level of
-identity (<gi>msIdentifier</gi>), but to branch out thereafter into as
-many parts, or even subparts, as necessary. If the parts of a
-composite manuscript have their own identifiers, they should be tagged
-using the <gi>idno</gi> element, rather than the <gi>msIdentifier</gi>
-element, as in the following example:
-<!-- don't understand why these need to to wrapped in <altIdentifier> -->
-<!-- I don't either, but now it has to be wrapped in an
-     <msIdentifier>, too. —Syd, 2016-09-10 :-) -->
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-  <msDesc xml:id="ex3" xml:lang="en">
-    <msIdentifier>
-      <settlement>Amiens</settlement>
-      <repository>Bibliothèque Municipale</repository>
-      <idno>MS 3</idno>
-      <msName>Maurdramnus Bible</msName>
-    </msIdentifier>
-    <!-- other elements here -->
-    <msPart>
-      <msIdentifier>
-	<altIdentifier type="other">
-	  <idno>MS 6</idno>
-	</altIdentifier>
-	<!-- other information specific to this part here -->
-      </msIdentifier>
-    </msPart>
-    <msPart>
-      <msIdentifier>
-	<altIdentifier type="other">
-	  <idno>MS 7</idno>
-	</altIdentifier>
-	<!-- other information specific to this part here -->
-      </msIdentifier>
-    </msPart>
-    <msPart>
-      <msIdentifier>
-	<altIdentifier type="other">
-	  <idno>MS 9</idno>
-	</altIdentifier>
-	<!-- other information specific to this part here -->
-      </msIdentifier>
-    </msPart>
-    <!-- other msParts here -->
-  </msDesc>
-</egXML>
-</p>
-</div>
-</div>
-<div xml:id="facs"><head>Metadata about digital facsimiles</head>
-<p>The <gi>facsimile</gi> element is used to describe the digital
-images of the manuscript being made available to the ENRICH
-project. It contains, as a minimum, one <gi>surface</gi> element for
-each distinct page image, which in turn specifies one or more
-<gi>graphic</gi> element. These elements are used as described in the
-<ref
-    target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/PH.html#PHFACS">TEI Guidelines, section11.1</ref>. </p>
-<p>Here is a simple example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<facsimile xml:base="http://www.handrit.org/AM/fol/">
-        <surface xml:id="LSB-1r" ulx="0" uly="0" lrx="200" lry="300">
-            <graphic mimeType="jpeg" xml:id= "AM02-5000-1r"
-url="AM02-5000-1r.jpg"/>
-            <graphic mimeType="jpeg" url="AM02-5000-1r-thumb.jpg"
-		     width="1in" decls="#thumb"/>
-            <zone ulx="20" uly="20" lrx="70" lry="70">
-            <graphic mimeType="jpeg" xml:id= "AM02-5000-1r-det"
-url="AM02-5000-1r-det.jpg"/>
-            </zone>
-        </surface>
-        <surface  start="#LSB-1v" ulx="0" uly="0" lrx="200" lry="300">
-            <graphic mimeType="jpeg" xml:id= "AM02-5000-1v"
-url="AM02-5000-1v.jgp"/>
-            <graphic mimeType="jpeg" url="AM02-5000-1v-thumb.jpg" decls="http://www.enrich.org/imageDescs#thumb"/>
-        </surface>
-    </facsimile></egXML>
-</p>
-<p>The <att>xml:base</att> attribute specifies the <soCalled>root
-URL</soCalled>, which will be prefixed to all URL values within the
-child elements of this <gi>facsimile</gi>. </p>
-<p>This example defines only two pages. There are three images
-associated with the first page, which is
-represented by the <gi>surface</gi> element with
-unique identifier <val>LSB-1r</val>, and two with  the second, which has no
-identifier. Each image is represented by means of a TEI
-<gi>graphic</gi> element. </p>
-<p>As well as acting as a container for the various images associated
-with a page, the <gi>surface</gi> element defines an abstract
-co-ordinate system which may be used when defining additional zones of
-interest on the page. In this example, the location of an initial
-letter on the page is defined, since we have a graphic representing
-this detail. The zone within which the initial letter falls is in the
-box defined by the co-ordinates (20,20,70,70) within a grid defined by
-the co-ordinates (0,0,200,300). Thus, if the surface depicted
-actually measured 200 by 300 mm, the initial letter would occupy a
-50 X 50 mm square, with its upper left corner located 20 mm from the
-left and 20 mm from the top edges of the surface. Note however that
-the numbers used to express co-ordinates are not measurements in any
-specific units and should not be used to determine the actual image
-size, since these may in any case vary greatly: in our example, the
-first image is a full page scan, while the second is a thumbnail.</p>
-<p>The <att>mimeType</att> attribute is used to indicate the format of
-the graphic file itself, and may be any valid MIME type, as defined by
-the IANA, for example <val>jpeg</val>, <val>png</val>, <val>bmp</val>,
-<val>tiff</val> etc. </p>
-<p>The <att>decls</att> attribute is used to indicate an external URI
-from which further metadata applicable to this image may be found. In
-this case we are assuming that there is a definition which can be used
-to indicate characteristics of a thumbnail image at the address
-indicated. Note that this must be given in full, since it would
-otherwise be interpreted as an address relative to the value of the
-<att>xml:base</att> attribute on the parent <gi>facsimile</gi>.</p>
-<note rend="query">Alternatively, should we invent a type-like attribute
-which could be validated in the schema? </note>
-<p>The <gi>desc</gi> element within a <gi>zone</gi> may be used to
-supply additional information about that zone, in this example to
-describe what it contains. In the TEI scheme, full documentation  of a
-facsimile and its contents is carried in other parts of the digital
-document, linked to it in either or both of the following ways:
-<list>
-<item>the <att>start</att> attribute may be used on a <gi>zone</gi> or
-<gi>surface</gi>; it points to an element in the transcription the
-start of which coincides with the zone or surface concerned.</item>
-<item>the <att>facs</att> attribute may be used, for example on the
-<gi>msContents</gi> or <gi>msItem</gi> element in a manuscript
-description, or on any element in the transcription, to point to the
-<gi>surface</gi> bearing the start of the matter in question. </item>
-</list>
-</p>
-<p>To complete the above example, we might thus expect that the
-<gi>msDesc</gi> for this manuscript will contain something like the
-following:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<msItem>
-    <locus facs="#LSB-1r">ff. 1r-1v</locus>
-    <title>Ludovícuss saga Bernharðssonar</title>
-</msItem>
-</egXML>
-Here, the value of the <att>facs</att> attribute is a
-pointer to the <gi>surface</gi> element corresponding with the part of
-the manuscript in which the <gi>msItem</gi> specified begins.
-
-If a transcription of this (regrettably nonexistent) manuscript exists,
-then it might begin as follows:
-
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<div facs="#LSB-1r">
-   <pb n="1r" />
-   <p>Maðr hét Ludovícus, sonr Bernharðs greifa, er kallaðr var loðinbjörn.
-                <!-- rest of text for page one -->
-   <pb n="1v" xml:id="LSB-1v"/>
-       <!-- text for second page here -->
-   </p>
-</div></egXML>
-pointer to the <gi>surface</gi> element corresponding with the part of
-the manuscript at which the transcribed text begins.
-</p>
-</div>
-<div>
-<head>Schema</head>
-<schemaSpec ident="tei_enrich" start="TEI msDesc teiHeader">
-	<moduleRef key="header"/>
-	<moduleRef key="core"/>
-	<moduleRef key="tei"/>
-	<moduleRef key="textstructure"/>
-	<moduleRef key="msdescription"/>
-	<moduleRef key="linking"/>
-	<moduleRef key="namesdates"/>
-	<moduleRef key="figures"/>
-	<moduleRef key="transcr"/>
-	<moduleRef key="gaiji"/>
-
-<!-- delete uninteresting classes -->
-
-<classSpec ident="att.global.linking" mode="delete" type="atts"/>
-<classSpec ident="att.datable.iso" type="atts" mode="delete"/>
-<classSpec ident="model.addrPart" type="model" mode="delete"/>
-
-<!-- delete unwanted elements -->
-
-<elementSpec module="core" ident="address" mode="delete"/>
-<elementSpec module="core" ident="analytic" mode="delete"/>
-<elementSpec module="core" ident="biblFull" mode="delete"/>
-<elementSpec module="core" ident="biblStruct" mode="delete"/>
-<elementSpec module="core" ident="binaryObject" mode="delete"/>
-<elementSpec module="core" ident="cit" mode="delete"/>
-<elementSpec module="core" ident="distinct" mode="delete"/>
-<elementSpec module="core" ident="email" mode="delete"/>
-<elementSpec module="core" ident="emph" mode="delete"/>
-<elementSpec module="core" ident="equiv" mode="delete"/>
-<elementSpec module="core" ident="headItem" mode="delete"/>
-<elementSpec module="core" ident="headLabel" mode="delete"/>
-<elementSpec module="core" ident="imprint" mode="delete"/>
-<elementSpec module="core" ident="measure" mode="delete"/>
-<elementSpec module="core" ident="measureGrp" mode="delete"/>
-<elementSpec module="core" ident="meeting" mode="delete"/>
-<elementSpec module="core" ident="mentioned" mode="delete"/>
-<elementSpec module="core" ident="monogr" mode="delete"/>
-<elementSpec module="core" ident="num" mode="delete"/>
-<elementSpec module="core" ident="postBox" mode="delete"/>
-<elementSpec module="core" ident="postCode" mode="delete"/>
-<elementSpec module="core" ident="refsDecl" mode="delete"/>
-<elementSpec module="core" ident="rs" mode="delete"/>
-<elementSpec module="core" ident="said" mode="delete"/>
-<elementSpec module="core" ident="series" mode="delete"/>
-<elementSpec module="core" ident="soCalled" mode="delete"/>
-<elementSpec module="core" ident="sp" mode="delete"/>
-<elementSpec module="core" ident="speaker" mode="delete"/>
-<elementSpec module="core" ident="stage" mode="delete"/>
-<elementSpec module="core" ident="street" mode="delete"/>
-<elementSpec module="core" ident="teiCorpus" mode="delete"/>
-<elementSpec module="core" ident="time" mode="delete"/>
-<elementSpec module="figures" ident="table" mode="delete"/>
-<elementSpec module="figures" ident="cell" mode="delete"/>
-<elementSpec module="figures" ident="row" mode="delete"/>
-<elementSpec module="header" ident="appInfo" mode="delete"/>
-<elementSpec module="header" ident="application" mode="delete"/>
-<elementSpec module="header" ident="broadcast" mode="delete"/>
-<elementSpec module="header" ident="correction" mode="delete"/>
-<elementSpec module="header" ident="cRefPattern" mode="delete"/>
-<elementSpec module="header" ident="equipment" mode="delete"/>
-<elementSpec module="header" ident="fsdDecl" mode="delete"/>
-<elementSpec module="header" ident="hyphenation" mode="delete"/>
-<elementSpec module="header" ident="interpretation" mode="delete"/>
-<elementSpec module="header" ident="metDecl" mode="delete"/>
-<elementSpec module="header" ident="metSym" mode="delete"/>
-<elementSpec module="header" ident="namespace" mode="delete"/>
-<elementSpec module="header" ident="normalization" mode="delete"/>
-<elementSpec module="header" ident="quotation" mode="delete"/>
-<elementSpec module="header" ident="recording" mode="delete"/>
-<elementSpec module="header" ident="recordingStmt" mode="delete"/>
-<elementSpec module="header" ident="rendition" mode="delete"/>
-<elementSpec module="header" ident="samplingDecl" mode="delete"/>
-<elementSpec module="header" ident="scriptStmt" mode="delete"/>
-<elementSpec module="header" ident="segmentation" mode="delete"/>
-<elementSpec module="header" ident="state" mode="delete"/>
-<elementSpec module="header" ident="stdVals" mode="delete"/>
-<elementSpec module="header" ident="tagUsage" mode="delete"/>
-<elementSpec module="header" ident="tagsDecl" mode="delete"/>
-<elementSpec module="header" ident="variantEncoding" mode="delete"/>
-<elementSpec module="linking" ident="ab" mode="delete"/>
-<elementSpec module="linking" ident="alt" mode="delete"/>
-<elementSpec module="linking" ident="altGrp" mode="delete"/>
-<elementSpec module="linking" ident="join" mode="delete"/>
-<elementSpec module="linking" ident="joinGrp" mode="delete"/>
-<elementSpec module="linking" ident="link" mode="delete"/>
-<elementSpec module="linking" ident="linkGrp" mode="delete"/>
-<elementSpec module="linking" ident="timeline" mode="delete"/>
-<elementSpec module="linking" ident="when" mode="delete"/>
-<elementSpec module="msdescription" ident="msItemStruct" mode="delete"/>
-<elementSpec module="namesdates" ident="climate" mode="delete"/>
-<elementSpec module="namesdates" ident="listNym" mode="delete"/>
-<elementSpec module="namesdates" ident="nym" mode="delete"/>
-<elementSpec module="namesdates" ident="terrain" mode="delete"/>
-<elementSpec module="textstructure" ident="argument" mode="delete"/>
-<elementSpec module="textstructure" ident="byline" mode="delete"/>
-<elementSpec module="textstructure" ident="closer" mode="delete"/>
-<elementSpec module="textstructure" ident="dateline" mode="delete"/>
-<elementSpec module="textstructure" ident="div1" mode="delete"/>
-<elementSpec module="textstructure" ident="div2" mode="delete"/>
-<elementSpec module="textstructure" ident="div3" mode="delete"/>
-<elementSpec module="textstructure" ident="div4" mode="delete"/>
-<elementSpec module="textstructure" ident="div5" mode="delete"/>
-<elementSpec module="textstructure" ident="div6" mode="delete"/>
-<elementSpec module="textstructure" ident="div7" mode="delete"/>
-<elementSpec module="textstructure" ident="docDate" mode="delete"/>
-<elementSpec module="textstructure" ident="epigraph" mode="delete"/>
-<elementSpec module="textstructure" ident="floatingText" mode="delete"/>
-<elementSpec module="textstructure" ident="imprimatur" mode="delete"/>
-<elementSpec module="textstructure" ident="opener" mode="delete"/>
-<elementSpec module="textstructure" ident="postscript" mode="delete"/>
-<elementSpec module="textstructure" ident="salute" mode="delete"/>
-<elementSpec module="textstructure" ident="signed" mode="delete"/>
-<elementSpec module="textstructure" ident="trailer" mode="delete"/>
-
-<!-- constrain attribute values for several elements and also supply defaults -->
-
-<elementSpec ident="biblScope" mode="change" module="core">
-<attList>
-<attDef ident="unit" mode="change" usage="req">
-<valList type="closed" mode="replace">
-<valItem ident="volume"/>
-<valItem ident="pages"/> 
-</valList>
-</attDef>
-</attList>
-</elementSpec>
-
-<elementSpec ident="gap" mode="change" module="core">
-<attList>
-  <attDef ident="reason" mode="change" usage="req">
-<desc  xml:lang="en" versionDate="2014-01-12">gives the reason for omission of this material from the
-transcription.</desc>
-<valList type="closed" mode="replace">
-<valItem ident="damage"><desc  xml:lang="en" versionDate="2014-01-12">medium is damaged</desc></valItem>  
-<valItem ident="illegible"><desc  xml:lang="en" versionDate="2014-01-12">material cannot be reliably read</desc></valItem>
-<valItem ident="cancelled"><desc  xml:lang="en" versionDate="2014-01-12">material can be read but has been cancelled
-by scribe</desc></valItem>
-<valItem ident="irrelevant"><desc  xml:lang="en" versionDate="2014-01-12">material is not regarded as relevant by
-the transcriber</desc></valItem>
-<valItem ident="omitted"><desc  xml:lang="en" versionDate="2014-01-12">material omitted by transcriber</desc></valItem>
-<valItem ident="lacuna"><desc  xml:lang="en" versionDate="2014-01-12">material missing from the source</desc></valItem>
-</valList>
-  </attDef>
-  <attDef ident="unit" mode="change" usage="opt">
-    <desc  xml:lang="en" versionDate="2014-01-12">names the unit used for describing the extent of the gap</desc>
-    <valList type="closed" mode="replace">
-      <valItem ident="chars"><desc  xml:lang="en" versionDate="2014-01-12">written characters</desc></valItem>
-      <valItem ident="leaves"><desc  xml:lang="en" versionDate="2014-01-12">leaves</desc></valItem>
-      <valItem ident="lines"><desc  xml:lang="en" versionDate="2014-01-12">lines</desc></valItem>
-      <valItem ident="mm"><desc  xml:lang="en" versionDate="2014-01-12">millimetres</desc></valItem>
-      <valItem ident="pages"><desc  xml:lang="en" versionDate="2014-01-12">pages</desc></valItem>
-      <valItem ident="words"><desc  xml:lang="en" versionDate="2014-01-12">words</desc></valItem>
-    </valList>
-<!-- no default!! -->
-  </attDef>
-</attList>
-</elementSpec>
-
-
-<elementSpec ident="hi" mode="change" module="core">
-<attList>
-<attDef ident="rend" mode="change" usage="req">
-<valList type="closed" mode="replace">
-<valItem ident="hyphenated"/>
-<valItem ident="underline"/>
-<valItem ident="double-underline"/>
-<valItem ident="bold"/>
-<valItem ident="caps"/>
-<valItem ident="italic"/>
-<valItem ident="sup"/>
-<valItem ident="rubric"/>
-</valList>
-</attDef>
-</attList>
-</elementSpec>
-
-<elementSpec ident="name" mode="change" module="core">
-<attList>
-<attDef ident="type" mode="change" usage="req">
-<valList type="closed" mode="replace">
-<valItem ident="person"/>
-<valItem ident="place"/>
-<valItem ident="org"/>  
-<valItem ident="unknown"/>  
-</valList>
-</attDef>
-</attList>
-</elementSpec>
-
-<elementSpec ident="handNote" mode="change" module="msdescription">
-<attList>
-  <attDef ident="script" mode="change" usage="req">
-<valList type="closed" mode="replace">
-<valItem ident="carolmin"/>
-<valItem ident="textualis"/>
-<valItem ident="cursiva"/>
-<valItem ident="hybrida"/>
-<valItem ident="humbook"/>
-<valItem ident="humcursiva"/>  
-<valItem ident="other"><desc  xml:lang="en" versionDate="2014-01-12">script other than one of these</desc></valItem>
-<valItem ident="unknown"><desc  xml:lang="en" versionDate="2014-01-12">script information not available</desc></valItem>
-</valList>
-</attDef>
-<attDef ident="scope" mode="change" usage="req">
-<valList type="closed" mode="replace">
-<valItem ident="sole"/>
-<valItem ident="major"/>
-<valItem ident="minor"/>
-</valList>
-</attDef>
-</attList>
-</elementSpec>
-
-<elementSpec ident="altIdentifier" module="msdescription" mode="change">
-<attList>
-  <attDef ident="type" mode="change" usage="req">
-<valList type="closed" mode="replace">
-<valItem ident="former"><desc  xml:lang="en" versionDate="2014-01-12">former catalogue or shelf number</desc></valItem>
-<valItem ident="system"><desc  xml:lang="en" versionDate="2014-01-12">former system identifier
-(Manuscriptorium specific)</desc></valItem>
-<valItem ident="partial"><desc  xml:lang="en" versionDate="2014-01-12">identifier of a previously distinct
-item</desc></valItem>
-<valItem ident="internal"><desc  xml:lang="en" versionDate="2014-01-12">internal project identifier</desc></valItem>
-<valItem ident="other"><desc  xml:lang="en" versionDate="2014-01-12">unspecified</desc></valItem>
-</valList>
-
-  </attDef>
-</attList>
-</elementSpec>
-
-<elementSpec ident="availability" mode="change" module="header">
-<attList>
-  <attDef ident="status" mode="change" usage="req">
-    <valList type="closed" mode="replace">
-<valItem ident="free"/>
-<valItem ident="unknown"/>
-<valItem ident="restricted"/>  
-    </valList>
-  </attDef>
-</attList>
-</elementSpec>
-
-<elementSpec ident="textLang" mode="change" module="msdescription">
-<attList>
-  <attDef ident="mainLang" mode="change" usage="req"/>
-</attList>
-</elementSpec>
-
-<elementSpec ident="objectDesc" mode="change" module="msdescription">
-<attList>
-<attDef ident="form" mode="change" usage="req">
-<valList type="closed" mode="replace">
-<valItem ident="codex"><desc  xml:lang="en" versionDate="2014-01-12">a bound codex</desc></valItem>
-<valItem ident="leaf"><desc  xml:lang="en" versionDate="2014-01-12">a loose leaf</desc></valItem>
-<valItem ident="scroll"><desc  xml:lang="en" versionDate="2014-01-12">a scroll</desc></valItem>
-<valItem ident="other"><desc  xml:lang="en" versionDate="2014-01-12">any other format</desc></valItem>
-</valList>
-</attDef></attList>
-</elementSpec>
-
-<elementSpec ident="supportDesc" mode="change" module="msdescription">
-<attList>
-  <attDef ident="material" mode="change" usage="req">
-    <valList type="closed" mode="replace">
-<valItem ident="perg"><desc  xml:lang="en" versionDate="2014-01-12">parchment</desc></valItem>
-<valItem ident="chart"><desc  xml:lang="en" versionDate="2014-01-12">paper</desc></valItem>
-<valItem ident="mixed"><desc  xml:lang="en" versionDate="2014-01-12">mixture of paper and parchment, or other materials</desc></valItem>  
-<valItem ident="unknown"/> 
-    </valList>
-  </attDef>
-</attList>
-</elementSpec>
-
-<elementSpec ident="layout" mode="change" module="msdescription">
-  <attList>
-    <attDef ident="columns" mode="change" usage="req"/>
-  </attList>
-</elementSpec>
-
-<elementSpec ident="msDesc" mode="change" module="msdescription">
-<attList>
-  <attDef ident="xml:id" mode="change" usage="req"/>
-  <attDef ident="xml:lang" mode="change" usage="req"/>
-</attList>
-</elementSpec>
-
-<elementSpec ident="decoNote" mode="change" module="msdescription">
-<attList>
-  <attDef ident="type" mode="change">
-<defaultVal>other</defaultVal>
-    <valList type="closed" mode="replace">
-<valItem ident="border"/>
-<valItem ident="diagram"/>
-<valItem ident="initial"/>
-<valItem ident="marginal"/>
-<valItem ident="miniature"/>
-<valItem ident="mixed"/>
-<valItem ident="paratext"/>
-<valItem ident="secondary"/>
-<valItem ident="other"/>
-<valItem ident="illustration"/>
-<valItem ident="printmark"/>
-<valItem ident="publishmark"/>
-<valItem ident="vignette"/>
-<valItem ident="frieze"/>
-<valItem ident="map"/>
-<valItem ident="unspecified"/>
-    </valList>
-  </attDef>
-</attList>
-</elementSpec>
-
-<elementSpec ident="custEvent" mode="change" module="msdescription">
-<attList>
-  <attDef ident="type" mode="change" usage="req">
-    <valList type="closed" mode="replace">
-<valItem ident="check"/>  
-<valItem ident="conservation"/>
-<valItem ident="description"/>
-<valItem ident="exhibition"/>
-<valItem ident="loan"/>
-<valItem ident="photography"/>
-<valItem ident="other"/>
-    </valList>
-
-  </attDef>
-
-</attList>
-</elementSpec>
-
-
-
-<elementSpec ident="person" mode="change" module="namesdates">
-<attList>
-  <attDef ident="sex" mode="change" usage="req"/>
-</attList>
-</elementSpec>
-
-
-<classSpec ident="att.dimensions" mode="change" type="atts">
-<attList>
-<attDef mode="delete" ident="precision"/>
-<attDef mode="change" ident="unit">
-<defaultVal>mm</defaultVal>
-<valList type="closed" mode="replace">
-<valItem ident="cm"/>
-<valItem ident="mm"/>
-<valItem ident="in"/>
-<valItem ident="lines"/>
-<valItem ident="chars"/>
-</valList></attDef></attList>
-</classSpec>
-
-<elementSpec ident="dimensions" mode="change" module="msdescription">
-<attList>
-  <attDef ident="type" mode="change" usage="req">
-    <valList type="closed" mode="replace">
-<valItem ident="leaf"/>
-<valItem ident="binding"/>
-<valItem ident="slip"/>
-<valItem ident="written"/>
-<valItem ident="boxed"/>  
-<valItem ident="unknown"/>  
-
-    </valList>
-  </attDef>
-</attList>
-</elementSpec>
-
-<elementSpec ident="region" mode="change" module="namesdates">
-<attList>
-  <attDef ident="type" mode="change" usage="req">
-    <valList type="closed" mode="replace">
-<valItem ident="parish"/>
-<valItem ident="county"/>
-<valItem ident="compass"/>
-<valItem ident="geog"/>
-<valItem ident="state"/> 
-<valItem ident="unknown"/> 
-    </valList>
-  </attDef>
-</attList>
-</elementSpec>
-
-<elementSpec ident="supplied" mode="change" module="transcr">
-<attList>
-  <attDef ident="reason" mode="change"   usage="req">
-    <valList type="closed" mode="replace">
-<valItem ident="omitted"/>
-<valItem ident="illegible"/>
-<valItem ident="damage"/>  
-<valItem ident="unknown"/> 
-    </valList>
-  </attDef>
-</attList>
-</elementSpec>
-
-<!-- constrain date attributes -->
-
-<elementSpec ident="date" mode="change" module="core">
-  <constraintSpec scheme="schematron" ident="dates">
-    <constraint>
-      <sch:assert test="@when or (@notAfter and @notBefore) or
-			(@from and @to)">
-      You must provide either @when or @to/@from, or @notAfter/@notBefore.</sch:assert>
-    </constraint>
-  </constraintSpec>
-</elementSpec>
-
-<!-- remove optional global attribute we don't want to use -->
-
-  <classSpec ident="att.global.rendition" type="atts" mode="change" module="tei">
-    <attList>
-<attDef ident="rendition" mode="delete"/>
-    </attList>
-  </classSpec>
-
-
-
-
-<!-- remove stupid (non-mandatory) elements we dont want in this place -->
-<!-- remove option of change within history -->
-
-<elementSpec  xmlns:rng="http://relaxng.org/ns/structure/1.0"
-	      module="msdescription"  ident="recordHist" mode="change">
-
-  <content>
-    <rng:choice>
-      <rng:oneOrMore>
-        <rng:ref name="model.pLike"/>
-      </rng:oneOrMore>
-      <rng:ref name="source"/>
-    </rng:choice>
-  </content>
-</elementSpec>
-
-
-
-<!-- HERE BE DIRTY STUFF WHICH SHOULD BE IN ITS OWN NAMESPACE 
-     BUT WHICH IS ALREADY SCHEDULED FOR INCLUSION IN NEXT P5 RELEASE-->
-
-<!-- add origPlace to att.typed  -->
-
-<elementSpec ident="origPlace" module="msdescription" mode="change">
-<classes mode="change">
-  <memberOf key="att.typed"/>
-  <memberOf key="att.datable"/>
-  <memberOf key="att.editLike"/>
-  <memberOf key="model.pPart.msdesc"/>
-</classes>
-</elementSpec>
-
-<!-- permit titlepage inside msContents -->
-<elementSpec ident="msContents" module="msdescription" mode="change">
-  <content>
-    <rng:choice xmlns:rng="http://relaxng.org/ns/structure/1.0">
-      <rng:oneOrMore>
-        <rng:ref name="model.pLike"/>
-      </rng:oneOrMore>
-      <rng:group>
-        <rng:optional>
-          <rng:ref name="summary"/>
-        </rng:optional>
-        <rng:optional>
-          <rng:ref name="textLang"/>
-        </rng:optional>
-        <rng:optional>
-          <rng:ref name="titlePage"/>
-        </rng:optional>
-        <rng:zeroOrMore>
-            <rng:ref name="msItem"/>
-	  </rng:zeroOrMore>
-      </rng:group>
-    </rng:choice>
-  </content>
-
-</elementSpec>
-
-<!-- change wording of desc to be less confusing -->
-<elementSpec ident="surrogates" mode="change" module="msdescription">
-<desc  xml:lang="en" versionDate="2014-01-12">contains information about any non-digital representations of the manuscript being described which may exist in the holding institution or elsewhere.
-</desc></elementSpec>
-
-</schemaSpec>
-
-</div>
-   </body>
+        -->
+
+        <!-- in Reykjavik, we removed head; I expect it will return though -->
+
+        <div type="div2" xml:id="msco">
+          <head>Intellectual Content</head>
+          <p>The <gi>msContents</gi> element is used to describe the
+          intellectual content of a manuscript or manuscript part. It comprises
+          <emph>either</emph> a series of informal prose paragraphs
+          <emph>or</emph> a series of <gi>msItem</gi> 
+          elements, each of which provides a more detailed description of a
+          single item contained within the manuscript. These may be prefaced, if
+          desired, by a <gi>summary</gi> element, which is especially useful
+          where one wishes to provide an overview of a manuscript's contents and
+          describe only some of the items in detail.
+          <specList>
+            <specDesc key="msContents"/>
+            <specDesc key="msItem"/>
+          </specList>
+          </p>
+          <p>In the simplest case, only a brief description may be provided, as
+          in the following examples:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <msContents>
+              <p>A collection of Lollard sermons</p>
+            </msContents>
+            <msContents>
+              <p>Atlas of the world from Western Europe and Africa to Indochina, 
+              containing 27 maps and 26 tables</p>
+            </msContents>
+            <msContents>
+              <p>Biblia sacra: Antiguo y Nuevo Testamento, con prefacios, prólogos 
+              y argumentos de san Jerónimo y de otros. Interpretaciones de los 
+              nombres hebreos.</p>
+            </msContents>
+          </egXML>
+          </p>
+          <p>This description may of course be expanded to include any of the
+          TEI elements generally available within a <gi>p</gi> element, such as
+          <gi>title</gi>, <gi>bibl</gi>, or <gi>list</gi>. More usually,
+          however, each individual work within a manuscript will be given its
+          own description, using the <gi>msItem</gi>
+          element described in the next section, as in the following example:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <msContents>
+              <msItem n="1">
+                <locus>fols. 5r -7v</locus>
+                <title>An ABC</title> 
+                <bibl>
+                  <title>IMEV</title> 
+                  <biblScope unit="pages">239</biblScope>
+                </bibl>
+              </msItem>
+              <msItem n="2">
+                <locus>fols. 7v -8v</locus>
+                <title xml:lang="fr">Lenvoy de Chaucer a Scogan</title>
+                <bibl>
+                  <title>IMEV</title>
+                  <biblScope unit="pages">3747</biblScope>
+                </bibl>
+              </msItem>
+              <msItem n="3">
+                <locus>fol. 8v</locus>
+                <title>Truth</title> 
+                <bibl>
+                  <title>IMEV</title> 
+                  <biblScope unit="pages">809</biblScope>
+                </bibl>
+              </msItem>
+              <msItem n="4">
+                <locus>fols. 8v-10v</locus>
+                <title>Birds Praise of Love</title>
+                <bibl>
+                  <title>IMEV</title> 
+                  <biblScope unit="pages">1506</biblScope>
+                </bibl>
+              </msItem>
+              <msItem n="5">
+                <locus>fols. 10v -11v</locus>
+                <title xml:lang="la">De amico ad amicam</title>
+                <title xml:lang="la">Responcio</title> 
+                <bibl>
+                  <title>IMEV</title> 
+                  <biblScope unit="pages">16 &amp; 19</biblScope>
+                </bibl>
+              </msItem>
+              <msItem n="6">
+                <locus>fols. 14r-126v</locus>
+                <title>Troilus and Criseyde</title> 
+                <note>Bk. 1:71-Bk. 5:1701, with additional losses due to
+                mutilation throughout</note>
+              </msItem>
+            </msContents>
+          </egXML>
+          </p>
+          <div type="div3" xml:id="mscoit">
+            <head>The <gi>msItem</gi> 
+            <!--and <gi>msItemStruct</gi> -->Element<!--s--></head>
+            <!-- I'm for killing off msItemStruct, personally -->
+            <p>Each discrete item in a manuscript or manuscript part can be described within a distinct <gi>msItem</gi> 
+            <!--or <gi>msItemStruct</gi>--> element, and may be classified using the <att>class</att> attribute.</p>
+            <p>These are the possible component elements of <gi>msItem</gi> 
+            <!--and <gi>msItemStruct</gi>-->.
+            <specList>
+              <specDesc key="author"/>
+              <specDesc key="respStmt"/>
+              <specDesc key="title"/>
+              <specDesc key="rubric"/>
+              <specDesc key="incipit"/>
+              <specDesc key="quote"/>
+              <specDesc key="explicit"/>
+              <specDesc key="finalRubric"/>
+              <specDesc key="colophon"/>
+              <specDesc key="decoNote"/>
+              <specDesc key="listBibl"/>
+              <specDesc key="bibl"/>
+              <specDesc key="filiation"/>
+              <specDesc key="note"/>
+              <specDesc key="textLang"/>
+            </specList>
+            </p>
+            <p>If early printed material or incunables are described using this
+            schema, the <gi>msItem</gi> should be used to record details of each
+            distinct work contained by the incunable. In this situation, the
+            following extra elements may be found useful to transcribe relevant
+            details from the original titlepage:
+            <specList>
+              <specDesc key="docAuthor"/>
+              <specDesc key="docTitle"/>
+              <specDesc key="docImprint"/>
+            </specList>
+            These elements are also available within the <gi>msItem</gi> element.
+            </p>
+
+
+            <p>In addition,<!-- a <gi>msItemStruct</gi> may contain nested
+            <gi>msItemStruct</gi> elements, just as--> an <gi>msItem</gi> may contain
+            nested <gi>msItem</gi> elements.</p>
+            <!--<p>The main difference between <gi>msItem</gi> and <gi>msItemStruct</gi> is
+                that in the former, the order and number of child elements is not
+                constrained; any element, in other words, may be given in any order,
+                and repeated as often as is judged necessary. In the latter, however, the
+                sub-elements, if used, must be given in the order specified above and
+                only some of  them may be repeated; specifically,  <gi>rubric</gi>,
+                <gi>finalRubric</gi>.  <gi>incipit</gi>, <gi>textLang</gi> and
+                <gi>explicit</gi> can appear only once.</p>
+                <p>While  neither
+                <gi>msItem</gi> nor <gi>msItemStruct</gi> -->
+            <p>Untagged running
+            text is not permitted directly within an <gi>msItem</gi>, unless it is
+            given within a <gi>p</gi> element, in which case 
+            none of the other component elements listed above is permitted.
+            </p>
+            <p>The elements <gi>msContents</gi>, <gi>msItem</gi>,
+            <!--<gi>msItemStruct</gi>, --><gi>incipit</gi>, and <gi>explicit</gi> are all
+            members of the class <ident type="class">att.msExcerpt</ident> from
+            which they inherit the <att>defective</att> attribute.
+            <specList>
+              <specDesc key="att.msExcerpt" atts="defective"/>
+            </specList>
+            This attribute can be used for example with collections
+            of fragments, where each fragment is given as a separate
+            <gi>msItem</gi> and the first and last words of each fragment are transcribed as
+            defective incipits and explicits <!--, as in the following example, a
+            manuscript containing four fragments of a single work:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <msContents>
+            <msItem defective="true"><locus from="1r" to="9v">1r-9v</locus>
+            <title>Knýtlinga saga</title>
+            <msItem n="1.1"><locus from="1r:1" to="2v:30">1r:1-2v:30</locus>
+            <incipit defective="true">dan<ex>n</ex>a a 
+            engl<ex>an</ex>di</incipit>
+            <explicit defective="true">en meðan <expan>haraldr</expan> 
+            hein hafði k<ex>onung</ex>r v<am><g ref="http://www.examples.com/abbrevs.xml#er"/></am>it 
+            yf<ex>ir</ex> danmork</explicit>
+            </msItem>
+            </msItem>
+            </msContents>
+            </egXML></p>
+            <p>The elements <gi>ex</gi>, <gi>am</gi>, and
+            <gi>expan</gi> used in the above example are further discussed in
+            section <ptr target="#PHAB"/>; they are available  only when the <ident type="module">transcr</ident> module defined by that chapter is
+            selected. Similarly, the <gi>g</gi> element used in this example to
+            represent the abbreviation mark is defined by the <ident type="module">gaiji</ident> module documented in chapter <ptr target="#WD"/>-->. </p>
+          </div>
+          <div type="div3" xml:id="msat">
+            <head>Authors and Titles</head>
+            <p>When used within a manuscript description, the <gi>title</gi> element should be used to supply a regularized
+            form of the item's title, as distinct from any rubric quoted from the
+            manuscript. If the item concerned has a standardized distinctive
+            title, e.g. <mentioned>Roman de la Rose</mentioned>, then this should
+            be the form given as content of the <gi>title</gi> element, with the
+            value of the <att>type</att> attribute given as
+            <code>uniform</code>. If no uniform title exists for an item, or none
+            has been yet identified, or if one wishes to provide a general
+            designation of the contents, then a <soCalled>supplied</soCalled>
+            title can be given, e.g. <mentioned>missal</mentioned>, in which case
+            the <att>type</att> attribute on the <gi>title</gi> should be given
+            the value <code>supplied</code>.</p>
+
+            <p>Similarly, if used within a manuscript description, the
+            <gi>author</gi> element should always contain the normalized form of
+            an author's name, irrespective of how (or whether) this form of the
+            name is cited in the manuscript. If it is desired to retain the form
+            of the author's name as given in the manuscript, this should be given
+            in the <gi>docAuthor</gi> element, or  as
+            a distinct <gi>name</gi> element, within the text at the point where
+            it occurs. </p>
+            <!-- an example would be nice here -->
+            <p>Note that the <att>key</att> or <att>ref</att> attributes can be
+            used, on titles and on author names as on names in general, to link
+            the name to a more detailed description of the person or work
+            concerned (see further <ptr target="#msnames"/>).</p>
+            <p>The <gi>respStmt</gi> element can be used to supply the name and role of a person other than the author who is responsible for some aspect of the intellectual content of the manuscript:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <author>Diogenes Laertius</author>
+              <respStmt>
+                <resp>in the translation of</resp>
+                <name type="person">Ambrogio Traversari</name>
+              </respStmt>
+            </egXML>
+            </p>
+            <p>The <gi>resp</gi> element is also a member of the
+            <ident>att.canonical</ident> class, from which it inherits the
+            <att>key</att> attribute. For ENRICH purposes, this may be used to
+            supply a standard relationship code for the kind of
+            responsibility concerned, as defined in the
+            list maintained at <ptr target="http://www.loc.gov/marc/relators/relacode.html"/>:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <respStmt>
+                <resp key="trl">přeložil</resp>
+                <name type="person">John Enrich</name>
+              </respStmt>
+            </egXML>
+            </p>
+            <p>The <gi>respStmt</gi> element can also be used where there is a discrepancy between the author of an item as given in the manuscript and the accepted scholarly view, as in the following example:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <title type="supplied">Sermons on the Epistles and the Gospels</title>
+              <respStmt>
+                <resp>here erroneously attributed to</resp>
+                <name type="person">St. Bonaventura</name>
+              </respStmt>
+            </egXML>
+            Note that such attributions of authorship, both correct and incorrect, are frequently found in the rubric or final rubric (and occasionally also elsewhere in the text), and can therefore be transcribed and included in the description, if desired, using the <gi>rubric</gi>, <gi>finalRubric</gi>, or <gi>quote</gi> elements, as appropriate.
+            </p>
+          </div>
+          <div type="div3" xml:id="mscorie">
+            <head>Rubrics, Incipits, Explicits, and Other Quotations from the Text</head>
+            <p>It is customary in a manuscript description to record the opening
+            and closing words of a text as well as any headings or colophons it
+            might have, and the specialised elements <gi>rubric</gi>,
+            <gi>incipit</gi>, <gi>explicit</gi>, <gi>finalRubric</gi>, and
+            <gi>colophon</gi> are available within <gi>msItem</gi> for doing so,
+            along with the more general <gi>quote</gi>, for recording other bits of
+            the text not covered by these elements. Each of these elements has the
+            same substructure, containing a mixture of phrase-level elements and
+            plain text. A <gi>locus</gi> element can be included within each, in
+            order to specify the location of the component, as in the following
+            example:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <msContents>
+                <msItem>
+                  <locus>f. 1-223</locus>
+                  <author>Radulphus Flaviacensis</author>
+                  <title>Expositio super Leviticum </title>
+                  <incipit>
+                    <locus>f. 1r</locus>
+                  Forte Hervei monachi</incipit>
+                  <explicit>
+                    <locus>f. 223v</locus>
+                  Benedictio salis et aquae</explicit>
+                </msItem>
+              </msContents>
+            </egXML>
+            </p>
+            <p>In the following example, standard TEI elements for the transcription of primary
+            sources have been used to mark
+            the expansion of abbreviations and other features present in the original:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <msItem defective="true">
+                <locus>ff. 1r-24v</locus>
+                <title type="uniform">Ágrip af Noregs konunga sǫgum</title>
+                <incipit defective="true">regi oc h<ex>ann</ex> seti 
+                ho<gap reason="illegible" quantity="7" unit="mm"/>
+                <lb/>sc heim se<ex>m</ex> þio</incipit>
+                <explicit defective="true">h<ex>on</ex> hev<ex>er</ex>
+                <ex>oc</ex> þa buit hesta .ij. <lb/>annan viþ fé en
+                h<ex>on</ex>o<ex>m</ex> annan til reiþ<ex>ar</ex>
+                </explicit>
+              </msItem>
+            </egXML>
+            Note here also the use of the <att>defective</att> attribute on <gi>incipit</gi> and <gi>explicit</gi> to indicate that the text begins and ends defectively.
+            </p>
+            <p>The <att>xml:lang</att> attribute for <gi>colophon</gi>, <gi>explicit</gi>, <gi>incipit</gi>, <gi>quote</gi>, and <gi>rubric</gi> may always be used to identify the language of the text quoted, if this is different from the default language specified by the <att>mainLang</att> attribute on <gi>textLang</gi>.</p>
+          </div>
+          <div type="div3" xml:id="msfil">
+            <head>Filiation</head>
+            <p>The <gi>filiation</gi> element can be used to provide information on the relationship between the manuscript and other surviving manuscripts of the same text, either specifically or in a general way, as in the following example:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <msItem>
+                <locus>118rb</locus>
+                <incipit>Ecce morior cum nichil horum ... <ref>[Dn 13, 43]</ref>. Verba ista dixit Susanna de illis</incipit>
+                <explicit>ut bonum comune conservatur.</explicit>
+                <bibl>Schneyer 3, 436 (Johannes Contractus OFM)</bibl>
+                <filiation>weitere Überl. Uppsala C 181, 35r.</filiation>
+              </msItem>
+            </egXML>
+            </p>
+          </div>
+          <div type="div3" xml:id="msclass">
+            <head>Text Classification</head>
+            <p>One or more text classification or text-type codes may be
+            specified, either for the whole of the <gi>msContents</gi> element, or
+            for one or more of its constituent <gi>msItem</gi> elements, using the
+            <att>class</att> attribute as specified above:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <msContents>
+                <msItem n="1" defective="false" class="#law">
+                  <locus from="1v" to="71v">1v-71v</locus>
+                  <title type="uniform">Jónsbók</title>
+                  <incipit>Magnus m<ex>ed</ex> guds miskun Noregs 
+                  k<ex>onungu</ex>r</incipit>
+                  <explicit>en<ex>n</ex> u<ex>ir</ex>da 
+                  þo t<ex>il</ex> fullra aura</explicit>
+                </msItem>
+              </msContents>
+            </egXML>
+            The value of the <att>class</att> attribute
+            should specify the identifier used for the appropriate classification
+            within a <gi>taxonomy</gi> element, defined in the <gi>classDecl</gi>
+            element of the TEI Header (<ptr target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/HD.html#HD55"/>), as
+            shown here:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <classDecl>
+                <taxonomy>
+                  <!-- -->
+                  <category xml:id="law">
+                    <catDesc>Laws</catDesc>
+                  </category>
+                  <!-- -->
+                </taxonomy>
+              </classDecl>
+            </egXML>
+            </p>
+            <p>
+              <note rend="query">Should  ENRICH
+              define its own taxonomy for this purpose, or re-use an
+              existing one?</note>
+            </p>
+          </div>
+          <div type="div3" xml:id="mslangs">
+            <head>Languages and Writing Systems</head>
+            <p>The <gi>textLang</gi> element should be used to provide
+            information about the languages used within a manuscript item. It may take
+            the form of a simple note, as in the following example:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <textLang mainLang="chu">Old Church Slavonic, written in Cyrillic script.</textLang>
+            </egXML>
+            </p>
+
+            <specGrp xml:id="spec2">
+              <elementSpec ident="textLang" mode="change" module="msdescription">
+                <attList>
+                  <attDef ident="mainLang" mode="change" usage="req"/>
+                </attList>
+              </elementSpec>
+            </specGrp>
+
+            <p>For validation and indexing purposes, the <att>mainLang</att>
+            attribute muse be supplied:  it takes
+            the same range of values as the global <att>xml:lang</att> attribute,
+            on which see further <ptr target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/CH.html#CHSH"/>. 
+            When a manuscript item  contains material in more than one language, the
+            <att>mainLang</att> attribute should be used only for the chief language. 
+            Other languages used may be specified using the <att>otherLangs</att>
+            attribute as in the following example:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <textLang mainLang="chu" otherLangs="RUS HEL">Mostly Old Church 
+              Slavonic, with some Russian and Greek material</textLang>
+            </egXML>
+            </p>
+            <p>Since Old Church Slavonic may be written in either
+            Cyrillic or Glagolitic scripts, and even occasionally in both within the
+            same manuscript, it might be preferable to use a more explicit
+            identifier:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <textLang mainLang="chu-Cyrs">Old Church Slavonic in Cyrillic script</textLang>
+            </egXML>
+            </p>
+            <p>The form and scope of language identifiers recommended by these
+            Guidelines is based on the IANA standard described at <ptr target="http://www.tei-c.org/release/doc/tei-p5-doc/html/CH.html#CHSH"/> and
+            should be followed throughout. Where additional detail is needed
+            correctly to describe a language, or to discuss its deployment in a
+            given text, this should be done using the <gi>langUsage</gi> element
+            in the TEI Header, within which individual <gi>language</gi> elements
+            document the languages used: see <ptr target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/HD.html#HD41"/>.  </p>
+            <p>Note that the <gi>language</gi> element defines a particular
+            combination of human language and writing system. Only one
+            <gi>language</gi> element may be supplied for each such
+            combination. Standard TEI practice also allows this element to be
+            referenced by any element using the global <att>xml:lang</att>
+            attribute in order to specify the language applicable to the content
+            of that element. For example, assuming that <gi>language</gi>
+            elements have been defined with the identifiers <ident>fr</ident> (for
+            French), <ident>la</ident> (for Latin), and <ident>de</ident> (for
+            German), a manuscript description written in French which specifies
+            that a particular manuscript contains predominantly German but also
+            some Latin material, might
+            have a <gi>textLang</gi> element like the following:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <textLang xml:lang="fr" mainLang="de" otherLangs="la">allemand et latin</textLang>
+            </egXML>
+            </p>
+          </div>
+        </div>
+        <div type="div2" xml:id="msph">
+          <head>Physical Description</head>
+          <p>Under the general heading <soCalled>physical description</soCalled>
+          we subsume a large number of different aspects generally regarded as
+          useful in the description of a given manuscript. These include:
+          <list>
+            <item>aspects
+            of the form, support, extent, and quire structure of the manuscript
+            object and of the way in which the text is laid out on the page (<ptr target="#msph1"/>);</item>
+            <item>the styles of writing, such as the way it is laid out on the
+            page, the styles of writing, decorative features, any musical notation
+            employed and any annotations or marginalia (<ptr target="#msph2"/>);</item>
+            <item> and discussion of its binding, seals, and any
+            accompanying material (<ptr target="#msph3"/>).</item>
+          </list>
+          </p>
+          <p>Most manuscript descriptions touch on several of these categories
+          of information though few include them all, and not all distinguish
+          them as clearly as we propose here. In particular, it is often the
+          case that an existing description will include within a single
+          paragraph, or even
+          sentence, information for which
+          we propose distinct elements. In this case, if rewriting is not an option, the
+          existing prose must be marked up simply as a series of <gi>p</gi> elements,
+          directly within the <gi>physDesc</gi> element.</p>
+          <p>The <gi>physDesc</gi> element may thus be used in either of two
+          distinct ways. It may contain a series of paragraphs addressing topics
+          listed above and similar ones. Alternatively, it may act as a container for any
+          choice of the more specialized elements described in the remainder of
+          this section, each of which itself contains a series of paragraphs,
+          and may also have more specific attributes. If the two ways
+          are  combined in a single description, care should be taken to avoid
+          duplication and all paragraphs of generic description must precede the first
+          of the more specialised elements.</p>
+          <div type="div3" xml:id="msph1">
+            <head>Object Description</head>
+            <p>The <gi>objectDesc</gi> element is used to group together those
+            parts of the physical description which relate specifically to the
+            text-bearing object, its format, constitution, layout, etc. The
+            <att>form</att> attribute is used to indicate the specific type of
+            writing vehicle being described: it must be supplied, and its
+            value must be one of <val>codex</val>, <val>scroll</val>,
+            <val>leaf</val>, or <val>other</val>. If no value is
+            supplied, the value <val>codex</val> will be assumed.
+
+            <specGrp xml:id="spec3">
+              <elementSpec ident="objectDesc" mode="change" module="msdescription">
+                <attList>
+                  <attDef ident="form" mode="change" usage="req">
+                    <valList type="closed" mode="replace">
+                      <valItem ident="codex">
+                        <desc xml:lang="en" versionDate="2014-01-12">a bound codex</desc>
+                      </valItem>
+                      <valItem ident="leaf">
+                        <desc xml:lang="en" versionDate="2014-01-12">a loose leaf</desc>
+                      </valItem>
+                      <valItem ident="scroll">
+                        <desc xml:lang="en" versionDate="2014-01-12">a scroll</desc>
+                      </valItem>
+                      <valItem ident="other">
+                        <desc xml:lang="en" versionDate="2014-01-12">any other format</desc>
+                      </valItem>
+                    </valList>
+
+                  </attDef>
+                </attList>
+              </elementSpec>
+            </specGrp>
+
+            The <gi>objectDesc</gi> element has two parts: a description of the
+            <term>support</term>, i.e. the physical carrier on which the text is
+            inscribed; and a description of the <term>layout</term>, i.e. the way
+            text is organized on the carrier.</p>
+            <p>Taking these in turn, the description of the support is tagged
+            using the following elements, each of which is discussed in more
+            detail below:
+            <specList>
+              <specDesc key="supportDesc" atts="material"/>
+              <specDesc key="support"/>
+              <specDesc key="extent"/>
+              <specDesc key="collation"/>
+              <specDesc key="foliation"/>
+              <specDesc key="condition"/>
+            </specList>
+            </p>
+            <p>Each of these elements contains paragraphs relating to the topic
+            concerned. Within these paragraphs, phrase-level elements (in
+            particular those discussed above at <ptr target="#msphrase"/>),
+            may be used to tag specific terms of interest if so
+            desired.</p>
+            <p>The <att>form</att> attribute on <gi>supportDesc</gi> is used to
+            summarize briefly the materials used for the support. For ENRICH
+            purposes, it must have one of the following values:
+            <val>perg</val> (parchment), 
+            <val>chart</val> (paper), 
+            <val>mixed</val>, <val>unknown</val>.
+
+            <specGrp xml:id="spec4">
+              <elementSpec ident="supportDesc" mode="change" module="msdescription">
+                <attList>
+                  <attDef ident="material" mode="change" usage="req">
+                    <valList type="closed" mode="replace">
+                      <valItem ident="perg">
+                        <desc xml:lang="en" versionDate="2014-01-12">parchment</desc>
+                      </valItem>
+                      <valItem ident="chart">
+                        <desc xml:lang="en" versionDate="2014-01-12">paper</desc>
+                      </valItem>
+                      <valItem ident="mixed">
+                        <desc xml:lang="en" versionDate="2014-01-12">mixture of paper and parchment, or other materials</desc>
+                      </valItem>  
+                      <valItem ident="unknown"/> 
+                    </valList>
+                  </attDef>
+                </attList>
+              </elementSpec>
+            </specGrp>
+            </p>
+            <p>Here is a simple example:
+
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <objectDesc form="codex">
+                <supportDesc material="mixed">
+                  <p>Mostly <material>paper</material>, with watermarks 
+                  <watermark>unicorn</watermark> (<ref>Briquet 9993</ref>) and 
+                  <watermark>ox</watermark> (close to <ref>Briquet 2785</ref>). 
+                  The first and last leaf of each quire, with the exception of 
+                  quires xvi and xviii, are constituted by bifolia of parchment, 
+                  and all seven miniatures have been painted on inserted 
+                  singletons of parchment.</p>
+                </supportDesc>
+              </objectDesc>
+            </egXML>
+            </p>
+
+            <p>This example combines information which might alternatively be more
+            precisely tagged using the more specific elements described in the
+            following subsections.</p>
+            <div type="div4" xml:id="msph1sup">
+              <head>Support</head>
+              <p>The <gi>support</gi> element groups together information about the
+              physical carrier. Typically, for western manuscripts, this will entail
+              discussion of the material (parchment, paper, or a combination of the
+              two) written on. For paper, a discussion of any watermarks present may
+              also be useful.  If this discussion makes reference to standard
+              catalogues of such items, these may be tagged using the standard
+              <gi>ref</gi> element as in the following example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <support>
+                  <p>
+                    <material>Paper</material> with watermark: <watermark>anchor in a circle 
+                    with star on top</watermark>, <watermark>countermark B-B with 
+                    trefoil</watermark> similar to <ref>Moschin, Anchor N 1680</ref>
+                  <date>1570-1585</date>.</p>
+                </support>
+              </egXML>
+              </p>
+            </div>
+            <div type="div4" xml:id="msph1ext">
+              <head>Extent</head>
+              <p>The <gi>extent</gi> element, defined in the TEI header, may also be
+              used in a manuscript description to specify the number of
+              leaves a manuscript contains, as in the following example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <extent>ii + 97 + ii</extent>
+              </egXML>
+              Information regarding the size of the leaves may be
+              specifically marked using the phrase level <gi>dimensions</gi>
+              element, as in the following example, or left as plain prose.
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <extent>ii + 321 leaves 
+                <dimensions type="leaf" unit="cm">
+                  <height>35</height>
+                  <width>27</width>
+                </dimensions>
+                </extent>
+              </egXML>
+              </p>
+              <!--
+                  <p>Alternatively, the generic <gi>measure</gi> element might be used within <gi>extent</gi>, as in the following example:
+                  <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                  <extent>
+                  <measure type="composition" unit="leaf" quantity="10">10 Bl.</measure>
+                  <measure type="height" quantity="37" unit="cm">37</measure> x
+                  <measure type="width" quantity="29" unit="cm">29</measure> cm
+                  </extent>
+                  </egXML></p>
+              -->
+            </div>
+            <div type="div4" xml:id="msph1col">
+              <head>Collation</head>
+              <p>The <gi>collation</gi> element should be used to provide a
+              description of a book's current and original structure, that is, the
+              arrangement of its leaves and quires. This information may be conveyed
+              using informal prose, or any appropriate notational
+              convention. Although no specific notation is defined here, an
+              appropriate element to enclose such an expression would be the <gi>formula</gi>
+              element, which is provided when the <ident type="module">figures</ident> module is included in a schema. Here are some examples of different ways of treating collation:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <collation>
+                  <p>
+                    <formula>1-3:8, 4:6, 5-13:8</formula>
+                  </p>
+                </collation>
+                <collation>
+                  <p>There are now four gatherings, the first, second and fourth originally consisting of 
+                  eight leaves, the third of seven. A fifth gathering thought to have followed has left no trace.
+                  <list>
+                    <item>Gathering I consists of 7 leaves, a first leaf, originally conjoint with <locus>fol. 7</locus>, 
+                    having been cut away leaving only a narrow strip along the gutter; the others, <locus>fols 1</locus> 
+                    and <locus>6</locus>, <locus>2</locus> and <locus>5</locus>, and <locus>3</locus> and <locus>4</locus>, 
+                    are bifolia.</item>
+                    <item>Gathering II consists of 8 leaves, 4 bifolia.</item>
+                    <item>Gathering III consists of 7 leaves; <locus>fols 16</locus> and <locus>22</locus> are conjoint, 
+                    the others singletons.</item>
+                    <item>Gathering IV consists of 2 leaves, a bifolium.</item>
+                  </list>
+                  </p>
+                </collation>
+                <collation>
+                  <p>I (1, 2+9, 3+8, 4+7, 5+6, 10); II (11, 12+17, 13, 14, 15, 16, 18, 19).</p>
+                </collation>
+                <collation>
+                  <p>
+                    <formula>1-5.8 6.6 (catchword, f. 46, does not match following 
+                    text) 7-8.8 9.10, 11.2 (through f. 82) 12-14.8 15.8(-7)</formula>
+                  </p>
+                </collation>
+              </egXML>
+              </p>
+            </div>
+            <div type="div4" xml:id="msphfo">
+              <head>Foliation</head>
+              <p>The <gi>foliation</gi> element may be used to indicate the scheme,
+              medium or location of folio, page, column, or line numbers written in
+              the manuscript, frequently including a statement about when and, if
+              known, by whom, the numbering was done.
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <foliation>
+                  <p>Neuere Foliierung, die auch das Vorsatzblatt mitgezählt hat.</p>
+                </foliation>
+                <foliation>
+                  <p>Folio numbers were added in brown ink by Árni Magnússon 
+                  ca. 1720-1730 in the upper right corner of all recto-pages.</p>
+                </foliation>
+              </egXML>
+              </p>
+              <p>Where a manuscript contains traces of more than
+              one foliation, each should be recorded as a distinct
+              <gi>foliation</gi> element and optionally given a distinct value for
+              its <att>xml:id</att> attribute. The <gi>locus</gi> element discussed in
+              <ptr target="#msloc"/> can then indicate which foliation scheme is being cited
+              by means of its <att>scheme</att> attribute, which points to this
+              identifier:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <foliation xml:id="original">
+                  <p>Original foliation in red roman numerals in the middle of 
+                  the outer margin of each recto</p>
+                </foliation>
+                <foliation xml:id="modern">
+                  <p>Foliated in pencil in the top right
+                  corner of each recto page.</p>
+                </foliation>
+                <!-- ... -->
+                <locus scheme="#modern">ff 1-20</locus>
+              </egXML>
+              </p>
+            </div>
+            <div type="div4" xml:id="msphco">
+              <head>Condition</head>
+              <p>The <gi>condition</gi> element is used to summarize the overall
+              physical state of a manuscript, in particular where such information
+              is not recorded elsewhere in the description. It should not, however, be
+              used to describe changes or repairs to a manuscript, as these are more
+              appropriately described as a part of its custodial history (see <ptr target="#msadch"/>). When used solely to describe the condition of
+              the binding, it should appear within the <gi>bindingDesc</gi> element
+              (<ptr target="#msphbi"/>).
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <condition>
+                  <p>The manuscript shows signs of damage from water and mould on its outermost leaves.</p>
+                </condition>
+                <condition>
+                  <p>Despite tears on many of the leaves the codex is reasonably well preserved. 
+                  The top and the bottom of f. 1 is damaged, and only a thin slip is left of the original second 
+                  leaf (now foliated as 1bis). The lower margin of f. 92 has been cut away. There is a lacuna of 
+                  one leaf between ff. 193 and 194. The manuscript ends defectively (there are approximately six 
+                  leaves missing).</p>
+                </condition>
+              </egXML>
+              </p>
+            </div>
+            <div type="div4" xml:id="msphla">
+              <head>Layout Description</head>
+
+              <p>The second part of the <gi>objectDesc</gi> element is the
+              <gi>layoutDesc</gi> element, which is used to describe and document
+              the <foreign>mise-en-page</foreign> of the manuscript, that is the way
+              in which text and illumination are arranged on the page, specifying
+              for example the number of written, ruled, or pricked lines and columns
+              per page, size of margins, distinct blocks such as glosses,
+              commentaries, etc. This may be given as a simple series of
+              paragraphs. Alternatively, one or more different layouts may be
+              identified within a single manuscript, each described by its own
+              <gi>layout</gi> element.
+              <specList>
+                <specDesc key="layoutDesc"/>
+                <specDesc key="layout"/>
+              </specList>
+              </p>
+              <p>Where the <gi>layout</gi> element is used, the layout will often be
+              sufficiently regular for the attributes on this element to convey all
+              that is necessary; more usually however a more detailed treatment will
+              be required. The attributes are provided as a convenient shorthand for
+              commonly occurring cases, and should not be used except where the
+              layout is regular. The value <code>NA</code> (not-applicable) should
+              be used for cases where the layout is either very irregular, or where
+              it cannot be characterized simply in terms of lines and columns, for
+              example, where blocks of commentary and text are arranged in a regular
+              but complex pattern on each page</p>
+              <p>The following examples indicate the range of possibilities:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <layout ruledLines="25 32" columns="1">
+                  <p>Most pages have between 25 and 32 long lines ruled in lead.</p>
+                </layout>
+                <layout columns="1" writtenLines="24">
+                  <p>Written in one column throughout; 24 lines per page.</p>
+                </layout>
+                <layout columns="1">
+                  <p>Written in a single column, with 8 lines of text and interlinear glosses in 
+                  the centre, and up to 26 lines of gloss in the outer two columns. Double 
+                  vertical bounding lines ruled in hard point on hair side. Text lines ruled 
+                  faintly in lead. Remains of prickings in upper, lower, and outer (for 8 lines 
+                  of text only) margins.</p>
+                </layout>
+              </egXML>
+              </p>
+              <p>Note that if (as in the last example above) no value is given for
+              the <att>columns</att> attribute, the assumption is that there is a
+              single column of writing on each page.
+              <specGrp xml:id="spec5">
+                <elementSpec ident="layout" mode="change" module="msdescription">
+                  <attList>
+                    <attDef ident="columns" mode="change" usage="req"/>
+                  </attList>
+                </elementSpec>
+              </specGrp>
+              </p>
+              <p>Where multiple <gi>layout</gi> elements are supplied, the scope for
+              each specification can be indicated by means of <gi>locus</gi>
+              elements within the content of the element, as in the following
+              example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <layoutDesc>
+                  <layout ruledLines="25 32" columns="1">
+                    <p>On <locus from="1r" to="202v">fols 1r-200v</locus> and 
+                    <locus from="210r" to="212v">fols 210r-212v</locus> there are
+                    between 25 and 32 ruled lines.</p>
+                  </layout>
+                  <layout ruledLines="34 50" columns="1">
+                    <p>On <locus from="203r" to="209v">fols 203r-209v</locus> there are between 34 
+                    and 50 ruled lines.</p>
+                  </layout>
+                </layoutDesc>
+              </egXML>
+              </p>
+            </div>
+          </div>
+          <div type="div3" xml:id="msph2">
+            <head>Writing, Decoration, and Other Notations</head>
+
+            <p>The second group of elements within a structured physical
+            description concerns aspects of the writing, illumination, or other
+            notation (notably, music) found in a manuscript, including additions
+            made in later hands — the <soCalled>text</soCalled>, as it were, as
+            opposed to the carrier.
+            <specList>
+              <specDesc key="handDesc" atts="hands"/>
+              <specDesc key="handNote" atts="script scope"/>
+              <specDesc key="typeDesc"/>
+              <specDesc key="typeNote"/>
+
+              <specDesc key="decoDesc"/>
+              <specDesc key="decoNote"/>
+              <specDesc key="musicNotation"/>
+              <specDesc key="additions"/>
+            </specList>
+            </p>
+            <div type="div4" xml:id="msphwr">
+              <head>Writing</head>
+
+              <p>The <gi>handDesc</gi> element can contain a short description of
+              the general characteristics of the writing observed in a manuscript,
+              as in the following example:
+
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <handDesc>
+                  <p>Written in a <term>late Caroline minuscule</term>; versals in a 
+                  form of <term>rustic capitals</term>; although the marginal and 
+                  interlinear gloss is written in varying shades of ink that are 
+                  not those of the main text, text and gloss appear to have been 
+                  copied during approximately the same time span.</p>
+                </handDesc>
+              </egXML>
+              </p>
+              <p>Note the use of the <gi>term</gi> element to mark specific technical
+              terms within the context of the <gi>handDesc</gi> element.</p>
+              <p>Where several distinct hands have been identified, this fact can be registered by using the <att>hands</att> attribute, as in
+              the following example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <handDesc hands="2">
+                  <p>The manuscript is written in two contemporary hands, otherwise
+                  unknown, but clearly those of practised scribes. Hand I writes
+                  ff. 1r-22v and hand II ff. 23 and 24. Some scholars, notably
+                  Verner Dahlerup and Hreinn Benediktsson, have argued for a third hand
+                  on f. 24, but the evidence for this is insubstantial.</p>
+                </handDesc>
+              </egXML>
+              </p>
+              <p>Where more specific
+              information about one or more of the hands identified is to be recorded,
+              the <gi>handNote</gi> element should
+              be used, as in the following example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <handDesc hands="3">
+                  <handNote xml:id="Eirsp-1" scope="minor" script="textualis">
+                    <p>The first part of the manuscript, 
+                    <locus from="1v" to="72v:4">fols 1v-72v:4</locus>, is written in a practised 
+                    Icelandic Gothic bookhand. This hand is not found elsewhere.</p>
+                  </handNote>
+                  <handNote xml:id="Eirsp-2" scope="major" script="textualis">
+                    <p>The second part of the manuscript, <locus from="72v:4" to="194v">fols 
+                    72v:4-194</locus>, is written in a hand contemporary with the first; it can 
+                    also be found in a fragment of <title>Knýtlinga saga</title>, 
+                    <ref>AM 20b II fol.</ref>.</p>
+                  </handNote>
+                  <handNote xml:id="Eirsp-3" scope="minor" script="cursiva">
+                    <p>The third hand has written the majority of the chapter headings. 
+                    This hand has been identified as the one also found in <ref>AM 
+                    221 fol.</ref>.</p>
+                  </handNote>
+                </handDesc>
+              </egXML>
+              </p>
+              <p>As the above example shows, the attributes <att>script</att> and
+              <att>scope</att> are both required on <gi>handNote</gi>. For ENRICH
+              purposes, the <att>script</att> attribute must take one of the following values:
+              <val>carolmin</val>, 
+              <val>textualis</val>, 
+              <val>cursiva</val>, 
+              <val>hybrida</val>, 
+              <val>humbook</val>, 
+              <val>humcursiva</val>, or <val>other</val>, and the <att>scope</att>
+              attribute must take one of the following values:
+              <val>sole</val>, 
+              <val>major</val>, 
+              <val>minor</val>.</p>
+
+              <p>If early printed material or incunables are described using this
+              schema, the <gi>typeDesc</gi> and <gi>typeNote</gi> elements may be
+              used (in the same way as <gi>handDesc</gi> and <gi>handNote</gi>) to
+              record information about the typefaces etc. of interest in the source.
+              <!-- example needed --> 
+              Both <gi>typeDesc</gi> and <gi>handDesc</gi> may be supplied, for
+              example in the case where a printed work has been annotated by a
+              number of hands. </p>
+
+              <p>The <gi>locus</gi> element, discussed in
+              section <ptr target="#msloc"/>, may be used to specify which parts of a
+              manuscript are written by a given hand.</p>
+
+              <p>In addition, when a full or partial transcription of a manuscript
+              is available in addition to the manuscript description, the
+              <gi>handShift</gi> element described in <ptr target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/PH.html#PHDH"/>
+              can be used to link the relevant parts of the transcription to the
+              appropriate <gi>handNote</gi> or <gi>typeNote</gi> element in the
+              description: for example, at the point in the transcript where the
+              second hand listed above starts (i.e. at folio 72v:4), we might insert
+              <code>&lt;handShift new="#Eirsp-2"/&gt;</code>.</p>
+              <p>No <gi>typeShift</gi> element is proposed; if it is felt
+              inappropriate to use <gi>handShift</gi> for this purpose, the generic
+              <gi>mileStone</gi> may be used.
+              <!-- example needed --></p>
+            </div>
+            <div type="div4" xml:id="msphdec">
+              <head>Decoration</head>
+              <p>It can be difficult to draw a clear distinction between aspects of
+              a manuscript which are purely physical and those which form part of
+              its intellectual content. This is particularly true of illuminations
+              and other forms of decoration in a manuscript. We propose the
+              following elements for the purpose of delimiting discussion of these
+              aspects within a manuscript description, and for convenience locate
+              them all within the physical description, despite the fact that the
+              illustrative features of a manuscript will in many cases also be seen
+              as constitutiing part of its intellectual content.</p>
+              <p>The <gi>decoDesc</gi> element may contain simply one or more
+              paragraphs summarizing the overall nature of the decorative features
+              of the manuscript, as in the following example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <decoDesc>
+                  <p>The decoration comprises two full page miniatures, perhaps added 
+                  by the original owner, or slightly later; the original major decoration
+                  consists of twenty-three large miniatures, illustrating the divisions of 
+                  the Passion narrative and the start of the major texts, and the major 
+                  divisions of the Hours; seventeen smaller miniatures, illustrating the 
+                  suffrages to saints; and seven historiated initials, illustrating
+                  the pericopes and major prayers.</p>
+                </decoDesc>
+              </egXML>
+              Alternatively, it may contain a series of more specific typed
+              <gi>decoNote</gi> elements, each summarizing a particular aspect or
+              individual instance of the decoration present, for example the use of
+              miniatures, initials (historiated or otherwise), borders, diagrams,
+              etc. The scope of the description is indicated by the <att>type</att>
+              attribute which, for ENRICH purposes, must take one of the following
+              values:
+              <val>border</val>, 
+              <val>diagram</val>, 
+              <val>initial</val>, 
+              <val>marginal</val>, 
+              <val>miniature</val>, 
+              <val>mixed</val>, 
+              <val>paratext</val>, 
+              <val>secondary</val>, 
+              <val>other</val>.
+
+              <specGrp xml:id="spec7">
+                <elementSpec ident="decoNote" mode="change" module="msdescription">
+                  <attList>
+                    <attDef ident="type" mode="change">
+                      <defaultVal>other</defaultVal>
+                      <valList type="closed" mode="replace">
+                        <valItem ident="border"/>
+                        <valItem ident="diagram"/>
+                        <valItem ident="initial"/>
+                        <valItem ident="marginal"/>
+                        <valItem ident="miniature"/>
+                        <valItem ident="mixed"/>
+                        <valItem ident="paratext"/>
+                        <valItem ident="secondary"/>
+                        <valItem ident="other"/>
+                      </valList>
+                    </attDef>
+                  </attList>
+                </elementSpec>
+              </specGrp>
+              </p>
+              <p>Here is a simple example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <decoDesc>
+                  <decoNote type="miniature">
+                    <p>One full-page miniature, facing the beginning of the first 
+                    Penitential Psalm.</p>
+                  </decoNote> 
+                  <decoNote type="initial">
+                    <p>One seven-line historiated initial, commencing the first 
+                    Penitential Psalm.</p>
+                  </decoNote>
+                  <decoNote type="initial">
+                    <p>Six four-line decorated initials, commencing the second through the 
+                    seventh Penitential Psalm.</p>
+                  </decoNote>
+                  <decoNote type="initial">
+                    <p>Some three hundred two-line versal initials with pen-flourishes, 
+                    commencing the psalm verses.</p>
+                  </decoNote>
+                  <decoNote type="border">
+                    <p>Four-sided border decoration surrounding the miniatures and three-sided 
+                    border decoration accompanying the historiated and decorated initials.</p>
+                  </decoNote>
+                </decoDesc>
+              </egXML>
+              </p>
+              <p>Where more exact indexing of the decorative content of a manuscript
+              is required, the standard TEI elements <gi>term</gi> or <gi>index</gi>
+              may be used within the prose description to supply or delimit
+              appropriate iconographic terms, as in the following example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <decoDesc>
+                  <decoNote type="miniature">
+                    <p>Fourteen large miniatures with arched tops, above five lines of text:
+                    <list>
+                      <item>
+                        <locus>fol. 14r</locus>Pericopes. <term>St. John writing on
+                        Patmos</term>, with the Eagle holding his ink-pot and pen-case; some 
+                      flaking of pigment, especially in the sky</item>
+                      <item>
+                        <locus>fol. 26r</locus>Hours of the Virgin, Matins.
+                      <term>Annunciation</term>; Gabriel and the Dove to the right</item>
+                      <item>
+                        <locus>fol. 60r</locus>Prime. <term>Nativity</term>; the
+                        <term>Virgin and Joseph adoring the Child</term>
+                      </item>
+                      <item>
+                        <locus>fol. 66r</locus>Terce. <term>Annunciation to the
+                        Shepherds</term>, one with <term>bagpipes</term>
+                      </item>
+                      <!-- ... -->
+                    </list>
+                    </p>
+                  </decoNote>
+                </decoDesc>
+              </egXML>
+              </p>
+            </div>
+            <div type="div4" xml:id="msphmu">
+              <head>Musical Notation</head>
+              <p>Where a manuscript contains music, the <gi>musicNotation</gi>
+              element may be used to describe the form of notation employed, as in
+              the following example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <musicNotation>
+                  <p>Square notation on 4-line red staves.</p>
+                </musicNotation>
+                <musicNotation>
+                  <p>Neumes in campo aperto of the St. Gall type.</p>
+                </musicNotation>
+              </egXML>
+              </p>
+            </div>
+            <div type="div4" xml:id="mspham">
+              <head>Additions and Marginalia</head>
+              <p>The <gi>additions</gi> element can be used to list or describe any
+              additions to the manuscript, such as marginalia, scribblings, doodles,
+              etc., which are considered to be of interest or importance. Such
+              topics may also be discussed or referenced elsewhere in a description,
+              for example in the <gi>history</gi> element, in cases where the
+              marginalia provide evidence of ownership. Some examples follow:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <additions>
+                  <p>Doodles on most leaves, possibly by children, and often quite amusing.</p>
+                </additions>
+                <additions>
+                  <p xml:lang="fr">Quelques annotations marginales des XVIe et XVIIe s.</p>
+                </additions>
+                <additions>
+                  <p>The text of this manuscript is not interpolated with sentences from 
+                  Royal decrees promulgated in 1294, 1305 and 1314. In the margins, however, 
+                  another somewhat later scribe has added the relevant paragraphs of these 
+                  decrees, see pp. 8, 24, 44, 47 etc.</p>
+                  <p>As a humorous gesture the scribe in one opening of the manuscript, pp. 36 
+                  and 37, has prolonged the lower stems of one letter f and five letters þ 
+                  and has them drizzle down the margin.</p>
+                </additions>
+                <additions>
+                  <p>Spaces for initials and chapter headings were left by the scribe but not filled in. 
+                  A later, probably fifteenth-century, hand has added initials and chapter headings in 
+                  greenish-coloured ink on fols <locus>8r</locus>, <locus>8v</locus>, <locus>9r</locus>, 
+                  <locus>10r</locus> and <locus>11r</locus>. Although a few of these chapter headings are 
+                  now rather difficult to read, most can be made out, e.g. fol. <locus>8rb</locus> 
+                  <quote xml:lang="is">floti ast<ex>ri</ex>d<ex>ar</ex>
+                  </quote>; fol. <locus>9rb</locus> 
+                  <quote xml:lang="is">v<ex>m</ex> olaf conung</quote>, and fol. <locus>10ra</locus> 
+                  <quote xml:lang="is">Gipti<ex>n</ex>g ol<ex>a</ex>fs k<ex>onun</ex>gs</quote>.</p>
+                  <p>The manuscript contains the following marginalia:
+                  <list>
+                    <item>Fol. <locus>4v</locus>, left margin: <quote xml:lang="is">hialmadr <ex>ok</ex> 
+                    <lb/>brynjadr</quote>, 
+                    in a fifteenth-cenury hand, imitating an addition made to the text by the scribe at this point.</item>
+                    <item>Fol. <locus>5r</locus>, lower margin: <quote xml:lang="is">þ<ex>e</ex>tta þiki 
+                    m<ex>er</ex> v<ex>er</ex>a gott blek en<ex>n</ex>da kan<ex>n</ex> ek icki 
+                    betr sia</quote>, in a fifteenth-century hand, probably the same as that on the previous page.</item>
+                    <item>Fol. <locus>9v</locus>, bottom margin: <quote xml:lang="is">þessa bok uilda eg <sic>gæt</sic> 
+                    lært med <lb/>an Gud gefe myer Gott ad <lb/>læra</quote>; seventeenth-century hand.</item>
+                  </list>
+                  </p>
+                  <p>There are in addition a number of illegible scribbles in a later hand (or hands) on fols 
+                  <locus>2r</locus>, <locus>3r</locus>, <locus>5v</locus> and <locus>19r</locus>.</p>
+                </additions>
+              </egXML>
+              </p>
+            </div>
+          </div>
+          <div type="div3" xml:id="msph3">
+            <head>Bindings, Seals, and Additional Material</head>
+            <p>The third major component of the physical description relates to
+            supporting but distinct physical components, such as bindings, 
+            seals and accompanying material. These may be described using the following specialist elements:
+            <specList>
+              <specDesc key="bindingDesc"/>
+              <specDesc key="binding"/>
+              <specDesc key="condition"/>
+              <specDesc key="sealDesc"/>
+              <specDesc key="seal"/>
+              <specDesc key="accMat"/>
+            </specList>
+            </p>
+            <div type="div4" xml:id="msphbi">
+              <head>Binding Descriptions</head>
+              <p>The <gi>bindingDesc</gi> element contains a description of the state of
+              the present and former bindings of a manuscript, including information
+              about its material, any distinctive marks, and provenance information. This may
+              be given as a series of paragraphs, if only one binding is being described, or
+              as a series of distinct <gi>binding</gi> elements, each describing a distinct
+              binding, where these are separately described. For example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <bindingDesc>
+                  <p>Sewing not visible; tightly rebound over 19th-century pasteboards, reusing 
+                  panels of 16th-century brown leather with gilt tooling à la fanfare, Paris 
+                  c. 1580-90, the centre of each cover inlaid with a 17th-century oval medallion 
+                  of red morocco tooled in gilt (perhaps replacing the identifying mark of a 
+                  previous owner); the spine similarly tooled, without raised bands or title-piece; 
+                  coloured endbands; the edges of the leaves and boards gilt. Boxed.</p>
+                </bindingDesc>
+              </egXML>
+              </p>
+              <p>Within a binding description, the element <gi>decoNote</gi> is
+              available, as an alternative to <gi>p</gi>, for paragraphs dealing
+              exclusively with information about decorative features of a binding,
+              as in the following example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <binding>
+                  <p>Bound, s. XVIII (?), in <material>diced russia leather</material>
+                  retaining most of the original 15th century metal ornaments (but with 
+                  some replacements) as well as the heavy wooden boards.</p>
+                  <decoNote>
+                    <p>On each cover: alternating circular stamps of the Holy Monogram, 
+                    a sunburst, and a flower.</p>
+                  </decoNote> 
+                  <decoNote>
+                    <p>On the cornerpieces, one of which is missing, a rectangular stamp 
+                    of the Agnus Dei.</p>
+                  </decoNote> 
+                  <p>Rebacked during the 19th century.</p>
+                </binding>
+              </egXML>
+              </p>
+            </div>
+            <div type="div4" xml:id="msphse">
+              <head>Seals</head>
+              <p>The <gi>sealDesc</gi> element supplies information about the
+              seal(s) attached to documents to guarantee their integrity, or to show
+              authentication of the issuer or consent of the participants. It may
+              contain one or more paragraphs summarizing the overall nature of the
+              seals, or may contain one or more <gi>seal</gi> elements.
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <sealDesc>
+                  <seal n="1" type="pendant" subtype="cauda_duplex">
+                    <p>Round seal of <name type="person">Anders Olufsen</name> in black wax: 
+                    <bibl>
+                      <ref>DAS 930</ref>
+                      </bibl>. Parchment tag, on which is written: 
+                    <quote>pertinere nos predictorum placiti nostri iusticarii precessorum dif</quote>.</p>
+                  </seal>
+                  <seal n="2" type="pendant" subtype="cauda_duplex">
+                    <p>The seal of <name type="person">Jens Olufsen</name> in black wax: 
+                    <bibl>
+                      <ref>DAS 1061</ref>
+                      </bibl>. Legend: <quote>S IOHANNES OLAVI</quote>.
+                    Parchment tag on which is written: <quote>Woldorp Iohanne G</quote>.</p>
+                  </seal>
+                </sealDesc>
+              </egXML>
+              </p>
+            </div>
+            <div type="div4" xml:id="msadac">
+              <head>Accompanying Material</head>
+              <p>The circumstance may arise where material not originally part of a
+              manuscript is bound into or otherwise kept with a manuscript. In some
+              cases this material would best be treated in a separate
+              <gi>msPart</gi> element (see <ptr target="#mspt"/> below).  There are,
+              however, cases where the additional matter is not self-evidently a
+              distinct manuscript: it might, for example, be a set of notes by a
+              later scholar, or a file of correspondence relating to the
+              manuscript. The <gi>accMat</gi> element is provided as a holder for
+              this kind of information.
+              <specList>
+                <specDesc key="accMat"/>
+              </specList>
+              </p>
+              <p>Here is an example of the use of this element, describing a note by
+              the Icelandic manuscript collector Árni Magnússon which
+              has been bound with the manuscript:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <accMat>
+                  <p>A slip in Árni Magnússon's hand has been stuck to the
+                  pastedown on the inside front cover; the text reads:
+                  <quote xml:lang="is">Þidreks Søgu þessa hefi eg 
+                  feiged af Sekreterer Wielandt Anno 1715 i Kaupmanna høfn. Hun er, 
+                  sem eg sie, Copia af Austfirda bókinni (Eidagás) en<ex>n</ex> 
+                  ecki progenies Brædratungu bokarinnar. Og er þar fyrer eigi i
+                  allan<ex>n</ex> máta samhlioda þ<ex>eir</ex>re er 
+                  Sr Jon Erlendz son hefer ritad fyrer Mag. Bryniolf. Þesse Þidreks 
+                  Saga mun vera komin fra Sr Vigfuse á Helgafelle.</quote>
+                  </p>
+                </accMat>
+              </egXML>
+              </p>
+
+            </div>
+          </div>
+        </div>
+        <div type="div2" xml:id="mshy">
+          <head>History</head>
+          <p>The following elements are used to record information about the history of a manuscript:
+          <specList>
+            <specDesc key="history"/>
+            <specDesc key="origin"/>
+            <specDesc key="provenance"/>
+            <specDesc key="acquisition"/>
+          </specList>
+          </p>
+          <p>The three components of the <gi>history</gi> element all have the
+          same substructure, consisting of one or more paragraphs marked as
+          <gi>p</gi> elements. Each of these three elements is also a member of
+          the <ident type="class">att.datable</ident> attribute class, itself a
+          member of the <ident type="class">att.datable.w3c</ident> class, and
+          thus also carries the following optional attributes:
+          <specList>
+            <specDesc key="att.datable.w3c" atts="notBefore notAfter       from to when">
+            </specDesc>
+          </specList>
+          </p>
+          <p>Information about the origins of the manuscript, its place and date
+          of writing, should be given as one or more paragraphs contained by a
+          single <gi>origin</gi> element; following this, any available
+          information on distinct stages in the history of the manuscript before
+          its acquisition by its current holding institution should be included
+          as paragraphs within one or more <gi>provenance</gi>
+          elements. Finally, any information specific to the means by which the
+          manuscript was acquired by its present owners should be given as
+          paragraphs within the <gi>acquisition</gi> element.</p>
+          <p>Here is a fairly simple example of the use of this element:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <history>
+              <origin>
+                <p>Written in <origPlace>Durham</origPlace> during <origDate notBefore="1125" notAfter="1175">the 
+                mid-twelfth century</origDate>.</p>
+              </origin> 
+              <provenance>
+                <p>Recorded in two medieval catalogues of the books belonging 
+                to <name type="org">Durham Priory</name>, made in <date>1391</date> and 
+                <date>1405</date>.</p>
+                <p>Given to <name type="person">W. Olleyf</name> by <name type="person">William 
+                Ebchester, Prior (1446-56)</name> and later belonged to <name type="person">Henry 
+                Dalton</name>, Prior of Holy Island (<name type="place">Lindisfarne</name>) 
+                according to inscriptions on ff. 4v and 5.</p>
+              </provenance>
+              <acquisition>
+                <p>Presented to <name type="org">Trinity College</name> in 
+                <date>1738</date> by <name type="person">Thomas Gale</name> and 
+                his son <name type="person">Roger</name>.</p>
+              </acquisition>
+            </history>
+          </egXML>
+          </p>
+          <p>Here is a fuller example:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <history>
+              <origin notBefore="1225" notAfter="1275">
+                <p>Written in Spain or Portugal in the middle of the 13th century 
+                (the date 1042, given in a marginal note on f. 97v, cannot be correct.)</p>
+              </origin>
+              <provenance>
+                <p>The Spanish scholar <name type="person">Benito Arias
+                Montano</name> (1527-1598) has written his name on f. 97r, and may be
+                presumed to have owned the manuscript. It came somehow into the
+                possession of <foreign xml:lang="da">etatsråd</foreign> 
+                <name type="person">Holger Parsberg</name> (1636-1692), who has written his 
+                name twice, once on the front pastedown and once on f. 1r, the former dated
+                <date>1680</date> and the latter <date>1682</date>. Following Parsberg's 
+                death the manuscript was bought by <foreign>etatsråd</foreign>
+                <name type="person">Jens Rosenkrantz</name> (1640-1695) when Parsberg's
+                library was auctioned off (23 October 1693).</p>
+              </provenance>
+              <acquisition notBefore="1696" notAfter="1697">
+                <p>The manuscript was acquired by Árni
+                Magnússon from the estate of Jens Rosenkrantz, presumably at
+                auction (the auction lot number 468 is written in red chalk on the
+                flyleaf), either in 1696 or 97.</p>
+              </acquisition>
+            </history>
+          </egXML>
+          </p>
+        </div>
+        <div type="div2" xml:id="msad">
+          <head>Additional information</head>
+          <p>Three categories of additional information are provided for by the
+          scheme described here, grouped together within the <gi>additional</gi>
+          element described in this section.
+          <specList>
+            <specDesc key="additional"/>
+            <specDesc key="adminInfo"/>
+            <specDesc key="surrogates"/>
+            <specDesc key="listBibl"/>
+          </specList>
+          </p>
+          <p>The <gi>surrogates</gi> element should not be used to describe
+          digital images of the manuscript  since the
+          <gi>facsimile</gi> element described in <ptr target="#facs"/> is
+          provided for this purpose.</p>
+          <p>None of the constituent elements of <gi>additional</gi> is
+          required. If any is supplied, it may appear once only; furthermore,
+          the order in which elements are supplied should be as specified above.</p>
+          <div type="div3" xml:id="msadad">
+            <head>Administrative information</head>
+            <p>The <gi>adminInfo</gi> element is used to hold information relating to the curation and management of
+            a manuscript.  This may be supplied  using
+            <gi>note</gi> element. Alternatively, different aspects of this
+            information may be presented grouped within one<!-- or more-->
+            of the following specialized elements:
+            <specList>
+              <specDesc key="recordHist"/>
+              <specDesc key="availability" atts="status"/>
+              <specDesc key="custodialHist"/>
+            </specList>
+            </p>
+            <p>The <att>status</att> attribute of <gi>availability</gi> must take
+            one of the following values: <val>free</val>, <val>restricted</val>,  <val>unknown</val>.
+            </p>
+            <div type="div4" xml:id="msrh">
+              <head>Record History</head>
+              <p>The <gi>recordHist</gi> element may contain either a series of
+              paragraphs or a single <gi>source</gi> element. It is used to document
+              the primary source of information for the record containing it, in a
+              similar way to the standard TEI <gi>sourceDesc</gi> element within a
+              TEI Header. If the record is a new one, made without reference to
+              anything other than the manuscript itself, then it may be omitted, or
+              simply contain a <gi>p</gi> element, as in the following example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <source>
+                  <p>Directly catalogued from the original manuscript.</p>
+                </source>
+              </egXML>
+              </p>
+              <p>Frequently, however, the record will be derived from some
+              previously existing description, which may be specified using the
+              <gi>bibl</gi> element, as in the following example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <recordHist>
+                  <source>
+                    <p>Information transcribed from <bibl>
+                    <title>The index of
+                    Middle English verse</title>
+                    <biblScope unit="pages">123</biblScope>
+                    </bibl>.</p>
+                  </source>
+                </recordHist>
+              </egXML>
+              </p>
+              <p>If, as is likely, a full bibliographic description of the source
+              from which cataloguing information was taken is included within the
+              <gi>listBibl</gi> element contained by the current <gi>additional</gi>
+              element, or elsewhere in the current document, then it need not be
+              repeated here. Instead, it should be referenced using the standard TEI
+              <gi>ref</gi> element, as in the following example:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <additional>
+                  <adminInfo>
+                    <recordHist>
+                      <source>
+                        <p>Information transcribed from 
+                        <bibl>
+                        <ref target="#IMEV">IMEV</ref> 123</bibl>.</p>
+                      </source>
+                    </recordHist>
+                  </adminInfo>
+                  <listBibl>
+                    <bibl xml:id="IMEV">
+                      <author>Carleton Brown</author> and <author>Rossell Hope Robbins</author>
+                      <title level="m">The index of Middle English verse</title>
+                      <pubPlace>New York</pubPlace>
+                      <date>1943</date>
+                    </bibl>
+                    <!-- other bibliographic records relating to this manuscript here -->
+                  </listBibl>
+                </additional>
+              </egXML>
+              </p>
+              <p>The <gi>change</gi> element 
+              within the <gi>revisionDesc</gi> element of the
+              TEI Header should be used to document the revision history of the
+              record. It should <emph>not</emph> be given within the
+              <gi>recordHist</gi> element. </p>
+
+            </div>
+            <div type="div4" xml:id="msadch">
+              <head>Availability and Custodial History</head>
+              <p>The <gi>availability</gi> element is another element also available
+              in  the TEI Header,
+              which should be used here to supply any information concerning
+              access to the current manuscript, such as its physical location (where this
+              is not implicit in its identifier), any restrictions on access, information
+              about copyright, etc.
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <availability status="restricted">
+                  <p>Viewed by appointment only, to be arranged with curator.</p>
+                </availability>
+                <availability status="unknown">
+                  <p>In conservation, Jan. - Mar., 2002. On loan to the 
+                  Bayerische Staatsbibliothek, April - July, 2002.</p>
+                </availability>
+                <availability status="restricted">
+                  <p>The manuscript is in poor condition, due to many of the leaves being 
+                  brittle and fragile and the poor quality of a number of earlier repairs; 
+                  it should therefore not be used or lent out until it has been conserved.</p>
+                </availability>
+              </egXML>
+              </p>
+              <p>The <gi>custodialHist</gi> record is used to describe the custodial
+              history of a manuscript, recording any significant events noted during
+              the period that it has been located within its holding institution. It
+              may contain either a series of 
+              <gi>p</gi> elements, or a series of <gi>custEvent</gi> elements, each
+              describing a distinct incident or event, further specified by a
+              <att>type</att> attribute, and carrying dating information by virtue
+              of its membership in the <ident type="class">att.datable</ident> class, as noted above.
+              <specList>
+                <specDesc key="custEvent"/>
+              </specList>
+              </p>
+              <p>For ENRICH purposes, the values of this attribute must be one of
+              the following: <val>check</val>, <val>conservation</val>,
+              <val>description</val>, <val>exhibition</val>, <val>loan</val>,
+              <val>photography</val>, <val>other</val>.
+
+              <specGrp xml:id="spec8">
+                <elementSpec ident="custEvent" mode="change" module="msdescription">
+                  <attList>
+                    <attDef ident="type" mode="change" usage="req">
+                      <valList type="closed" mode="replace">
+                        <valItem ident="check"/>  
+                        <valItem ident="conservation"/>
+                        <valItem ident="description"/>
+                        <valItem ident="exhibition"/>
+                        <valItem ident="loan"/>
+                        <valItem ident="photography"/>
+                        <valItem ident="other"/>
+                      </valList>
+
+                    </attDef>
+
+                  </attList>
+                </elementSpec>
+              </specGrp>
+              </p>
+
+              <p>Here is an example of the use of this element:
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <custodialHist>
+                  <custEvent type="conservation" notBefore="1961-03-01" notAfter="1963-02-28">
+                    <p>Conserved between March 1961 and February 1963 at Birgitte Dalls 
+                    Konserveringsværksted.</p>
+                  </custEvent>
+                  <custEvent type="photography" notBefore="1988-05-01" notAfter="1988-05-30">
+                    <p>Photographed in May 1988 by AMI/FA.</p>
+                  </custEvent>
+                  <custEvent type="loan" notBefore="1989-11-13" notAfter="1989-11-13">
+                    <p>Dispatched to Iceland 13 November 1989.</p>
+                  </custEvent>
+                </custodialHist>
+              </egXML>
+              </p>
+            </div>
+          </div>
+          <div type="div3" xml:id="msadsu">
+            <head>Surrogates</head>
+            <p>The <gi>surrogates</gi> element is used
+            to provide information about any digital or photographic
+            representations of the manuscript which may exist within the holding
+            institution or elsewhere. 
+            <specList>
+              <specDesc key="surrogates"/>
+            </specList>
+            </p>
+            <p>The <gi>surrogates</gi> element should not be used to repeat
+            information about representations of the manuscript available within
+            published works; this should normally be documented within the
+            <gi>listBibl</gi> element within the <gi>additional</gi>
+            element. However, it is often also convenient to record information
+            such as negative numbers or digital identifiers for unpublished
+            collections of manuscript images maintained within the holding
+            institution, as well as to provide more detailed descriptive
+            information about the surrogate itself. Such information may be provided
+            as prose paragraphs, within which identifying information about particular
+            surrogates may be presented using the standard TEI <gi>bibl</gi> element,
+            as in the following example:
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <surrogates>
+                <p>
+                  <bibl>
+                    <title type="gmd">microfilm (master)</title>
+                  <idno>G.neg. 160</idno> n.d.</bibl>
+                  <bibl>
+                    <title type="gmd">microfilm (archive)</title>
+                  <idno>G.pos. 186</idno> n.d.</bibl>
+                  <bibl>
+                    <title type="gmd">b/w prints</title>
+                    <idno>AM 795 4to</idno>
+                    <date when="1999-01-27">27 January 1999</date>
+                    <note>copy of G.pos. 186</note>
+                  </bibl>
+                  <bibl>
+                    <title type="gmd">b/w prints</title>
+                    <idno>reg.nr. 75</idno>
+                    <date when="1999-01-25">25 January 1999</date>
+                    <note>photographs of the spine, outside covers, stitching etc.</note>
+                  </bibl>
+                </p>
+              </surrogates>
+            </egXML>
+            Note the use of the specialized form of title (<term>general material designation</term>) to specify the kind of surrogate being documented.</p>
+            <p>For ENRICH purposes, information about digital
+            images of the manuscript being described should be provided within the
+            <gi>facsimile</gi> element discussed in section <ptr target="#facs"/>
+            below rather than within the  <gi>surrogates</gi> element.</p>
+          </div>
+        </div>
+        <div type="div2" xml:id="mspt">
+          <head>Manuscript Parts</head>
+          <p>The <gi>msPart</gi> element may be used in cases where what were
+          originally physically separate manuscripts or parts of manuscripts
+          have been bound together and/or share the same call number.
+          <specList>
+            <specDesc key="msPart"/>
+          </specList>
+          </p>
+          <p>Since each component of such a composite manuscript will in all
+          likelihood have its own content, physical description, history, and so
+          on, the structure of <gi>msPart</gi> is in the main identical to that
+          of <gi>msDesc</gi>, allowing one to retain the top level of
+          identity (<gi>msIdentifier</gi>), but to branch out thereafter into as
+          many parts, or even subparts, as necessary. If the parts of a
+          composite manuscript have their own identifiers, they should be tagged
+          using the <gi>idno</gi> element, rather than the <gi>msIdentifier</gi>
+          element, as in the following example:
+          <!-- don't understand why these need to to wrapped in <altIdentifier> -->
+          <!-- I don't either, but now it has to be wrapped in an
+               <msIdentifier>, too. —Syd, 2016-09-10 :-) -->
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <msDesc xml:id="ex3" xml:lang="en">
+              <msIdentifier>
+                <settlement>Amiens</settlement>
+                <repository>Bibliothèque Municipale</repository>
+                <idno>MS 3</idno>
+                <msName>Maurdramnus Bible</msName>
+              </msIdentifier>
+              <!-- other elements here -->
+              <msPart>
+                <msIdentifier>
+                  <altIdentifier type="other">
+                    <idno>MS 6</idno>
+                  </altIdentifier>
+                  <!-- other information specific to this part here -->
+                </msIdentifier>
+              </msPart>
+              <msPart>
+                <msIdentifier>
+                  <altIdentifier type="other">
+                    <idno>MS 7</idno>
+                  </altIdentifier>
+                  <!-- other information specific to this part here -->
+                </msIdentifier>
+              </msPart>
+              <msPart>
+                <msIdentifier>
+                  <altIdentifier type="other">
+                    <idno>MS 9</idno>
+                  </altIdentifier>
+                  <!-- other information specific to this part here -->
+                </msIdentifier>
+              </msPart>
+              <!-- other msParts here -->
+            </msDesc>
+          </egXML>
+          </p>
+        </div>
+      </div>
+      <div xml:id="facs">
+        <head>Metadata about digital facsimiles</head>
+        <p>The <gi>facsimile</gi> element is used to describe the digital
+        images of the manuscript being made available to the ENRICH
+        project. It contains, as a minimum, one <gi>surface</gi> element for
+        each distinct page image, which in turn specifies one or more
+        <gi>graphic</gi> element. These elements are used as described in the
+        <ref target="http://www.tei-c.org/release/doc/tei-p5-doc/en/html/PH.html#PHFACS">TEI Guidelines, section11.1</ref>. </p>
+        <p>Here is a simple example:
+        <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <facsimile xml:base="http://www.handrit.org/AM/fol/">
+            <surface xml:id="LSB-1r" ulx="0" uly="0" lrx="200" lry="300">
+              <graphic mimeType="jpeg" xml:id="AM02-5000-1r" url="AM02-5000-1r.jpg"/>
+              <graphic mimeType="jpeg"
+                       url="AM02-5000-1r-thumb.jpg"
+                       width="1in"
+                       decls="#thumb"/>
+              <zone ulx="20" uly="20" lrx="70" lry="70">
+                <graphic mimeType="jpeg"
+                         xml:id="AM02-5000-1r-det"
+                         url="AM02-5000-1r-det.jpg"/>
+              </zone>
+            </surface>
+            <surface start="#LSB-1v" ulx="0" uly="0" lrx="200" lry="300">
+              <graphic mimeType="jpeg" xml:id="AM02-5000-1v" url="AM02-5000-1v.jgp"/>
+              <graphic mimeType="jpeg"
+                       url="AM02-5000-1v-thumb.jpg"
+                       decls="http://www.enrich.org/imageDescs#thumb"/>
+            </surface>
+          </facsimile>
+        </egXML>
+        </p>
+        <p>The <att>xml:base</att> attribute specifies the <soCalled>root
+        URL</soCalled>, which will be prefixed to all URL values within the
+        child elements of this <gi>facsimile</gi>. </p>
+        <p>This example defines only two pages. There are three images
+        associated with the first page, which is
+        represented by the <gi>surface</gi> element with
+        unique identifier <val>LSB-1r</val>, and two with  the second, which has no
+        identifier. Each image is represented by means of a TEI
+        <gi>graphic</gi> element. </p>
+        <p>As well as acting as a container for the various images associated
+        with a page, the <gi>surface</gi> element defines an abstract
+        co-ordinate system which may be used when defining additional zones of
+        interest on the page. In this example, the location of an initial
+        letter on the page is defined, since we have a graphic representing
+        this detail. The zone within which the initial letter falls is in the
+        box defined by the co-ordinates (20,20,70,70) within a grid defined by
+        the co-ordinates (0,0,200,300). Thus, if the surface depicted
+        actually measured 200 by 300 mm, the initial letter would occupy a
+        50 X 50 mm square, with its upper left corner located 20 mm from the
+        left and 20 mm from the top edges of the surface. Note however that
+        the numbers used to express co-ordinates are not measurements in any
+        specific units and should not be used to determine the actual image
+        size, since these may in any case vary greatly: in our example, the
+        first image is a full page scan, while the second is a thumbnail.</p>
+        <p>The <att>mimeType</att> attribute is used to indicate the format of
+        the graphic file itself, and may be any valid MIME type, as defined by
+        the IANA, for example <val>jpeg</val>, <val>png</val>, <val>bmp</val>,
+        <val>tiff</val> etc. </p>
+        <p>The <att>decls</att> attribute is used to indicate an external URI
+        from which further metadata applicable to this image may be found. In
+        this case we are assuming that there is a definition which can be used
+        to indicate characteristics of a thumbnail image at the address
+        indicated. Note that this must be given in full, since it would
+        otherwise be interpreted as an address relative to the value of the
+        <att>xml:base</att> attribute on the parent <gi>facsimile</gi>.</p>
+        <note rend="query">Alternatively, should we invent a type-like attribute
+        which could be validated in the schema? </note>
+        <p>The <gi>desc</gi> element within a <gi>zone</gi> may be used to
+        supply additional information about that zone, in this example to
+        describe what it contains. In the TEI scheme, full documentation  of a
+        facsimile and its contents is carried in other parts of the digital
+        document, linked to it in either or both of the following ways:
+        <list>
+          <item>the <att>start</att> attribute may be used on a <gi>zone</gi> or
+          <gi>surface</gi>; it points to an element in the transcription the
+          start of which coincides with the zone or surface concerned.</item>
+          <item>the <att>facs</att> attribute may be used, for example on the
+          <gi>msContents</gi> or <gi>msItem</gi> element in a manuscript
+          description, or on any element in the transcription, to point to the
+          <gi>surface</gi> bearing the start of the matter in question. </item>
+        </list>
+        </p>
+        <p>To complete the above example, we might thus expect that the
+        <gi>msDesc</gi> for this manuscript will contain something like the
+        following:
+        <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <msItem>
+            <locus facs="#LSB-1r">ff. 1r-1v</locus>
+            <title>Ludovícuss saga Bernharðssonar</title>
+          </msItem>
+        </egXML>
+        Here, the value of the <att>facs</att> attribute is a
+        pointer to the <gi>surface</gi> element corresponding with the part of
+        the manuscript in which the <gi>msItem</gi> specified begins.
+
+        If a transcription of this (regrettably nonexistent) manuscript exists,
+        then it might begin as follows:
+
+        <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <div facs="#LSB-1r">
+            <pb n="1r"/>
+            <p>Maðr hét Ludovícus, sonr Bernharðs greifa, er kallaðr var loðinbjörn.
+            <!-- rest of text for page one -->
+            <pb n="1v" xml:id="LSB-1v"/>
+            <!-- text for second page here -->
+            </p>
+          </div>
+        </egXML>
+        pointer to the <gi>surface</gi> element corresponding with the part of
+        the manuscript at which the transcribed text begins.
+        </p>
+      </div>
+      <div>
+        <head>Schema</head>
+        <schemaSpec ident="tei_enrich" start="TEI msDesc teiHeader">
+          <moduleRef key="header"/>
+          <moduleRef key="core"/>
+          <moduleRef key="tei"/>
+          <moduleRef key="textstructure"/>
+          <moduleRef key="msdescription"/>
+          <moduleRef key="linking"/>
+          <moduleRef key="namesdates"/>
+          <moduleRef key="figures"/>
+          <moduleRef key="transcr"/>
+          <moduleRef key="gaiji"/>
+
+          <!-- delete uninteresting classes -->
+
+          <classSpec ident="att.global.linking" mode="delete" type="atts"/>
+          <classSpec ident="att.datable.iso" type="atts" mode="delete"/>
+          <classSpec ident="model.addrPart" type="model" mode="delete"/>
+
+          <!-- delete unwanted elements -->
+
+          <elementSpec module="core" ident="address" mode="delete"/>
+          <elementSpec module="core" ident="analytic" mode="delete"/>
+          <elementSpec module="core" ident="biblFull" mode="delete"/>
+          <elementSpec module="core" ident="biblStruct" mode="delete"/>
+          <elementSpec module="core" ident="binaryObject" mode="delete"/>
+          <elementSpec module="core" ident="cit" mode="delete"/>
+          <elementSpec module="core" ident="distinct" mode="delete"/>
+          <elementSpec module="core" ident="email" mode="delete"/>
+          <elementSpec module="core" ident="emph" mode="delete"/>
+          <elementSpec module="core" ident="equiv" mode="delete"/>
+          <elementSpec module="core" ident="headItem" mode="delete"/>
+          <elementSpec module="core" ident="headLabel" mode="delete"/>
+          <elementSpec module="core" ident="imprint" mode="delete"/>
+          <elementSpec module="core" ident="measure" mode="delete"/>
+          <elementSpec module="core" ident="measureGrp" mode="delete"/>
+          <elementSpec module="core" ident="meeting" mode="delete"/>
+          <elementSpec module="core" ident="mentioned" mode="delete"/>
+          <elementSpec module="core" ident="monogr" mode="delete"/>
+          <elementSpec module="core" ident="num" mode="delete"/>
+          <elementSpec module="core" ident="postBox" mode="delete"/>
+          <elementSpec module="core" ident="postCode" mode="delete"/>
+          <elementSpec module="core" ident="refsDecl" mode="delete"/>
+          <elementSpec module="core" ident="rs" mode="delete"/>
+          <elementSpec module="core" ident="said" mode="delete"/>
+          <elementSpec module="core" ident="series" mode="delete"/>
+          <elementSpec module="core" ident="soCalled" mode="delete"/>
+          <elementSpec module="core" ident="sp" mode="delete"/>
+          <elementSpec module="core" ident="speaker" mode="delete"/>
+          <elementSpec module="core" ident="stage" mode="delete"/>
+          <elementSpec module="core" ident="street" mode="delete"/>
+          <elementSpec module="core" ident="teiCorpus" mode="delete"/>
+          <elementSpec module="core" ident="time" mode="delete"/>
+          <elementSpec module="figures" ident="table" mode="delete"/>
+          <elementSpec module="figures" ident="cell" mode="delete"/>
+          <elementSpec module="figures" ident="row" mode="delete"/>
+          <elementSpec module="header" ident="appInfo" mode="delete"/>
+          <elementSpec module="header" ident="application" mode="delete"/>
+          <elementSpec module="header" ident="broadcast" mode="delete"/>
+          <elementSpec module="header" ident="correction" mode="delete"/>
+          <elementSpec module="header" ident="cRefPattern" mode="delete"/>
+          <elementSpec module="header" ident="equipment" mode="delete"/>
+          <elementSpec module="header" ident="fsdDecl" mode="delete"/>
+          <elementSpec module="header" ident="hyphenation" mode="delete"/>
+          <elementSpec module="header" ident="interpretation" mode="delete"/>
+          <elementSpec module="header" ident="metDecl" mode="delete"/>
+          <elementSpec module="header" ident="metSym" mode="delete"/>
+          <elementSpec module="header" ident="namespace" mode="delete"/>
+          <elementSpec module="header" ident="normalization" mode="delete"/>
+          <elementSpec module="header" ident="quotation" mode="delete"/>
+          <elementSpec module="header" ident="recording" mode="delete"/>
+          <elementSpec module="header" ident="recordingStmt" mode="delete"/>
+          <elementSpec module="header" ident="rendition" mode="delete"/>
+          <elementSpec module="header" ident="samplingDecl" mode="delete"/>
+          <elementSpec module="header" ident="scriptStmt" mode="delete"/>
+          <elementSpec module="header" ident="segmentation" mode="delete"/>
+          <elementSpec module="header" ident="state" mode="delete"/>
+          <elementSpec module="header" ident="stdVals" mode="delete"/>
+          <elementSpec module="header" ident="tagUsage" mode="delete"/>
+          <elementSpec module="header" ident="tagsDecl" mode="delete"/>
+          <elementSpec module="header" ident="variantEncoding" mode="delete"/>
+          <elementSpec module="linking" ident="ab" mode="delete"/>
+          <elementSpec module="linking" ident="alt" mode="delete"/>
+          <elementSpec module="linking" ident="altGrp" mode="delete"/>
+          <elementSpec module="linking" ident="join" mode="delete"/>
+          <elementSpec module="linking" ident="joinGrp" mode="delete"/>
+          <elementSpec module="linking" ident="link" mode="delete"/>
+          <elementSpec module="linking" ident="linkGrp" mode="delete"/>
+          <elementSpec module="linking" ident="timeline" mode="delete"/>
+          <elementSpec module="linking" ident="when" mode="delete"/>
+          <elementSpec module="msdescription" ident="msItemStruct" mode="delete"/>
+          <elementSpec module="namesdates" ident="climate" mode="delete"/>
+          <elementSpec module="namesdates" ident="listNym" mode="delete"/>
+          <elementSpec module="namesdates" ident="nym" mode="delete"/>
+          <elementSpec module="namesdates" ident="terrain" mode="delete"/>
+          <elementSpec module="textstructure" ident="argument" mode="delete"/>
+          <elementSpec module="textstructure" ident="byline" mode="delete"/>
+          <elementSpec module="textstructure" ident="closer" mode="delete"/>
+          <elementSpec module="textstructure" ident="dateline" mode="delete"/>
+          <elementSpec module="textstructure" ident="div1" mode="delete"/>
+          <elementSpec module="textstructure" ident="div2" mode="delete"/>
+          <elementSpec module="textstructure" ident="div3" mode="delete"/>
+          <elementSpec module="textstructure" ident="div4" mode="delete"/>
+          <elementSpec module="textstructure" ident="div5" mode="delete"/>
+          <elementSpec module="textstructure" ident="div6" mode="delete"/>
+          <elementSpec module="textstructure" ident="div7" mode="delete"/>
+          <elementSpec module="textstructure" ident="docDate" mode="delete"/>
+          <elementSpec module="textstructure" ident="epigraph" mode="delete"/>
+          <elementSpec module="textstructure" ident="floatingText" mode="delete"/>
+          <elementSpec module="textstructure" ident="imprimatur" mode="delete"/>
+          <elementSpec module="textstructure" ident="opener" mode="delete"/>
+          <elementSpec module="textstructure" ident="postscript" mode="delete"/>
+          <elementSpec module="textstructure" ident="salute" mode="delete"/>
+          <elementSpec module="textstructure" ident="signed" mode="delete"/>
+          <elementSpec module="textstructure" ident="trailer" mode="delete"/>
+
+          <!-- constrain attribute values for several elements and also supply defaults -->
+
+          <elementSpec ident="biblScope" mode="change" module="core">
+            <attList>
+              <attDef ident="unit" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="volume"/>
+                  <valItem ident="pages"/> 
+                </valList>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="gap" mode="change" module="core">
+            <attList>
+              <attDef ident="reason" mode="change" usage="req">
+                <desc xml:lang="en" versionDate="2014-01-12">gives the reason for omission of this material from the
+                transcription.</desc>
+                <valList type="closed" mode="replace">
+                  <valItem ident="damage">
+                    <desc xml:lang="en" versionDate="2014-01-12">medium is damaged</desc>
+                  </valItem>  
+                  <valItem ident="illegible">
+                    <desc xml:lang="en" versionDate="2014-01-12">material cannot be reliably read</desc>
+                  </valItem>
+                  <valItem ident="cancelled">
+                    <desc xml:lang="en" versionDate="2014-01-12">material can be read but has been cancelled
+                    by scribe</desc>
+                  </valItem>
+                  <valItem ident="irrelevant">
+                    <desc xml:lang="en" versionDate="2014-01-12">material is not regarded as relevant by
+                    the transcriber</desc>
+                  </valItem>
+                  <valItem ident="omitted">
+                    <desc xml:lang="en" versionDate="2014-01-12">material omitted by transcriber</desc>
+                  </valItem>
+                  <valItem ident="lacuna">
+                    <desc xml:lang="en" versionDate="2014-01-12">material missing from the source</desc>
+                  </valItem>
+                </valList>
+              </attDef>
+              <attDef ident="unit" mode="change" usage="opt">
+                <desc xml:lang="en" versionDate="2014-01-12">names the unit used for describing the extent of the gap</desc>
+                <valList type="closed" mode="replace">
+                  <valItem ident="chars">
+                    <desc xml:lang="en" versionDate="2014-01-12">written characters</desc>
+                  </valItem>
+                  <valItem ident="leaves">
+                    <desc xml:lang="en" versionDate="2014-01-12">leaves</desc>
+                  </valItem>
+                  <valItem ident="lines">
+                    <desc xml:lang="en" versionDate="2014-01-12">lines</desc>
+                  </valItem>
+                  <valItem ident="mm">
+                    <desc xml:lang="en" versionDate="2014-01-12">millimetres</desc>
+                  </valItem>
+                  <valItem ident="pages">
+                    <desc xml:lang="en" versionDate="2014-01-12">pages</desc>
+                  </valItem>
+                  <valItem ident="words">
+                    <desc xml:lang="en" versionDate="2014-01-12">words</desc>
+                  </valItem>
+                </valList>
+                <!-- no default!! -->
+              </attDef>
+            </attList>
+          </elementSpec>
+
+
+          <elementSpec ident="hi" mode="change" module="core">
+            <attList>
+              <attDef ident="rend" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="hyphenated"/>
+                  <valItem ident="underline"/>
+                  <valItem ident="double-underline"/>
+                  <valItem ident="bold"/>
+                  <valItem ident="caps"/>
+                  <valItem ident="italic"/>
+                  <valItem ident="sup"/>
+                  <valItem ident="rubric"/>
+                </valList>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="name" mode="change" module="core">
+            <attList>
+              <attDef ident="type" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="person"/>
+                  <valItem ident="place"/>
+                  <valItem ident="org"/>  
+                  <valItem ident="unknown"/>  
+                </valList>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="handNote" mode="change" module="msdescription">
+            <attList>
+              <attDef ident="script" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="carolmin"/>
+                  <valItem ident="textualis"/>
+                  <valItem ident="cursiva"/>
+                  <valItem ident="hybrida"/>
+                  <valItem ident="humbook"/>
+                  <valItem ident="humcursiva"/>  
+                  <valItem ident="other">
+                    <desc xml:lang="en" versionDate="2014-01-12">script other than one of these</desc>
+                  </valItem>
+                  <valItem ident="unknown">
+                    <desc xml:lang="en" versionDate="2014-01-12">script information not available</desc>
+                  </valItem>
+                </valList>
+              </attDef>
+              <attDef ident="scope" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="sole"/>
+                  <valItem ident="major"/>
+                  <valItem ident="minor"/>
+                </valList>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="altIdentifier" module="msdescription" mode="change">
+            <attList>
+              <attDef ident="type" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="former">
+                    <desc xml:lang="en" versionDate="2014-01-12">former catalogue or shelf number</desc>
+                  </valItem>
+                  <valItem ident="system">
+                    <desc xml:lang="en" versionDate="2014-01-12">former system identifier
+                    (Manuscriptorium specific)</desc>
+                  </valItem>
+                  <valItem ident="partial">
+                    <desc xml:lang="en" versionDate="2014-01-12">identifier of a previously distinct
+                    item</desc>
+                  </valItem>
+                  <valItem ident="internal">
+                    <desc xml:lang="en" versionDate="2014-01-12">internal project identifier</desc>
+                  </valItem>
+                  <valItem ident="other">
+                    <desc xml:lang="en" versionDate="2014-01-12">unspecified</desc>
+                  </valItem>
+                </valList>
+
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="availability" mode="change" module="header">
+            <attList>
+              <attDef ident="status" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="free"/>
+                  <valItem ident="unknown"/>
+                  <valItem ident="restricted"/>  
+                </valList>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="textLang" mode="change" module="msdescription">
+            <attList>
+              <attDef ident="mainLang" mode="change" usage="req"/>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="objectDesc" mode="change" module="msdescription">
+            <attList>
+              <attDef ident="form" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="codex">
+                    <desc xml:lang="en" versionDate="2014-01-12">a bound codex</desc>
+                  </valItem>
+                  <valItem ident="leaf">
+                    <desc xml:lang="en" versionDate="2014-01-12">a loose leaf</desc>
+                  </valItem>
+                  <valItem ident="scroll">
+                    <desc xml:lang="en" versionDate="2014-01-12">a scroll</desc>
+                  </valItem>
+                  <valItem ident="other">
+                    <desc xml:lang="en" versionDate="2014-01-12">any other format</desc>
+                  </valItem>
+                </valList>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="supportDesc" mode="change" module="msdescription">
+            <attList>
+              <attDef ident="material" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="perg">
+                    <desc xml:lang="en" versionDate="2014-01-12">parchment</desc>
+                  </valItem>
+                  <valItem ident="chart">
+                    <desc xml:lang="en" versionDate="2014-01-12">paper</desc>
+                  </valItem>
+                  <valItem ident="mixed">
+                    <desc xml:lang="en" versionDate="2014-01-12">mixture of paper and parchment, or other materials</desc>
+                  </valItem>  
+                  <valItem ident="unknown"/> 
+                </valList>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="layout" mode="change" module="msdescription">
+            <attList>
+              <attDef ident="columns" mode="change" usage="req"/>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="msDesc" mode="change" module="msdescription">
+            <attList>
+              <attDef ident="xml:id" mode="change" usage="req"/>
+              <attDef ident="xml:lang" mode="change" usage="req"/>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="decoNote" mode="change" module="msdescription">
+            <attList>
+              <attDef ident="type" mode="change">
+                <defaultVal>other</defaultVal>
+                <valList type="closed" mode="replace">
+                  <valItem ident="border"/>
+                  <valItem ident="diagram"/>
+                  <valItem ident="initial"/>
+                  <valItem ident="marginal"/>
+                  <valItem ident="miniature"/>
+                  <valItem ident="mixed"/>
+                  <valItem ident="paratext"/>
+                  <valItem ident="secondary"/>
+                  <valItem ident="other"/>
+                  <valItem ident="illustration"/>
+                  <valItem ident="printmark"/>
+                  <valItem ident="publishmark"/>
+                  <valItem ident="vignette"/>
+                  <valItem ident="frieze"/>
+                  <valItem ident="map"/>
+                  <valItem ident="unspecified"/>
+                </valList>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="custEvent" mode="change" module="msdescription">
+            <attList>
+              <attDef ident="type" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="check"/>  
+                  <valItem ident="conservation"/>
+                  <valItem ident="description"/>
+                  <valItem ident="exhibition"/>
+                  <valItem ident="loan"/>
+                  <valItem ident="photography"/>
+                  <valItem ident="other"/>
+                </valList>
+
+              </attDef>
+
+            </attList>
+          </elementSpec>
+
+
+
+          <elementSpec ident="person" mode="change" module="namesdates">
+            <attList>
+              <attDef ident="sex" mode="change" usage="req"/>
+            </attList>
+          </elementSpec>
+
+
+          <classSpec ident="att.dimensions" mode="change" type="atts">
+            <attList>
+              <attDef mode="delete" ident="precision"/>
+              <attDef mode="change" ident="unit">
+                <defaultVal>mm</defaultVal>
+                <valList type="closed" mode="replace">
+                  <valItem ident="cm"/>
+                  <valItem ident="mm"/>
+                  <valItem ident="in"/>
+                  <valItem ident="lines"/>
+                  <valItem ident="chars"/>
+                </valList>
+              </attDef>
+            </attList>
+          </classSpec>
+
+          <elementSpec ident="dimensions" mode="change" module="msdescription">
+            <attList>
+              <attDef ident="type" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="leaf"/>
+                  <valItem ident="binding"/>
+                  <valItem ident="slip"/>
+                  <valItem ident="written"/>
+                  <valItem ident="boxed"/>  
+                  <valItem ident="unknown"/>  
+
+                </valList>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="region" mode="change" module="namesdates">
+            <attList>
+              <attDef ident="type" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="parish"/>
+                  <valItem ident="county"/>
+                  <valItem ident="compass"/>
+                  <valItem ident="geog"/>
+                  <valItem ident="state"/> 
+                  <valItem ident="unknown"/> 
+                </valList>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="supplied" mode="change" module="transcr">
+            <attList>
+              <attDef ident="reason" mode="change" usage="req">
+                <valList type="closed" mode="replace">
+                  <valItem ident="omitted"/>
+                  <valItem ident="illegible"/>
+                  <valItem ident="damage"/>  
+                  <valItem ident="unknown"/> 
+                </valList>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <!-- constrain date attributes -->
+
+          <elementSpec ident="date" mode="change" module="core">
+            <constraintSpec scheme="schematron" ident="dates">
+              <constraint>
+                <sch:assert test="@when or (@notAfter and @notBefore) or    (@from and @to)">
+                You must provide either @when or @to/@from, or @notAfter/@notBefore.</sch:assert>
+              </constraint>
+            </constraintSpec>
+          </elementSpec>
+
+          <!-- remove optional global attribute we don't want to use -->
+
+          <classSpec ident="att.global.rendition"
+                     type="atts"
+                     mode="change"
+                     module="tei">
+            <attList>
+              <attDef ident="rendition" mode="delete"/>
+            </attList>
+          </classSpec>
+
+
+
+
+          <!-- remove stupid (non-mandatory) elements we dont want in this place -->
+          <!-- remove option of change within history -->
+
+          <elementSpec module="msdescription" ident="recordHist" mode="change">
+
+            <content>
+              <alternate>
+                <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>
+                <elementRef key="source"/>
+              </alternate>
+            </content>
+          </elementSpec>
+
+
+
+          <!-- HERE BE DIRTY STUFF WHICH SHOULD BE IN ITS OWN NAMESPACE 
+               BUT WHICH IS ALREADY SCHEDULED FOR INCLUSION IN NEXT P5 RELEASE-->
+
+          <!-- add origPlace to att.typed  -->
+
+          <elementSpec ident="origPlace" module="msdescription" mode="change">
+            <classes mode="change">
+              <memberOf key="att.typed"/>
+              <memberOf key="att.datable"/>
+              <memberOf key="att.editLike"/>
+              <memberOf key="model.pPart.msdesc"/>
+            </classes>
+          </elementSpec>
+
+          <!-- permit titlepage inside msContents -->
+          <elementSpec ident="msContents" module="msdescription" mode="change">
+            <content>
+              <alternate>
+                <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>
+                <sequence>
+                  <elementRef key="summary" minOccurs="0"/>
+                  <elementRef key="textLang" minOccurs="0"/>
+                  <elementRef key="titlePage" minOccurs="0"/>
+                  <elementRef key="msItem" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+              </alternate>
+            </content>
+
+          </elementSpec>
+
+          <!-- change wording of desc to be less confusing -->
+          <elementSpec ident="surrogates" mode="change" module="msdescription">
+            <desc xml:lang="en" versionDate="2014-01-12">contains information about any non-digital representations of the manuscript being described which may exist in the holding institution or elsewhere.
+            </desc>
+          </elementSpec>
+
+        </schemaSpec>
+
+      </div>
+    </body>
   </text>
 </TEI>

--- a/P5/Exemplars/tei_lite.odd
+++ b/P5/Exemplars/tei_lite.odd
@@ -12,45 +12,45 @@ $Id$
   <teiHeader>
     <fileDesc>
       <titleStmt>
-	<title>Encoding for Interchange: an introduction to the TEI</title>
+        <title>Encoding for Interchange: an introduction to the TEI</title>
       </titleStmt>
       <publicationStmt>
-	<publisher>TEI Consortium</publisher>
-	<availability>
-	  <licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a Creative
-	  Commons Attribution-ShareAlike 3.0 Unported License </licence>
-	  <licence target="http://www.opensource.org/licenses/BSD-2-Clause">
-	    <p>Copyright 2013 TEI Consortium.</p>
-	    <p>All rights reserved.</p>
-	    <p>Redistribution and use in source and binary forms, with or without modification, are
-	    permitted provided that the following conditions are met:</p>
-	    <list>
-	      <item>Redistributions of source code must retain the above copyright notice, this list of
-	      conditions and the following disclaimer.</item>
-	      <item>Redistributions in binary form must reproduce the above copyright notice, this list of
-	      conditions and the following disclaimer in the documentation and/or other materials provided
-	      with the distribution.</item>
-	    </list>
-	    <p>This software is provided by the copyright holders and contributors "as is" and any express
-	    or implied warranties, including, but not limited to, the implied warranties of
-	    merchantability and fitness for a particular purpose are disclaimed. In no event shall the
-	    copyright holder or contributors be liable for any direct, indirect, incidental, special,
-	    exemplary, or consequential damages (including, but not limited to, procurement of substitute
-	    goods or services; loss of use, data, or profits; or business interruption) however caused
-	    and on any theory of liability, whether in contract, strict liability, or tort (including
-	    negligence or otherwise) arising in any way out of the use of this software, even if advised
-	    of the possibility of such damage.</p>
-	  </licence>
-	  <p>TEI material can be licensed differently depending on the use you intend to make of it.
-	  Hence it is made available under both the CC+BY and BSD-2 licences. The CC+BY licence is
-	  generally appropriate for usages which treat TEI content as data or documentation. The BSD-2
-	  licence is generally appropriate for usage of TEI content in a software environment. For
-	  further information or clarification, please contact the <ref target="mailto:info@tei-c.org">TEI Consortium</ref>. </p>
-	</availability>
+        <publisher>TEI Consortium</publisher>
+        <availability>
+          <licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a Creative
+          Commons Attribution-ShareAlike 3.0 Unported License </licence>
+          <licence target="http://www.opensource.org/licenses/BSD-2-Clause">
+            <p>Copyright 2013 TEI Consortium.</p>
+            <p>All rights reserved.</p>
+            <p>Redistribution and use in source and binary forms, with or without modification, are
+            permitted provided that the following conditions are met:</p>
+            <list>
+              <item>Redistributions of source code must retain the above copyright notice, this list of
+              conditions and the following disclaimer.</item>
+              <item>Redistributions in binary form must reproduce the above copyright notice, this list of
+              conditions and the following disclaimer in the documentation and/or other materials provided
+              with the distribution.</item>
+            </list>
+            <p>This software is provided by the copyright holders and contributors "as is" and any express
+            or implied warranties, including, but not limited to, the implied warranties of
+            merchantability and fitness for a particular purpose are disclaimed. In no event shall the
+            copyright holder or contributors be liable for any direct, indirect, incidental, special,
+            exemplary, or consequential damages (including, but not limited to, procurement of substitute
+            goods or services; loss of use, data, or profits; or business interruption) however caused
+            and on any theory of liability, whether in contract, strict liability, or tort (including
+            negligence or otherwise) arising in any way out of the use of this software, even if advised
+            of the possibility of such damage.</p>
+          </licence>
+          <p>TEI material can be licensed differently depending on the use you intend to make of it.
+          Hence it is made available under both the CC+BY and BSD-2 licences. The CC+BY licence is
+          generally appropriate for usages which treat TEI content as data or documentation. The BSD-2
+          licence is generally appropriate for usage of TEI content in a software environment. For
+          further information or clarification, please contact the <ref target="mailto:info@tei-c.org">TEI Consortium</ref>. </p>
+        </availability>
       </publicationStmt>
       <sourceDesc>
-	<bibl>TEI U5 (derived from TEI U1: An Introduction to TEI Tagging (derived from TEI ED W21:
-	Living with the Guidelines)</bibl>
+        <bibl>TEI U5 (derived from TEI U1: An Introduction to TEI Tagging (derived from TEI ED W21:
+        Living with the Guidelines)</bibl>
       </sourceDesc>
     </fileDesc>
     <revisionDesc>
@@ -98,47 +98,47 @@ $Id$
   <text>
     <front>
       <titlePage>
-	<docTitle>
-	  <titlePart type="main">TEI Lite: Encoding for Interchange: an introduction to the TEI </titlePart>
-	  <titlePart type="sub">Final revised edition for TEI P5</titlePart>
-	</docTitle>
-	<docAuthor>Lou Burnard</docAuthor>
-	<docAuthor>C. M. Sperberg-McQueen</docAuthor>
-	<docDate>August 2012</docDate>
+        <docTitle>
+          <titlePart type="main">TEI Lite: Encoding for Interchange: an introduction to the TEI </titlePart>
+          <titlePart type="sub">Final revised edition for TEI P5</titlePart>
+        </docTitle>
+        <docAuthor>Lou Burnard</docAuthor>
+        <docAuthor>C. M. Sperberg-McQueen</docAuthor>
+        <docDate>August 2012</docDate>
       </titlePage>
       <div xml:id="U5-pref">
-	<head>Prefatory note</head>
-	<p>TEI Lite was the name adopted for what the TEI editors originally conceived of as a simple
-	demonstration of how the TEI (Text Encoding Initiative) encoding scheme might be adopted to
-	meet 90% of the needs of 90% of the TEI user community. In retrospect, it was predictable that
-	many people should imagine TEI Lite to be all there is to TEI, or find TEI Lite to be far too
-	heavy for their needs.</p>
-	<p>The original TEI Lite (1996) was based largely on observations of existing and previous
-	practice in the encoding of texts, particularly as manifest in the collections of the <ref target="http://ota.ahds.ac.uk/">Oxford Text Archive</ref> and other collections of the period.
-	It is therefore unsurprising that it seems to have become, if not a <foreign xml:lang="la">de
-	facto</foreign> standard, at least a common point of departure for electronic text centres and
-	encoding projects world wide. Maybe the fact that we actually produced this shortish, readable,
-	manual for it also helped.</p>
-	<p>Early adopters of TEI Lite included a number of <soCalled>Electronic Text Centers</soCalled>
-	<!-- , many
-	     of whom produced their own documentation and
-	     tutorial materials (some examples are listed in
-	     <ref target="http://www.tei-c.org/Tutorials/"> the
-	     TEI Tutorials pages</ref>)-->
-	and digital library initiatives. It was also adopted as the basis for some early TEI-conformant
-	authoring systems, and as the basis for introductory tutorials, many of them in languages other
-	than English (see further the list of legacy versions at <ptr target="http://www.tei-c.org/Vault/P4/Lite/"/>).</p>
-	<p>In 2002, following the publication of TEI P4, the XML version of the TEI Guidelines, which
-	uses the generation of TEI Lite as an example of the TEI modification mechanism, the
-	opportunity was taken to produce a lightly revised XML-conformant version. In 2006, a more
-	substantially revised version based on TEI P5 was produced; this reflected the many changes
-	between TEI P4 and TEI P5, but was not otherwise significantly different. In 2012, the TEI
-	Technical Council, decided that a final revision should be undertaken to ensure that the
-	documentation remained consistent with the latest (2.1) release of TEI P5. This version uses a
-	recently added mechanism in the TEI customization architecture, which permits a customization
-	to define only the TEI elements to be included in a schema, rather than the elements to be
-	excluded from it. As such it is probably more resilient to change than earlier versions. </p>
-	<trailer>Lou Burnard, August 2012</trailer>
+        <head>Prefatory note</head>
+        <p>TEI Lite was the name adopted for what the TEI editors originally conceived of as a simple
+        demonstration of how the TEI (Text Encoding Initiative) encoding scheme might be adopted to
+        meet 90% of the needs of 90% of the TEI user community. In retrospect, it was predictable that
+        many people should imagine TEI Lite to be all there is to TEI, or find TEI Lite to be far too
+        heavy for their needs.</p>
+        <p>The original TEI Lite (1996) was based largely on observations of existing and previous
+        practice in the encoding of texts, particularly as manifest in the collections of the <ref target="http://ota.ahds.ac.uk/">Oxford Text Archive</ref> and other collections of the period.
+        It is therefore unsurprising that it seems to have become, if not a <foreign xml:lang="la">de
+        facto</foreign> standard, at least a common point of departure for electronic text centres and
+        encoding projects world wide. Maybe the fact that we actually produced this shortish, readable,
+        manual for it also helped.</p>
+        <p>Early adopters of TEI Lite included a number of <soCalled>Electronic Text Centers</soCalled>
+        <!-- , many
+             of whom produced their own documentation and
+             tutorial materials (some examples are listed in
+             <ref target="http://www.tei-c.org/Tutorials/"> the
+             TEI Tutorials pages</ref>)-->
+        and digital library initiatives. It was also adopted as the basis for some early TEI-conformant
+        authoring systems, and as the basis for introductory tutorials, many of them in languages other
+        than English (see further the list of legacy versions at <ptr target="http://www.tei-c.org/Vault/P4/Lite/"/>).</p>
+        <p>In 2002, following the publication of TEI P4, the XML version of the TEI Guidelines, which
+        uses the generation of TEI Lite as an example of the TEI modification mechanism, the
+        opportunity was taken to produce a lightly revised XML-conformant version. In 2006, a more
+        substantially revised version based on TEI P5 was produced; this reflected the many changes
+        between TEI P4 and TEI P5, but was not otherwise significantly different. In 2012, the TEI
+        Technical Council, decided that a final revision should be undertaken to ensure that the
+        documentation remained consistent with the latest (2.1) release of TEI P5. This version uses a
+        recently added mechanism in the TEI customization architecture, which permits a customization
+        to define only the TEI elements to be included in a schema, rather than the elements to be
+        excluded from it. As such it is probably more resilient to change than earlier versions. </p>
+        <trailer>Lou Burnard, August 2012</trailer>
       </div>
     </front>
     <body>
@@ -151,240 +151,240 @@ $Id$
       and Interchange</title>, as of February 2006, and available from the TEI Consortium website at
       <ptr target="http://www.tei-c.org/"/>. </p>
       <div xml:id="U5-Intro">
-	<head>Introduction</head>
-	<p>The Text Encoding Initiative (TEI) Guidelines are addressed to anyone who wants to
-	interchange information stored in an electronic form. They emphasize the interchange of textual
-	information, but other forms of information such as images and sound are also addressed. The
-	Guidelines are equally applicable in the creation of new resources and in the interchange of
-	existing ones.</p>
-	<p>The Guidelines provide a means of making explicit certain features of a text in such a way as
-	to aid the processing of that text by computer software running on different machines. This
-	process of making explicit we call <term>markup</term> or <term>encoding</term>. Any textual
-	representation on a computer uses some form of markup; the TEI came into being partly because
-	of the enormous variety of mutually incomprehensible encoding schemes currently besetting
-	scholarship, and partly because of the expanding range of scholarly uses now being identified
-	for texts in electronic form.</p>
-	<p>The TEI Guidelines describe an encoding scheme which can be expressed using a number of
-	different formal languages. The first editions of the Guidelines used the <term>Standard
-	Generalized Markup Language</term> (SGML); since 2002, this has been replaced by the use of
-	the Extensible Markup Language (XML). These markup languages have in common the definition of
-	text in terms of <term>elements</term> and <term>attributes</term>, and rules governing their
-	appearance within a text. The TEI's use of XML is ambitious in its complexity and generality,
-	but it is fundamentally no different from that of any other XML markup scheme, and so any
-	general-purpose XML-aware software is able to process TEI-conformant texts.</p>
-	<p>Since 2001, the TEI has been a community initiative supported by an international membership
-	consortium. It was originally an international research project sponsored by the Association
-	for Computers and the Humanities, the Association for Computational Linguistics, and the
-	Association for Literary and Linguistic Computing, with substantial funding over its first five
-	years from the U.S. National Endowment for the Humanities, Directorate General XIII of the
-	Commission of the European Communities, the Andrew W. Mellon Foundation, the Social Science and
-	Humanities Research Council of Canada and others. The Guidelines were first published in May
-	1994, after six years of development involving many hundreds of scholars from different
-	academic disciplines worldwide. During the years that followed, the Guidelines became
-	increasingly influential in the development of the digital library, in the language industries,
-	and even in the development of the World Wide Web itself. The TEI Consortium was set up in
-	January 2001, and a year later produced an edition of the Guidelines entirely revised for XML
-	compatibility. In 2004, it set about a major revision of the Guidelines to take full advantage
-	of new schema languages, the first release of which appeared in 2005. This revision of the TEI
-	Lite document conforms to version 2.1 of this most recent edition of the Guidelines, TEI P5,
-	released in June 2012.</p>
-	<p>At the outset of its work, the overall goals of the TEI were defined by the closing statement
-	of a planning conference held at Vassar College, N.Y., in November, 1987; these
-	<soCalled>Poughkeepsie Principles</soCalled> were further elaborated in a series of design
-	documents. The Guidelines, say these design documents, should: <list>
-	<item>suffice to represent the textual features needed for research;</item>
-	<item>be simple, clear, and concrete;</item>
-	<item>be easy for researchers to use without special-purpose software;</item>
-	<item>allow the rigorous definition and efficient processing of texts;</item>
-	<item>provide for user-defined extensions;</item>
-	<item>conform to existing and emergent standards.</item>
+        <head>Introduction</head>
+        <p>The Text Encoding Initiative (TEI) Guidelines are addressed to anyone who wants to
+        interchange information stored in an electronic form. They emphasize the interchange of textual
+        information, but other forms of information such as images and sound are also addressed. The
+        Guidelines are equally applicable in the creation of new resources and in the interchange of
+        existing ones.</p>
+        <p>The Guidelines provide a means of making explicit certain features of a text in such a way as
+        to aid the processing of that text by computer software running on different machines. This
+        process of making explicit we call <term>markup</term> or <term>encoding</term>. Any textual
+        representation on a computer uses some form of markup; the TEI came into being partly because
+        of the enormous variety of mutually incomprehensible encoding schemes currently besetting
+        scholarship, and partly because of the expanding range of scholarly uses now being identified
+        for texts in electronic form.</p>
+        <p>The TEI Guidelines describe an encoding scheme which can be expressed using a number of
+        different formal languages. The first editions of the Guidelines used the <term>Standard
+        Generalized Markup Language</term> (SGML); since 2002, this has been replaced by the use of
+        the Extensible Markup Language (XML). These markup languages have in common the definition of
+        text in terms of <term>elements</term> and <term>attributes</term>, and rules governing their
+        appearance within a text. The TEI's use of XML is ambitious in its complexity and generality,
+        but it is fundamentally no different from that of any other XML markup scheme, and so any
+        general-purpose XML-aware software is able to process TEI-conformant texts.</p>
+        <p>Since 2001, the TEI has been a community initiative supported by an international membership
+        consortium. It was originally an international research project sponsored by the Association
+        for Computers and the Humanities, the Association for Computational Linguistics, and the
+        Association for Literary and Linguistic Computing, with substantial funding over its first five
+        years from the U.S. National Endowment for the Humanities, Directorate General XIII of the
+        Commission of the European Communities, the Andrew W. Mellon Foundation, the Social Science and
+        Humanities Research Council of Canada and others. The Guidelines were first published in May
+        1994, after six years of development involving many hundreds of scholars from different
+        academic disciplines worldwide. During the years that followed, the Guidelines became
+        increasingly influential in the development of the digital library, in the language industries,
+        and even in the development of the World Wide Web itself. The TEI Consortium was set up in
+        January 2001, and a year later produced an edition of the Guidelines entirely revised for XML
+        compatibility. In 2004, it set about a major revision of the Guidelines to take full advantage
+        of new schema languages, the first release of which appeared in 2005. This revision of the TEI
+        Lite document conforms to version 2.1 of this most recent edition of the Guidelines, TEI P5,
+        released in June 2012.</p>
+        <p>At the outset of its work, the overall goals of the TEI were defined by the closing statement
+        of a planning conference held at Vassar College, N.Y., in November, 1987; these
+        <soCalled>Poughkeepsie Principles</soCalled> were further elaborated in a series of design
+        documents. The Guidelines, say these design documents, should: <list>
+        <item>suffice to represent the textual features needed for research;</item>
+        <item>be simple, clear, and concrete;</item>
+        <item>be easy for researchers to use without special-purpose software;</item>
+        <item>allow the rigorous definition and efficient processing of texts;</item>
+        <item>provide for user-defined extensions;</item>
+        <item>conform to existing and emergent standards.</item>
       </list>
-	</p>
-	<p>The world of scholarship is large and diverse. For the Guidelines to have wide acceptability,
-	it was important to ensure that: <list type="ordered">
-	<item>the common core of textual features be easily shared;</item>
-	<item>additional specialist features be easy to add to (or remove from) a text;</item>
-	<item>multiple parallel encodings of the same feature should be possible;</item>
-	<item>the richness of markup should be user-defined, with a very small minimal
-	requirement;</item>
-	<item>adequate documentation of the text and its encoding should be provided.</item>
+        </p>
+        <p>The world of scholarship is large and diverse. For the Guidelines to have wide acceptability,
+        it was important to ensure that: <list type="ordered">
+        <item>the common core of textual features be easily shared;</item>
+        <item>additional specialist features be easy to add to (or remove from) a text;</item>
+        <item>multiple parallel encodings of the same feature should be possible;</item>
+        <item>the richness of markup should be user-defined, with a very small minimal
+        requirement;</item>
+        <item>adequate documentation of the text and its encoding should be provided.</item>
       </list>
-	</p>
-	<p>The present document describes a manageable selection from the extensive set of elements and
-	recommendations resulting from those design goals, which is called <title>TEI Lite</title>.</p>
-	<p>In selecting from the several hundred elements defined by the full TEI scheme, we have tried
-	to identify a useful <soCalled>starter set</soCalled>, comprising the elements which almost
-	every user should know about. Experience working with TEI Lite will be invaluable in
-	understanding the full TEI scheme and in knowing how to integrate specialized parts of it into
-	the general TEI framework.</p>
-	<p>Our goals in defining this subset may be summarized as follows: <list type="simple">
-	<item>it should be able to handle adequately a reasonably wide variety of texts, at the level
-	of detail found in existing practice (as demonstrated in, for example, the holdings of the
-	Oxford Text Archive);</item>
-	<item>it should be useful for the production of new documents (such as this one) as well as
-	the encoding of existing texts;</item>
-	<item>it should be usable with a wide range of existing XML software;</item>
-	<item>it should be a pure subset of the full TEI scheme and defined using the customizaticon
-	methods described in the TEI Guidelines;</item>
-	<item>it should be as small and simple as is consistent with the other goals.</item>
-	</list> The reader may judge our success in meeting these goals for him or herself.</p>
-	<p>Although we have tried to make this document self-contained, as suits a tutorial text, the
-	reader should be aware that it does not cover every detail of the TEI encoding scheme. All of
-	the elements described here are fully documented in the TEI Guidelines themselves, which should
-	be consulted for authoritative reference information on these, and on the many others which are
-	not described here. Some basic knowledge of XML is assumed.</p>
+        </p>
+        <p>The present document describes a manageable selection from the extensive set of elements and
+        recommendations resulting from those design goals, which is called <title>TEI Lite</title>.</p>
+        <p>In selecting from the several hundred elements defined by the full TEI scheme, we have tried
+        to identify a useful <soCalled>starter set</soCalled>, comprising the elements which almost
+        every user should know about. Experience working with TEI Lite will be invaluable in
+        understanding the full TEI scheme and in knowing how to integrate specialized parts of it into
+        the general TEI framework.</p>
+        <p>Our goals in defining this subset may be summarized as follows: <list type="simple">
+        <item>it should be able to handle adequately a reasonably wide variety of texts, at the level
+        of detail found in existing practice (as demonstrated in, for example, the holdings of the
+        Oxford Text Archive);</item>
+        <item>it should be useful for the production of new documents (such as this one) as well as
+        the encoding of existing texts;</item>
+        <item>it should be usable with a wide range of existing XML software;</item>
+        <item>it should be a pure subset of the full TEI scheme and defined using the customizaticon
+        methods described in the TEI Guidelines;</item>
+        <item>it should be as small and simple as is consistent with the other goals.</item>
+        </list> The reader may judge our success in meeting these goals for him or herself.</p>
+        <p>Although we have tried to make this document self-contained, as suits a tutorial text, the
+        reader should be aware that it does not cover every detail of the TEI encoding scheme. All of
+        the elements described here are fully documented in the TEI Guidelines themselves, which should
+        be consulted for authoritative reference information on these, and on the many others which are
+        not described here. Some basic knowledge of XML is assumed.</p>
       </div>
       <div xml:id="U5-eg">
-	<head>A Short Example</head>
-	<p>We begin with a short example, intended to show what happens when a passage of prose is typed
-	into a computer by someone with little sense of the purpose of mark-up, or the potential of
-	electronic texts. In an ideal world, such output might be generated by a very accurate optical
-	scanner. It attempts to be faithful to the appearance of the printed text, by retaining the
-	original line breaks, by introducing blanks to represent the layout of the original headings
-	and page breaks, and so forth. Where characters not available on the keyboard are needed (such
-	as the accented letter <mentioned>a</mentioned> in <mentioned>faàl</mentioned> or the long
-	dash), it attempts to mimic their appearance.</p>
-	<p>
-	  <eg xml:space="preserve">
-	    CHAPTER 38
-	    
-	    READER, I married him. A quiet wedding we had: he and I, the par-
-	    son and clerk, were alone present. When we got back from church, I
-	    went into the kitchen of the manor-house, where Mary was cooking
-	    the dinner, and John cleaning the knives, and I said --
-	    'Mary, I have been married to Mr Rochester this morning.' The
-	    housekeeper and her husband were of that decent, phlegmatic
-	    order of people, to whom one may at any time safely communicate a
-	    remarkable piece of news without incurring the danger of having
-	    one's ears pierced by some shrill ejaculation and subsequently stunned
-	    by a torrent of wordy wonderment. Mary did look up, and she did
-	    stare at me; the ladle with which she was basting a pair of chickens
-	    roasting at the fire, did for some three minutes hang suspended in air,
-	    and for the same space of time John's knives also had rest from the
-	    polishing process; but Mary, bending again over the roast, said only --
-	    'Have you, miss? Well, for sure!'
-	    A short time after she pursued, 'I seed you go out with the master,
-	    but I didn't know you were gone to church to be wed'; and she
-	    basted away. John, when I turned to him, was grinning from ear to
-	    ear.
-	    'I telled Mary how it would be,' he said: 'I knew what Mr Ed-
-	    ward' (John was an old servant, and had known his master when he
-	    was the cadet of the house, therefore he often gave him his Christian
-	    name) -- 'I knew what Mr Edward would do; and I was certain he
-	    would not wait long either: and he's done right, for aught I know. I
-	    wish you joy, miss!' and he politely pulled his forelock.
-	    'Thank you, John. Mr Rochester told me to give you and Mary
-	    this.'
-	    I put into his hand a five-pound note.  Without waiting to hear
-	    more, I left the kitchen. In passing the door of that sanctum some time
-	    after, I caught the words --
-	    'She'll happen do better for him nor ony o' t' grand ladies.' And
-	    again, 'If she ben't one o' th' handsomest, she's noan faa\l, and varry
-	    good-natured; and i' his een she's fair beautiful, onybody may see
-	    that.'
-	    I wrote to Moor House and to Cambridge immediately, to say what
-	    I had done: fully explaining also why I had thus acted. Diana and
-	    
-	    474
-	    
-	    JANE EYRE                      475
-	    
-	    Mary approved the step unreservedly. Diana announced that she
-	    would just give me time to get over the honeymoon, and then she
-	    would come and see me.
-	    'She had better not wait till then, Jane,' said Mr Rochester, when I
-	    read her letter to him; 'if she does, she will be too late, for our honey-
-	    moon will shine our life long: its beams will only fade over your
-	    grave or mine.'
-	    How St John received the news I don't know: he never answered
-	    the letter in which I communicated it: yet six months after he wrote
-	    to me, without, however, mentioning Mr Rochester's name or allud-
-	    ing to my marriage. His letter was then calm, and though very serious,
-	    kind. He has maintained a regular, though not very frequent correspond-
-	    ence ever since: he hopes I am happy, and trusts I am not of those who
-	    live without God in the world, and only mind earthly things.
-	    
-	  </eg>
-	</p>
-	<p>This transcription suffers from a number of shortcomings: <list>
-	<item>the page numbers and running titles are intermingled with the text in a way which makes
-	it difficult for software to disentangle them;</item>
-	<item>no distinction is made between single quotation marks and apostrophe, so it is difficult
-	to know exactly which passages are in direct speech;</item>
-	<item>the preservation of the copy text's hyphenation means that simple-minded search programs
-	will not find the broken words;</item>
-	<item>the accented letter in <mentioned>faàl</mentioned> and the long dash have been rendered
-	by ad hoc keying conventions which follow no standard pattern and will be processed correctly
-	only if the transcriber remembers to mention them in the documentation;</item>
-	<item>paragraph divisions are marked only by the use of white space, and hard carriage returns
-	have been introduced at the end of each line. Consequently, if the size of type used to print
-	the text changes, reformatting will be problematic.</item>
+        <head>A Short Example</head>
+        <p>We begin with a short example, intended to show what happens when a passage of prose is typed
+        into a computer by someone with little sense of the purpose of mark-up, or the potential of
+        electronic texts. In an ideal world, such output might be generated by a very accurate optical
+        scanner. It attempts to be faithful to the appearance of the printed text, by retaining the
+        original line breaks, by introducing blanks to represent the layout of the original headings
+        and page breaks, and so forth. Where characters not available on the keyboard are needed (such
+        as the accented letter <mentioned>a</mentioned> in <mentioned>faàl</mentioned> or the long
+        dash), it attempts to mimic their appearance.</p>
+        <p>
+          <eg xml:space="preserve">
+            CHAPTER 38
+            
+            READER, I married him. A quiet wedding we had: he and I, the par-
+            son and clerk, were alone present. When we got back from church, I
+            went into the kitchen of the manor-house, where Mary was cooking
+            the dinner, and John cleaning the knives, and I said --
+            'Mary, I have been married to Mr Rochester this morning.' The
+            housekeeper and her husband were of that decent, phlegmatic
+            order of people, to whom one may at any time safely communicate a
+            remarkable piece of news without incurring the danger of having
+            one's ears pierced by some shrill ejaculation and subsequently stunned
+            by a torrent of wordy wonderment. Mary did look up, and she did
+            stare at me; the ladle with which she was basting a pair of chickens
+            roasting at the fire, did for some three minutes hang suspended in air,
+            and for the same space of time John's knives also had rest from the
+            polishing process; but Mary, bending again over the roast, said only --
+            'Have you, miss? Well, for sure!'
+            A short time after she pursued, 'I seed you go out with the master,
+            but I didn't know you were gone to church to be wed'; and she
+            basted away. John, when I turned to him, was grinning from ear to
+            ear.
+            'I telled Mary how it would be,' he said: 'I knew what Mr Ed-
+            ward' (John was an old servant, and had known his master when he
+            was the cadet of the house, therefore he often gave him his Christian
+            name) -- 'I knew what Mr Edward would do; and I was certain he
+            would not wait long either: and he's done right, for aught I know. I
+            wish you joy, miss!' and he politely pulled his forelock.
+            'Thank you, John. Mr Rochester told me to give you and Mary
+            this.'
+            I put into his hand a five-pound note.  Without waiting to hear
+            more, I left the kitchen. In passing the door of that sanctum some time
+            after, I caught the words --
+            'She'll happen do better for him nor ony o' t' grand ladies.' And
+            again, 'If she ben't one o' th' handsomest, she's noan faa\l, and varry
+            good-natured; and i' his een she's fair beautiful, onybody may see
+            that.'
+            I wrote to Moor House and to Cambridge immediately, to say what
+            I had done: fully explaining also why I had thus acted. Diana and
+            
+            474
+            
+            JANE EYRE                      475
+            
+            Mary approved the step unreservedly. Diana announced that she
+            would just give me time to get over the honeymoon, and then she
+            would come and see me.
+            'She had better not wait till then, Jane,' said Mr Rochester, when I
+            read her letter to him; 'if she does, she will be too late, for our honey-
+            moon will shine our life long: its beams will only fade over your
+            grave or mine.'
+            How St John received the news I don't know: he never answered
+            the letter in which I communicated it: yet six months after he wrote
+            to me, without, however, mentioning Mr Rochester's name or allud-
+            ing to my marriage. His letter was then calm, and though very serious,
+            kind. He has maintained a regular, though not very frequent correspond-
+            ence ever since: he hopes I am happy, and trusts I am not of those who
+            live without God in the world, and only mind earthly things.
+            
+          </eg>
+        </p>
+        <p>This transcription suffers from a number of shortcomings: <list>
+        <item>the page numbers and running titles are intermingled with the text in a way which makes
+        it difficult for software to disentangle them;</item>
+        <item>no distinction is made between single quotation marks and apostrophe, so it is difficult
+        to know exactly which passages are in direct speech;</item>
+        <item>the preservation of the copy text's hyphenation means that simple-minded search programs
+        will not find the broken words;</item>
+        <item>the accented letter in <mentioned>faàl</mentioned> and the long dash have been rendered
+        by ad hoc keying conventions which follow no standard pattern and will be processed correctly
+        only if the transcriber remembers to mention them in the documentation;</item>
+        <item>paragraph divisions are marked only by the use of white space, and hard carriage returns
+        have been introduced at the end of each line. Consequently, if the size of type used to print
+        the text changes, reformatting will be problematic.</item>
       </list>
-	</p>
-	<p>We now present the same passage, as it might be encoded using the TEI Guidelines. As we shall
-	see, there are many ways in which this encoding could be extended, but as a minimum, the TEI
-	approach allows us to represent the following distinctions: <list>
-	<item>Paragraph and chapter divisions are now marked explicitly.</item>
-	<item>Apostrophes are distinguished from quotation marks; direct speech is explicitly
-	marked.</item>
-	<item>The accented letter and the long dash are correctly represented.</item>
-	<item>Page divisions have been marked with an empty <gi>pb</gi> element alone.</item>
-	<item>The lineation of the original has not been retained and words broken by typographic
-	accident at the end of a line have been re-assembled without comment.</item>
-	<item>For convenience of proof reading, a new line has been introduced at the start of each
-	paragraph, but the indentation is removed.</item>
+        </p>
+        <p>We now present the same passage, as it might be encoded using the TEI Guidelines. As we shall
+        see, there are many ways in which this encoding could be extended, but as a minimum, the TEI
+        approach allows us to represent the following distinctions: <list>
+        <item>Paragraph and chapter divisions are now marked explicitly.</item>
+        <item>Apostrophes are distinguished from quotation marks; direct speech is explicitly
+        marked.</item>
+        <item>The accented letter and the long dash are correctly represented.</item>
+        <item>Page divisions have been marked with an empty <gi>pb</gi> element alone.</item>
+        <item>The lineation of the original has not been retained and words broken by typographic
+        accident at the end of a line have been re-assembled without comment.</item>
+        <item>For convenience of proof reading, a new line has been introduced at the start of each
+        paragraph, but the indentation is removed.</item>
       </list>
       <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	<pb n="474"/>
-	<div type="chapter" n="38">
-	  <p>Reader, I married him. A quiet wedding we had: he and I, the parson and clerk, were alone
-	  present. When we got back from church, I went into the kitchen of the manor-house, where
-	  Mary was cooking the dinner, and John cleaning the knives, and I said —</p>
-	  <p>
-	    <q>Mary, I have been married to Mr Rochester this morning.</q> The housekeeper and her
-	    husband were of that decent, phlegmatic order of people, to whom one may at any time safely
-	    communicate a remarkable piece of news without incurring the danger of having one's ears
-	    pierced by some shrill ejaculation and subsequently stunned by a torrent of wordy
-	    wonderment. Mary did look up, and she did stare at me; the ladle with which she was basting
-	    a pair of chickens roasting at the fire, did for some three minutes hang suspended in air,
-	    and for the same space of time John's knives also had rest from the polishing process; but
-	  Mary, bending again over the roast, said only —</p>
-	  <p>
-	    <q>Have you, miss? Well, for sure!</q>
-	  </p>
-	  <p>A short time after she pursued, <q>I seed you go out with the master, but I didn't know
-	  you were gone to church to be wed</q>; and she basted away. John, when I turned to him, was
-	  grinning from ear to ear. <q>I telled Mary how it would be,</q> he said: <q>I knew what Mr
-	  Edward</q> (John was an old servant, and had known his master when he was the cadet of the
-	  house, therefore he often gave him his Christian name) — <q>I knew what Mr Edward would do;
-	  and I was certain he would not wait long either: and he's done right, for aught I know. I
-	  wish you joy, miss!</q> and he politely pulled his forelock.</p>
-	  <p>
-	    <q>Thank you, John. Mr Rochester told me to give you and Mary this.</q>
-	  </p>
-	  <p>I put into his hand a five-pound note. Without waiting to hear more, I left the kitchen.
-	  In passing the door of that sanctum some time after, I caught the words —</p>
-	  <p>
-	    <q>She'll happen do better for him nor ony o' t' grand ladies.</q> And again, <q>If she
-	    ben't one o' th' handsomest, she's noan faàl, and varry good-natured; and i' his een she's
-	    fair beautiful, onybody may see that.</q>
-	  </p>
-	  <p>I wrote to Moor House and to Cambridge immediately, to say what I had done: fully
-	  explaining also why I had thus acted. Diana and <pb n="475"/> Mary approved the step
-	  unreservedly. Diana announced that she would just give me time to get over the honeymoon,
-	  and then she would come and see me.</p>
-	  <p>
-	    <q>She had better not wait till then, Jane,</q> said Mr Rochester, when I read her letter
-	    to him; <q>if she does, she will be too late, for our honeymoon will shine our life long:
-	    its beams will only fade over your grave or mine.</q>
-	  </p>
-	  <p>How St John received the news I don't know: he never answered the letter in which I
-	  communicated it: yet six months after he wrote to me, without, however, mentioning Mr
-	  Rochester's name or alluding to my marriage. His letter was then calm, and though very
-	  serious, kind. He has maintained a regular, though not very frequent correspondence ever
-	  since: he hopes I am happy, and trusts I am not of those who live without God in the world,
-	  and only mind earthly things.</p>
-	</div>
+        <pb n="474"/>
+        <div type="chapter" n="38">
+          <p>Reader, I married him. A quiet wedding we had: he and I, the parson and clerk, were alone
+          present. When we got back from church, I went into the kitchen of the manor-house, where
+          Mary was cooking the dinner, and John cleaning the knives, and I said —</p>
+          <p>
+            <q>Mary, I have been married to Mr Rochester this morning.</q> The housekeeper and her
+            husband were of that decent, phlegmatic order of people, to whom one may at any time safely
+            communicate a remarkable piece of news without incurring the danger of having one's ears
+            pierced by some shrill ejaculation and subsequently stunned by a torrent of wordy
+            wonderment. Mary did look up, and she did stare at me; the ladle with which she was basting
+            a pair of chickens roasting at the fire, did for some three minutes hang suspended in air,
+            and for the same space of time John's knives also had rest from the polishing process; but
+          Mary, bending again over the roast, said only —</p>
+          <p>
+            <q>Have you, miss? Well, for sure!</q>
+          </p>
+          <p>A short time after she pursued, <q>I seed you go out with the master, but I didn't know
+          you were gone to church to be wed</q>; and she basted away. John, when I turned to him, was
+          grinning from ear to ear. <q>I telled Mary how it would be,</q> he said: <q>I knew what Mr
+          Edward</q> (John was an old servant, and had known his master when he was the cadet of the
+          house, therefore he often gave him his Christian name) — <q>I knew what Mr Edward would do;
+          and I was certain he would not wait long either: and he's done right, for aught I know. I
+          wish you joy, miss!</q> and he politely pulled his forelock.</p>
+          <p>
+            <q>Thank you, John. Mr Rochester told me to give you and Mary this.</q>
+          </p>
+          <p>I put into his hand a five-pound note. Without waiting to hear more, I left the kitchen.
+          In passing the door of that sanctum some time after, I caught the words —</p>
+          <p>
+            <q>She'll happen do better for him nor ony o' t' grand ladies.</q> And again, <q>If she
+            ben't one o' th' handsomest, she's noan faàl, and varry good-natured; and i' his een she's
+            fair beautiful, onybody may see that.</q>
+          </p>
+          <p>I wrote to Moor House and to Cambridge immediately, to say what I had done: fully
+          explaining also why I had thus acted. Diana and <pb n="475"/> Mary approved the step
+          unreservedly. Diana announced that she would just give me time to get over the honeymoon,
+          and then she would come and see me.</p>
+          <p>
+            <q>She had better not wait till then, Jane,</q> said Mr Rochester, when I read her letter
+            to him; <q>if she does, she will be too late, for our honeymoon will shine our life long:
+            its beams will only fade over your grave or mine.</q>
+          </p>
+          <p>How St John received the news I don't know: he never answered the letter in which I
+          communicated it: yet six months after he wrote to me, without, however, mentioning Mr
+          Rochester's name or alluding to my marriage. His letter was then calm, and though very
+          serious, kind. He has maintained a regular, though not very frequent correspondence ever
+          since: he hopes I am happy, and trusts I am not of those who live without God in the world,
+          and only mind earthly things.</p>
+        </div>
       </egXML>
     </p>
     <p>This particular encoding represents a set of choices or priorities. As a trivial example,
@@ -447,13 +447,13 @@ $Id$
     <TEI>
       <teiHeader><!-- [ TEI Header information ]  --></teiHeader>
       <text>
-	<front><!-- [ front matter ... ] -->
-	</front>
-	<body>
-	  <!-- [ body of text ... ]  -->
-	</body>
-	<back><!--  [ back matter ...  ] -->
-	</back>
+        <front><!-- [ front matter ... ] -->
+        </front>
+        <body>
+          <!-- [ body of text ... ]  -->
+        </body>
+        <back><!--  [ back matter ...  ] -->
+        </back>
       </text>
     </TEI>
   </egXML>
@@ -463,40 +463,40 @@ $Id$
     using an overall structure like this: <egXML xmlns="http://www.tei-c.org/ns/Examples">
     <TEI>
       <teiHeader>
-	<!--[ header information for the composite ]-->
+        <!--[ header information for the composite ]-->
       </teiHeader>
       <text>
-	<front>
-	  <!--[ front matter for the composite  ]-->
-	</front>
-	<group>
-	  <text>
-	    <front>
-	      <!--[ front matter of first text ]-->
-	    </front>
-	    <body>
-	      <!--[ body of first text  ]-->
-	    </body>
-	    <back>
-	      <!--[ back matter of first text ]-->
-	    </back>
-	  </text>
-	  <text>
-	    <front>
-	      <!--[ front matter of second text]-->
-	    </front>
-	    <body>
-	      <!--[ body of second text  ]-->
-	    </body>
-	    <back>
-	      <!--[ back matter of second text ]-->
-	    </back>
-	  </text>
-	  <!--[ more texts or groups of texts here ]-->
-	</group>
-	<back>
-	  <!--[ back matter for the composite  ]-->
-	</back>
+        <front>
+          <!--[ front matter for the composite  ]-->
+        </front>
+        <group>
+          <text>
+            <front>
+              <!--[ front matter of first text ]-->
+            </front>
+            <body>
+              <!--[ body of first text  ]-->
+            </body>
+            <back>
+              <!--[ back matter of first text ]-->
+            </back>
+          </text>
+          <text>
+            <front>
+              <!--[ front matter of second text]-->
+            </front>
+            <body>
+              <!--[ body of second text  ]-->
+            </body>
+            <back>
+              <!--[ back matter of second text ]-->
+            </back>
+          </text>
+          <!--[ more texts or groups of texts here ]-->
+        </group>
+        <back>
+          <!--[ back matter for the composite  ]-->
+        </back>
       </text>
     </TEI>
   </egXML>
@@ -505,18 +505,19 @@ $Id$
     Such a collection is known as a <term>TEI corpus</term>, and may itself have a header: <egXML xmlns="http://www.tei-c.org/ns/Examples">
     <teiCorpus>
       <teiHeader>
-      <!--[header information for the corpus]--></teiHeader>
+        <!--[header information for the corpus]-->
+      </teiHeader>
       <TEI>
-	<teiHeader><!--[header information for first text]--></teiHeader>
-	<text>
-	  <!--[first text in corpus]-->
-	</text>
+        <teiHeader><!--[header information for first text]--></teiHeader>
+        <text>
+          <!--[first text in corpus]-->
+        </text>
       </TEI>
       <TEI>
-	<teiHeader><!--[header information for second text]--></teiHeader>
-	<text>
-	  <!--[second text in corpus]-->
-	</text>
+        <teiHeader><!--[header information for second text]--></teiHeader>
+        <text>
+          <!--[second text in corpus]-->
+        </text>
       </TEI>
     </teiCorpus>
     </egXML> It is also possible to create a composite of corpora -- that is,
@@ -596,27 +597,27 @@ $Id$
       five books, each of which is divided into chapters, while some chapters are further subdivided
       into parts. We might define <att>xml:id</att> values for this structure as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <body>
-	<div xml:id="WN1" n="I" type="book">
-	  <div xml:id="WN101" n="I.1" type="chapter">
-	    <!-- ... -->
-	  </div>
-	  <div xml:id="WN102" n="I.2" type="chapter">
-	    <!-- ... -->
-	  </div>
-	  <!-- ... -->
-	  <div xml:id="WN110" n="I.10" type="chapter">
-	    <div xml:id="WN1101" n="I.10.1" type="part">
-	      <!-- ... -->
-	    </div>
-	    <div xml:id="WN1102" n="I.10.2" type="part">
-	      <!-- ... -->
-	    </div>
-	  </div>
-	  <!-- ... -->
-	</div>
-	<div xml:id="WN2" n="II" type="book">
-	  <!-- ... -->
-	</div>
+        <div xml:id="WN1" n="I" type="book">
+          <div xml:id="WN101" n="I.1" type="chapter">
+            <!-- ... -->
+          </div>
+          <div xml:id="WN102" n="I.2" type="chapter">
+            <!-- ... -->
+          </div>
+          <!-- ... -->
+          <div xml:id="WN110" n="I.10" type="chapter">
+            <div xml:id="WN1101" n="I.10.1" type="part">
+              <!-- ... -->
+            </div>
+            <div xml:id="WN1102" n="I.10.2" type="part">
+              <!-- ... -->
+            </div>
+          </div>
+          <!-- ... -->
+        </div>
+        <div xml:id="WN2" n="II" type="book">
+          <!-- ... -->
+        </div>
       </body>
     </egXML>
       </p>
@@ -626,19 +627,19 @@ $Id$
       where the chapters are numbered sequentially through the whole work, rather than within each
       book, one might use a scheme such as the following: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <body>
-	<div xml:id="TS01" n="1" type="volume">
-	  <div xml:id="TS011" n="1" type="chapter">
-	    <!-- ... -->
-	  </div>
-	  <div xml:id="TS012" n="2" type="chapter">
-	  <!-- ... --></div>
-	</div>
-	<div xml:id="TS02" n="2" type="volume">
-	  <div xml:id="TS021" n="3" type="chapter">
-	  <!-- ... --></div>
-	  <div xml:id="TS022" n="4" type="chapter">
-	  <!-- ... --></div>
-	</div>
+        <div xml:id="TS01" n="1" type="volume">
+          <div xml:id="TS011" n="1" type="chapter">
+            <!-- ... -->
+          </div>
+          <div xml:id="TS012" n="2" type="chapter">
+          <!-- ... --></div>
+        </div>
+        <div xml:id="TS02" n="2" type="volume">
+          <div xml:id="TS021" n="3" type="chapter">
+          <!-- ... --></div>
+          <div xml:id="TS022" n="4" type="chapter">
+          <!-- ... --></div>
+        </div>
       </body>
       </egXML> Here the work has two volumes, each containing two chapters. The chapters are
       numbered conventionally 1 to 4, but the <att>xml:id</att> values specified allow them to be
@@ -660,10 +661,10 @@ $Id$
       otherwise unrecoverable text it should always be included. For example, the start of Hardy's
       <title>Under the Greenwood Tree</title> might be encoded as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <div xml:id="UGT1" n="Winter" type="Part">
-	<div xml:id="UGT11" n="1" type="Chapter">
-	  <head>Mellstock-Lane</head>
-	  <p>To dwellers in a wood almost every species of tree ... </p>
-	</div>
+        <div xml:id="UGT11" n="1" type="Chapter">
+          <head>Mellstock-Lane</head>
+          <p>To dwellers in a wood almost every species of tree ... </p>
+        </div>
       </div>
     </egXML>
       </p>
@@ -684,22 +685,22 @@ $Id$
       <p>Here, for example, is the start of a poetic text in which verse lines and stanzas are
       tagged: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <lg n="I">
-	<l>I Sing the progresse of a
-	deathlesse soule,</l>
-	<l>Whom Fate, with God made, but doth not controule,</l>
-	<l>Plac'd in
-	most shapes; all times before the law</l>
-	<l>Yoak'd us, and when, and since, in this I
-	sing.</l>
-	<l>And the great world to his aged evening;</l>
-	<l>From infant morne, through manly
-	noone I draw.</l>
-	<l>What the gold Chaldee, of silver Persian saw,</l>
-	<l>Greeke brass, or
-	Roman iron, is in this one;</l>
-	<l>A worke t'out weare Seths pillars, bricke and
-	stone,</l>
-	<l>And (holy writs excepted) made to yeeld to none,</l>
+        <l>I Sing the progresse of a
+        deathlesse soule,</l>
+        <l>Whom Fate, with God made, but doth not controule,</l>
+        <l>Plac'd in
+        most shapes; all times before the law</l>
+        <l>Yoak'd us, and when, and since, in this I
+        sing.</l>
+        <l>And the great world to his aged evening;</l>
+        <l>From infant morne, through manly
+        noone I draw.</l>
+        <l>What the gold Chaldee, of silver Persian saw,</l>
+        <l>Greeke brass, or
+        Roman iron, is in this one;</l>
+        <l>A worke t'out weare Seths pillars, bricke and
+        stone,</l>
+        <l>And (holy writs excepted) made to yeeld to none,</l>
       </lg>
     </egXML>
       </p>
@@ -710,31 +711,31 @@ $Id$
       <p>Here is the end of a famous dramatic text, in which speeches and stage directions are
       marked: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <sp>
-	<speaker>Vladimir</speaker>
-	<p>Pull on your trousers.</p>
+        <speaker>Vladimir</speaker>
+        <p>Pull on your trousers.</p>
       </sp>
       <sp>
-	<speaker>Estragon</speaker>
-	<p>You want me to pull off my trousers?</p>
+        <speaker>Estragon</speaker>
+        <p>You want me to pull off my trousers?</p>
       </sp>
       <sp>
-	<speaker>Vladimir</speaker>
-	<p>Pull <emph>on</emph> your trousers.</p>
+        <speaker>Vladimir</speaker>
+        <p>Pull <emph>on</emph> your trousers.</p>
       </sp>
       <sp>
-	<speaker>Vladimir</speaker>
-	<p>
-	  <stage>(realizing his trousers are down)</stage>.
-	True</p>
+        <speaker>Vladimir</speaker>
+        <p>
+          <stage>(realizing his trousers are down)</stage>.
+        True</p>
       </sp>
       <stage>He pulls up his trousers</stage>
       <sp>
-	<speaker>Vladimir</speaker>
-	<p>Well? Shall we go?</p>
+        <speaker>Vladimir</speaker>
+        <p>Well? Shall we go?</p>
       </sp>
       <sp>
-	<speaker>Estragon</speaker>
-	<p>Yes, let's go.</p>
+        <speaker>Estragon</speaker>
+        <p>Yes, let's go.</p>
       </sp>
       <stage>They do not move.</stage>
     </egXML>
@@ -746,56 +747,56 @@ $Id$
       find that verse lines are split between speakers. The easiest way of encoding this is to use
       the <att>part</att> attribute to indicate that the lines so fragmented are incomplete : <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <div type="Act" n="I">
-	<head>ACT I</head>
-	<div type="Scene" n="1">
-	  <head>SCENE I</head>
-	  <stage rend="italic"> Enter Barnardo and Francisco, two Sentinels, at several doors</stage>
-	  <sp>
-	    <speaker>Barn</speaker>
-	    <l part="Y">Who's there?</l>
-	  </sp>
-	  <sp>
-	    <speaker>Fran</speaker>
-	    <l>Nay, answer me. Stand and unfold yourself.</l>
-	  </sp>
-	  <sp>
-	    <speaker>Barn</speaker>
-	    <l part="I">Long live the King!</l>
-	  </sp>
-	  <sp>
-	    <speaker>Fran</speaker>
-	    <l part="M">Barnardo?</l>
-	  </sp>
-	  <sp>
-	    <speaker>Barn</speaker>
-	    <l part="F">He.</l>
-	  </sp>
-	  <sp>
-	    <speaker>Fran</speaker>
-	    <l>You come most carefully upon your hour.</l>
-	  </sp>
-	  <!-- ... -->
-	</div>
+        <head>ACT I</head>
+        <div type="Scene" n="1">
+          <head>SCENE I</head>
+          <stage rend="italic"> Enter Barnardo and Francisco, two Sentinels, at several doors</stage>
+          <sp>
+            <speaker>Barn</speaker>
+            <l part="Y">Who's there?</l>
+          </sp>
+          <sp>
+            <speaker>Fran</speaker>
+            <l>Nay, answer me. Stand and unfold yourself.</l>
+          </sp>
+          <sp>
+            <speaker>Barn</speaker>
+            <l part="I">Long live the King!</l>
+          </sp>
+          <sp>
+            <speaker>Fran</speaker>
+            <l part="M">Barnardo?</l>
+          </sp>
+          <sp>
+            <speaker>Barn</speaker>
+            <l part="F">He.</l>
+          </sp>
+          <sp>
+            <speaker>Fran</speaker>
+            <l>You come most carefully upon your hour.</l>
+          </sp>
+          <!-- ... -->
+        </div>
       </div>
     </egXML>
       </p>
       <p>The same mechanism may be applied to stanzas which are divided between two speakers: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <div>
-	<sp>
-	  <speaker>First voice</speaker>
-	  <lg type="stanza" part="I">
-	    <l>But why drives on that ship so fast</l>
-	    <l>Withouten wave or wind?</l>
-	  </lg>
-	</sp>
-	<sp>
-	  <speaker>Second Voice</speaker>
-	  <lg part="F">
-	    <l>The air is cut away before.</l>
-	    <l>And closes from behind.</l>
-	  </lg>
-	</sp>
-	<!-- ... -->
+        <sp>
+          <speaker>First voice</speaker>
+          <lg type="stanza" part="I">
+            <l>But why drives on that ship so fast</l>
+            <l>Withouten wave or wind?</l>
+          </lg>
+        </sp>
+        <sp>
+          <speaker>Second Voice</speaker>
+          <lg part="F">
+            <l>The air is cut away before.</l>
+            <l>And closes from behind.</l>
+          </lg>
+        </sp>
+        <!-- ... -->
       </div>
     </egXML>
       </p>
@@ -803,32 +804,32 @@ $Id$
       were drama, as in the next example, which also demonstrates the use of the <att>who</att>
       attribute to bear a code identifying the speaker of the piece of dialogue concerned: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <div>
-	<sp who="#OPI">
-	  <speaker>The reverend Doctor Opimian</speaker>
-	  <p>I do not think I have named a single unpresentable fish.</p>
-	</sp>
-	<sp who="#GRM">
-	  <speaker>Mr Gryll</speaker>
-	  <p>Bream, Doctor: there is not much to be said for bream.</p>
-	</sp>
-	<sp who="#OPI">
-	  <speaker>The Reverend Doctor Opimian</speaker>
-	  <p>On the contrary, sir, I think there is much to be said for him. In the first
-	  place....</p>
-	  <p>Fish, Miss Gryll -- I could discourse to you on fish by the hour: but for the present I
-	  will forbear.</p>
-	</sp>
+        <sp who="#OPI">
+          <speaker>The reverend Doctor Opimian</speaker>
+          <p>I do not think I have named a single unpresentable fish.</p>
+        </sp>
+        <sp who="#GRM">
+          <speaker>Mr Gryll</speaker>
+          <p>Bream, Doctor: there is not much to be said for bream.</p>
+        </sp>
+        <sp who="#OPI">
+          <speaker>The Reverend Doctor Opimian</speaker>
+          <p>On the contrary, sir, I think there is much to be said for him. In the first
+          place....</p>
+          <p>Fish, Miss Gryll -- I could discourse to you on fish by the hour: but for the present I
+          will forbear.</p>
+        </sp>
       </div>
       </egXML> Here the <att>who</att> attribute values (<code>#OPI</code> etc.) are links,
       pointing to a list of the characters in the novel, each of which has an identifier: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <list>
-	<head>Characters in the novel</head>
-	<item xml:id="OPI">
-	<name>Dr Opimian</name> : named for the famous Roman fine wine</item>
-	<item xml:id="GRM">
-	  <name>Mr Gryll</name> : named for the mythical Gryllus, one of Ulysses'
-	  sailors transformed by Circe into a pig, who argues that he was happier in that state than
-	as a man</item>
+        <head>Characters in the novel</head>
+        <item xml:id="OPI">
+        <name>Dr Opimian</name> : named for the famous Roman fine wine</item>
+        <item xml:id="GRM">
+          <name>Mr Gryll</name> : named for the mythical Gryllus, one of Ulysses'
+          sailors transformed by Circe into a pig, who argues that he was happier in that state than
+        as a man</item>
       </list>
     </egXML>
       </p>
@@ -847,7 +848,7 @@ $Id$
     to simplify later proof-reading. It is also useful for synchronizing an encoded text with a set
     of page images. Recording the line breaks may be useful for similar reasons.
     <!--; treatment of end-of-line
-	hyphenation in printed source texts will require some consideration.--></p>
+        hyphenation in printed source texts will require some consideration.--></p>
     <p>If features such as pagination or lineation are marked for more than one edition, specify the
     edition in question using the <att>ed</att> attribute, and supply as many tags are necessary.
     For example, in the following passage we indicate where the page breaks occur in two different
@@ -901,8 +902,8 @@ $Id$
       <p>In the following example, the use of a distinct typeface for the subheading and for the
       included name are recorded but not interpreted: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <p>
-	<hi rend="gothic">And this Indenture further
-	witnesseth</hi> that the said <hi rend="italic">Walter Shandy</hi>, merchant, in
+        <hi rend="gothic">And this Indenture further
+        witnesseth</hi> that the said <hi rend="italic">Walter Shandy</hi>, merchant, in
       consideration of the said intended marriage ...</p>
     </egXML>
       </p>
@@ -963,8 +964,8 @@ $Id$
       <p>Direct speech interrupted by a narrator can be represented simply by ending the quotation
       and beginning it again after the interruption, as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <p>
-	<q>Who-e debel you?</q> — he at last said —
-	<q>you no speak-e, damme, I kill-e.</q> And so saying, the lighted tomahawk began
+        <q>Who-e debel you?</q> — he at last said —
+        <q>you no speak-e, damme, I kill-e.</q> And so saying, the lighted tomahawk began
       flourishing about me in the dark.</p>
       </egXML> If it is important to convey the idea that the
       two <gi>q</gi> elements together make up a single speech, the linking attributes
@@ -1000,7 +1001,7 @@ $Id$
       <p>Have you read <title xml:lang="de">Die
       Dreigroschenoper</title>?</p>
       <p>
-	<mentioned xml:lang="fr">Savoir-faire</mentioned> is French
+        <mentioned xml:lang="fr">Savoir-faire</mentioned> is French
       for know-how.</p>
       <p>The court issued a writ of <term xml:lang="la">mandamus</term>.</p>
     </egXML>
@@ -1017,34 +1018,34 @@ $Id$
       further explained in the relevant section of the TEI Guidelines. Some simple example codes for
       a few languages are given here: <table>
       <row>
-	<cell>zh</cell>
-	<cell>Chinese</cell>
-	<cell>grc</cell>
-	<cell>Ancient Greek</cell>
+        <cell>zh</cell>
+        <cell>Chinese</cell>
+        <cell>grc</cell>
+        <cell>Ancient Greek</cell>
       </row>
       <row>
-	<cell>en</cell>
-	<cell>English</cell>
-	<cell>el</cell>
-	<cell>Greek</cell>
+        <cell>en</cell>
+        <cell>English</cell>
+        <cell>el</cell>
+        <cell>Greek</cell>
       </row>
       <row>
-	<cell>enm</cell>
-	<cell>Middle English</cell>
-	<cell>ja</cell>
-	<cell>Japanese</cell>
+        <cell>enm</cell>
+        <cell>Middle English</cell>
+        <cell>ja</cell>
+        <cell>Japanese</cell>
       </row>
       <row>
-	<cell>fr</cell>
-	<cell>French</cell>
-	<cell>la</cell>
-	<cell>Latin</cell>
+        <cell>fr</cell>
+        <cell>French</cell>
+        <cell>la</cell>
+        <cell>Latin</cell>
       </row>
       <row>
-	<cell>de</cell>
-	<cell>German</cell>
-	<cell>sa</cell>
-	<cell>Sanskrit</cell>
+        <cell>de</cell>
+        <cell>German</cell>
+        <cell>sa</cell>
+        <cell>Sanskrit</cell>
       </row>
     </table>
       </p>
@@ -1178,34 +1179,34 @@ $Id$
       where the elements to be linked to do not bear identifiers and must therefore be located by
       some other means.
       <!--A full specification of the language is well beyond
-	  the scope of this document; here we provide only a flavour of its power. </p>
-	  <p>In the XPath language, locations are defined as a series of <term>steps</term>, each one
-	  identifying some part of the document, often in terms of the locations identified by the
-	  previous step. For example, you would point to the third sentence of the second paragraph of
-	  chapter two by selecting chapter two in the first step, the second paragraph in the second
-	  step, and the third sentence in the last step. A step can be defined in terms of the document
-	  tree itself, using such concepts as <val>parent</val>, <val>descendent</val>,
-	  <val>preceding</val>, etc. or, more loosely, in terms of text patterns, word or character
-	  positions. --></p>
+          the scope of this document; here we provide only a flavour of its power. </p>
+          <p>In the XPath language, locations are defined as a series of <term>steps</term>, each one
+          identifying some part of the document, often in terms of the locations identified by the
+          previous step. For example, you would point to the third sentence of the second paragraph of
+          chapter two by selecting chapter two in the first step, the second paragraph in the second
+          step, and the third sentence in the last step. A step can be defined in terms of the document
+          tree itself, using such concepts as <val>parent</val>, <val>descendent</val>,
+          <val>preceding</val>, etc. or, more loosely, in terms of text patterns, word or character
+          positions. --></p>
     </div>
     <div xml:id="xatts">
       <head>Special kinds of Linking</head>
       <p>The following special purpose <term>linking</term> attributes are defined for every element
       in the TEI Lite scheme: <list type="gloss">
       <label>
-	<att>ana</att>
+        <att>ana</att>
       </label>
       <item>links an element with its interpretation.</item>
       <label>
-	<att>corresp</att>
+        <att>corresp</att>
       </label>
       <item>links an element with one or more other corresponding elements.</item>
       <label>
-	<att>next</att>
+        <att>next</att>
       </label>
       <item>links an element to the next element in an aggregate.</item>
       <label>
-	<att>prev</att>
+        <att>prev</att>
       </label>
       <item>links an element to the previous element in an aggregate.</item>
     </list>
@@ -1215,9 +1216,9 @@ $Id$
       section <ptr target="#U5-anal"/>. For example, a linguistic analysis of the sentence <q>John
       loves Nancy</q> might be encoded as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <seg type="sentence" ana="SVO">
-	<seg type="lex" ana="#NP1">John</seg>
-	<seg type="lex" ana="#VVI">loves</seg>
-	<seg type="lex" ana="#NP1">Nancy</seg>
+        <seg type="lex" ana="#NP1">John</seg>
+        <seg type="lex" ana="#VVI">loves</seg>
+        <seg type="lex" ana="#NP1">Nancy</seg>
       </seg>
       </egXML> This encoding
       implies the existence elsewhere in the document of elements with identifiers <val>SVO</val>,
@@ -1237,9 +1238,9 @@ $Id$
       been used to represent the correspondences between <q rend="inline" type="inline">the
       show</q> and <q>Shirley</q>, and between <q>NBC</q> and <q>the network</q>: <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <p>
-	<title xml:id="shirley">Shirley</title>, which
-	made its Friday night debut only a month ago, was not listed on <name xml:id="nbc">NBC</name>'s new schedule, although <seg xml:id="network" corresp="#nbc">the network</seg>
-	says <seg xml:id="show" corresp="#shirley">the show</seg> still is being
+        <title xml:id="shirley">Shirley</title>, which
+        made its Friday night debut only a month ago, was not listed on <name xml:id="nbc">NBC</name>'s new schedule, although <seg xml:id="network" corresp="#nbc">the network</seg>
+        says <seg xml:id="show" corresp="#shirley">the show</seg> still is being
       considered.</p>
     </egXML>
       </p>
@@ -1251,1794 +1252,1794 @@ $Id$
     </div>
       </div>
       <div xml:id="U5-edit1">
-	<head>Editorial Interventions</head>
-	<p>The process of encoding an electronic text has much in common with the process of editing a
-	manuscript or other text for printed publication. In either case a conscientious editor may
-	wish to record both the original state of the source and any editorial correction or other
-	change made in it. The elements discussed in this and the next section provide some facilities
-	for meeting these needs.</p>
-	<div>
-	  <head>Correction and Normalization</head>
-	  <p>The following elements may be used to mark <term>correction</term>, that is editorial
-	  changes introduced where the editor believes the original to be erroneous: <specList>
-	  <specDesc key="corr"/>
-	  <specDesc key="sic"/>
-	</specList>
-	  </p>
-	  <p>The following elements may be used to mark <term>normalization</term>, that is editorial
-	  changes introduced for the sake of consistency or modernization of a text: <specList>
-	  <specDesc key="orig"/>
-	  <specDesc key="reg"/>
-	</specList>
-	  </p>
-	  <p>As an example, consider this extract from the quarto printing of Shakespeare's <title>Henry
-	  V</title>. <eg> ... for his nose was as sharp as a pen and a table of green feelds</eg>
-	  </p>
-	  <p>A modern editor might wish to make a number of interventions here, specifically to modernize
-	  (or normalise) the Elizabethan spellings of <mentioned>a'</mentioned> and
-	  <mentioned>feelds</mentioned> for <mentioned>he</mentioned> and <mentioned>fields</mentioned>
-	  respectively. He or she might also want to emend <mentioned>table</mentioned> to
-	  <mentioned>babbl'd</mentioned>, following an editorial tradition that goes back to the 18th
-	  century Shakespearian scholar Lewis Theobald. The following encoding would then be
-	  appropriate: <egXML xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as
-	  a pen and <reg>he</reg>
-	  <corr resp="#Theobald">babbl'd</corr> of green <reg>fields</reg>
-	</egXML>
-	  </p>
-	  <p>A more conservative or source-oriented editor, however, might want to retain the original,
-	  but at the same time signal that some of the readings it contains are in some sense anomalous:
-	  <egXML xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as a pen and
-	  <orig>a</orig>
-	  <sic>table</sic> of green <orig>feelds</orig>
-	  </egXML>
-	  </p>
-	  <p>Finally, a modern digital editor may decide to combine both possibilities in a single
-	  composite text, using the <gi>choice</gi> element. <specList>
-	  <specDesc key="choice"/>
-	  </specList> This allows an editor to mark where alternative readings are possible: <egXML xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as a pen and
-	  <choice>
-	    <orig>a</orig>
-	    <reg>he</reg>
-	  </choice>
-	  <choice>
-	    <corr resp="#Theobald">babbl'd</corr>
-	    <sic>table</sic>
-	    </choice> of green
-	    <choice>
-	      <orig>feelds</orig>
-	      <reg>fields</reg>
-	    </choice>
-	  </egXML>
-	  </p>
-	</div>
-	<div xml:id="U5-edit2">
-	  <head>Omissions, Deletions, and Additions</head>
-	  <p>In addition to correcting or normalizing words and phrases, editors and transcribers may
-	  also supply missing material, omit material, or transcribe material deleted or crossed out in
-	  the source. In addition, some material may be particularly hard to transcribe because it is
-	  hard to make out on the page. The following elements may be used to record such phenomena: <specList>
-	  <specDesc key="add"/>
-	  <specDesc key="gap"/>
-	  <specDesc key="del"/>
-	  <specDesc key="unclear"/>
-	</specList>
-	  </p>
-	  <p>These elements may be used to record changes made by an editor, by the transcriber, or (in
-	  manuscript material) by the author or scribe. For example, if the source for an electronic
-	  text read <q>The following elements are provided for for simple editorial interventions.</q>
-	  then it might be felt desirable to correct the obvious error, but at the same time to record
-	  the deletion of the superfluous second <mentioned>for</mentioned>, thus: <egXML xmlns="http://www.tei-c.org/ns/Examples">The following elements are provided for <del resp="#LB">for</del> simple editorial interventions.</egXML> The attribute value
-	  <code>#LB</code> on the <att>resp</att> attribute is used to point to a fuller definition
-	  (typically in a <gi>respStmt</gi> element) for the agency responsible for correcting the
-	  duplication of <mentioned>for</mentioned>.</p>
-	  <p>If the source read <q>The following elements provided for simple editorial
-	  interventions.</q> (i.e. if the verb had been inadvertently dropped) then the corrected text
-	  might read: <egXML xmlns="http://www.tei-c.org/ns/Examples">The following elements <add resp="#LB">are</add> provided for simple editorial interventions.</egXML>
-	  </p>
-	  <p>These elements are also used to record
-	  authorial changes in manuscripts. A manuscript in which the author has first written <q>How it
-	  galls me, what a galling shadow</q>, then crossed out the word <mentioned>galls</mentioned>
-	  and inserted <mentioned>dogs</mentioned> might be encoded thus: <egXML xmlns="http://www.tei-c.org/ns/Examples">How it <del hand="#DHL" type="overstrike">galls</del>
-	  <add hand="#DHL" place="supralinear">dogs</add> me, what a galling shadow</egXML> Again, the
-	  code <code>#DHL</code> points to another location where more information about the hand
-	  concerned is to be found<note place="foot">The full TEI provides a range of elements for
-	  encoding metadata about manuscript production and description, which are not however included
-	  in TEI Lite</note>. </p>
-	  <p>Similarly, the <gi>unclear</gi> and <gi>gap</gi> elements may be used together to indicate
-	  the omission of illegible material; the following example also shows the use of <gi>add</gi>
-	  for a conjectural emendation: <egXML xmlns="http://www.tei-c.org/ns/Examples">One hundred
-	  &amp; twenty good regulars joined to me <unclear>
-	  <gap reason="indecipherable"/>
-	</unclear>
-	&amp; instantly, would aid me signally <add hand="#ed">in?</add> an enterprise against
-	Wilmington.</egXML>
-	  </p>
-	  <p>The <gi>del</gi> element marks material which has been transcribed as part of the electronic text
-	  despite being marked as deleted, while <gi>gap</gi> marks the location of material which is
-	  omitted from the electronic text, whether it is legible or not. A language corpus, for
-	  example, might omit long quotations in foreign languages: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <p> ... An example of a list appearing in a fief
-	  ledger of <name type="place">Koldinghus</name>
-	  <date>1611/12</date> is given below. It shows cash income from a sale of
-	  honey.</p>
-	  <gap>
-	    <desc>quotation from ledger (in Danish)</desc>
-	  </gap>
-	  <p>A description of the
-	  overall structure of the account is once again ... </p>
-	</egXML>
-	  </p>
-	  <p>Other corpora (particular those constructed before the widespread use of scanners)
-	  systematically omit figures and mathematics: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <p>At the bottom of your screen below the mode line is the <term>minibuffer</term>. This is
-	  the area where Emacs echoes the commands you enter and where you specify filenames for Emacs
-	  to find, values for search and replace, and so on. <gap reason="graphic">
-	  <desc>diagram of
-	  Emacs screen</desc>
-	</gap>
-	  </p>
-	</egXML>
-	  </p>
-	  <p>The full TEI scheme provides more precise ways of capturing
-	  different aspects of  a transcription, distinguishing for example
-	  between text added or supplied by the encoder and text indicated as
-	  supplied or deleted in the source. TEI Lite does not provide different
-	  tags for these purposes.</p>
-	</div>
-	<div>
-	  <head>Abbreviations and their Expansion</head>
-	  <p>Like names, dates, and numbers, abbreviations may be transcribed as they stand or expanded;
-	  they may be left unmarked, or encoded using the following elements: <specList>
-	  <specDesc key="abbr"/>
-	  <specDesc key="expan"/>
-	</specList>
-	  </p>
-	  <p>The <gi>abbr</gi> element is useful as a means of distinguishing semi-lexical items such as
-	  acronyms or jargon: <egXML xmlns="http://www.tei-c.org/ns/Examples">We can sum up the above
-	  discussion as follows: the identity of a <abbr>CC</abbr> is defined by that calibration of
-	  values which motivates the elements of its <abbr>GSP</abbr>;</egXML>
-	  <egXML xmlns="http://www.tei-c.org/ns/Examples">Every manufacturer of <abbr>3GL</abbr> or
-	  <abbr>4GL</abbr> languages is currently nailing on <abbr>OOP</abbr> extensions</egXML>
-	  </p>
-	  <p>The <att>type</att> attribute may be used to distinguish types of abbreviation by their
-	  function. </p>
-	  <p>The <gi>expan</gi> element is used to mark an expansion supplied by an encoder. This element
-	  is particularly useful in the transcription of manuscript materials. For example, the
-	  character p with a bar through its descender as a conventional representation for the word
-	  <val>per</val> is commonly encountered in Medieval European manuscripts. An encoder may
-	  choose to expand this as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <expan>per</expan>
-	</egXML>
-	  </p>
-	  <p>The expansion corresponding with an abbreviated form may not always contain the same letters
-	  as the abbreviation. Where it does, however, common editorial practice is to italicize or
-	  otherwise signal which letters have been supplied. The <gi>expan</gi> element should not be
-	  used for this purpose since its function is to indicate an expanded form, not a part of one.
-	  For example, consider the common abbreviation <val>wt</val> (for <val>with</val>) found in
-	  medieval texts. In a modern edition, an editor might wish to represent this as <soCalled>w<hi rend="it">i</hi>t<hi rend="it">h</hi>
-	  </soCalled>, italicising the letters not found in the
-	  source. One simple means of achieving that would be an encoding such as the follow<egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <expan>w<hi rend="it">i</hi>t<hi rend="it">h</hi>
-	  </expan>
-	</egXML>
-	The full TEI also provides elements <gi>ex</gi> and <gi>am</gi>
-	for use in this situation, but these are not included in the TEI Lite
-	  schema.</p>
-	  <p>To record both an abbreviation and its expansion, the <gi>choice</gi> element mentioned
-	  above may be used to group the abbreviated form with its proposed expansion: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <choice>
-	    <abbr>wt</abbr>
-	    <expan>with</expan>
-	  </choice>
-	</egXML>
-	  </p>
-	</div>
+        <head>Editorial Interventions</head>
+        <p>The process of encoding an electronic text has much in common with the process of editing a
+        manuscript or other text for printed publication. In either case a conscientious editor may
+        wish to record both the original state of the source and any editorial correction or other
+        change made in it. The elements discussed in this and the next section provide some facilities
+        for meeting these needs.</p>
+        <div>
+          <head>Correction and Normalization</head>
+          <p>The following elements may be used to mark <term>correction</term>, that is editorial
+          changes introduced where the editor believes the original to be erroneous: <specList>
+          <specDesc key="corr"/>
+          <specDesc key="sic"/>
+        </specList>
+          </p>
+          <p>The following elements may be used to mark <term>normalization</term>, that is editorial
+          changes introduced for the sake of consistency or modernization of a text: <specList>
+          <specDesc key="orig"/>
+          <specDesc key="reg"/>
+        </specList>
+          </p>
+          <p>As an example, consider this extract from the quarto printing of Shakespeare's <title>Henry
+          V</title>. <eg> ... for his nose was as sharp as a pen and a table of green feelds</eg>
+          </p>
+          <p>A modern editor might wish to make a number of interventions here, specifically to modernize
+          (or normalise) the Elizabethan spellings of <mentioned>a'</mentioned> and
+          <mentioned>feelds</mentioned> for <mentioned>he</mentioned> and <mentioned>fields</mentioned>
+          respectively. He or she might also want to emend <mentioned>table</mentioned> to
+          <mentioned>babbl'd</mentioned>, following an editorial tradition that goes back to the 18th
+          century Shakespearian scholar Lewis Theobald. The following encoding would then be
+          appropriate: <egXML xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as
+          a pen and <reg>he</reg>
+          <corr resp="#Theobald">babbl'd</corr> of green <reg>fields</reg>
+        </egXML>
+          </p>
+          <p>A more conservative or source-oriented editor, however, might want to retain the original,
+          but at the same time signal that some of the readings it contains are in some sense anomalous:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as a pen and
+          <orig>a</orig>
+          <sic>table</sic> of green <orig>feelds</orig>
+          </egXML>
+          </p>
+          <p>Finally, a modern digital editor may decide to combine both possibilities in a single
+          composite text, using the <gi>choice</gi> element. <specList>
+          <specDesc key="choice"/>
+          </specList> This allows an editor to mark where alternative readings are possible: <egXML xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as a pen and
+          <choice>
+            <orig>a</orig>
+            <reg>he</reg>
+          </choice>
+          <choice>
+            <corr resp="#Theobald">babbl'd</corr>
+            <sic>table</sic>
+            </choice> of green
+            <choice>
+              <orig>feelds</orig>
+              <reg>fields</reg>
+            </choice>
+          </egXML>
+          </p>
+        </div>
+        <div xml:id="U5-edit2">
+          <head>Omissions, Deletions, and Additions</head>
+          <p>In addition to correcting or normalizing words and phrases, editors and transcribers may
+          also supply missing material, omit material, or transcribe material deleted or crossed out in
+          the source. In addition, some material may be particularly hard to transcribe because it is
+          hard to make out on the page. The following elements may be used to record such phenomena: <specList>
+          <specDesc key="add"/>
+          <specDesc key="gap"/>
+          <specDesc key="del"/>
+          <specDesc key="unclear"/>
+        </specList>
+          </p>
+          <p>These elements may be used to record changes made by an editor, by the transcriber, or (in
+          manuscript material) by the author or scribe. For example, if the source for an electronic
+          text read <q>The following elements are provided for for simple editorial interventions.</q>
+          then it might be felt desirable to correct the obvious error, but at the same time to record
+          the deletion of the superfluous second <mentioned>for</mentioned>, thus: <egXML xmlns="http://www.tei-c.org/ns/Examples">The following elements are provided for <del resp="#LB">for</del> simple editorial interventions.</egXML> The attribute value
+          <code>#LB</code> on the <att>resp</att> attribute is used to point to a fuller definition
+          (typically in a <gi>respStmt</gi> element) for the agency responsible for correcting the
+          duplication of <mentioned>for</mentioned>.</p>
+          <p>If the source read <q>The following elements provided for simple editorial
+          interventions.</q> (i.e. if the verb had been inadvertently dropped) then the corrected text
+          might read: <egXML xmlns="http://www.tei-c.org/ns/Examples">The following elements <add resp="#LB">are</add> provided for simple editorial interventions.</egXML>
+          </p>
+          <p>These elements are also used to record
+          authorial changes in manuscripts. A manuscript in which the author has first written <q>How it
+          galls me, what a galling shadow</q>, then crossed out the word <mentioned>galls</mentioned>
+          and inserted <mentioned>dogs</mentioned> might be encoded thus: <egXML xmlns="http://www.tei-c.org/ns/Examples">How it <del hand="#DHL" type="overstrike">galls</del>
+          <add hand="#DHL" place="supralinear">dogs</add> me, what a galling shadow</egXML> Again, the
+          code <code>#DHL</code> points to another location where more information about the hand
+          concerned is to be found<note place="foot">The full TEI provides a range of elements for
+          encoding metadata about manuscript production and description, which are not however included
+          in TEI Lite</note>. </p>
+          <p>Similarly, the <gi>unclear</gi> and <gi>gap</gi> elements may be used together to indicate
+          the omission of illegible material; the following example also shows the use of <gi>add</gi>
+          for a conjectural emendation: <egXML xmlns="http://www.tei-c.org/ns/Examples">One hundred
+          &amp; twenty good regulars joined to me <unclear>
+          <gap reason="indecipherable"/>
+        </unclear>
+        &amp; instantly, would aid me signally <add hand="#ed">in?</add> an enterprise against
+        Wilmington.</egXML>
+          </p>
+          <p>The <gi>del</gi> element marks material which has been transcribed as part of the electronic text
+          despite being marked as deleted, while <gi>gap</gi> marks the location of material which is
+          omitted from the electronic text, whether it is legible or not. A language corpus, for
+          example, might omit long quotations in foreign languages: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <p> ... An example of a list appearing in a fief
+          ledger of <name type="place">Koldinghus</name>
+          <date>1611/12</date> is given below. It shows cash income from a sale of
+          honey.</p>
+          <gap>
+            <desc>quotation from ledger (in Danish)</desc>
+          </gap>
+          <p>A description of the
+          overall structure of the account is once again ... </p>
+        </egXML>
+          </p>
+          <p>Other corpora (particular those constructed before the widespread use of scanners)
+          systematically omit figures and mathematics: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <p>At the bottom of your screen below the mode line is the <term>minibuffer</term>. This is
+          the area where Emacs echoes the commands you enter and where you specify filenames for Emacs
+          to find, values for search and replace, and so on. <gap reason="graphic">
+          <desc>diagram of
+          Emacs screen</desc>
+        </gap>
+          </p>
+        </egXML>
+          </p>
+          <p>The full TEI scheme provides more precise ways of capturing
+          different aspects of  a transcription, distinguishing for example
+          between text added or supplied by the encoder and text indicated as
+          supplied or deleted in the source. TEI Lite does not provide different
+          tags for these purposes.</p>
+        </div>
+        <div>
+          <head>Abbreviations and their Expansion</head>
+          <p>Like names, dates, and numbers, abbreviations may be transcribed as they stand or expanded;
+          they may be left unmarked, or encoded using the following elements: <specList>
+          <specDesc key="abbr"/>
+          <specDesc key="expan"/>
+        </specList>
+          </p>
+          <p>The <gi>abbr</gi> element is useful as a means of distinguishing semi-lexical items such as
+          acronyms or jargon: <egXML xmlns="http://www.tei-c.org/ns/Examples">We can sum up the above
+          discussion as follows: the identity of a <abbr>CC</abbr> is defined by that calibration of
+          values which motivates the elements of its <abbr>GSP</abbr>;</egXML>
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">Every manufacturer of <abbr>3GL</abbr> or
+          <abbr>4GL</abbr> languages is currently nailing on <abbr>OOP</abbr> extensions</egXML>
+          </p>
+          <p>The <att>type</att> attribute may be used to distinguish types of abbreviation by their
+          function. </p>
+          <p>The <gi>expan</gi> element is used to mark an expansion supplied by an encoder. This element
+          is particularly useful in the transcription of manuscript materials. For example, the
+          character p with a bar through its descender as a conventional representation for the word
+          <val>per</val> is commonly encountered in Medieval European manuscripts. An encoder may
+          choose to expand this as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <expan>per</expan>
+        </egXML>
+          </p>
+          <p>The expansion corresponding with an abbreviated form may not always contain the same letters
+          as the abbreviation. Where it does, however, common editorial practice is to italicize or
+          otherwise signal which letters have been supplied. The <gi>expan</gi> element should not be
+          used for this purpose since its function is to indicate an expanded form, not a part of one.
+          For example, consider the common abbreviation <val>wt</val> (for <val>with</val>) found in
+          medieval texts. In a modern edition, an editor might wish to represent this as <soCalled>w<hi rend="it">i</hi>t<hi rend="it">h</hi>
+          </soCalled>, italicising the letters not found in the
+          source. One simple means of achieving that would be an encoding such as the follow<egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <expan>w<hi rend="it">i</hi>t<hi rend="it">h</hi>
+          </expan>
+        </egXML>
+        The full TEI also provides elements <gi>ex</gi> and <gi>am</gi>
+        for use in this situation, but these are not included in the TEI Lite
+          schema.</p>
+          <p>To record both an abbreviation and its expansion, the <gi>choice</gi> element mentioned
+          above may be used to group the abbreviated form with its proposed expansion: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <choice>
+            <abbr>wt</abbr>
+            <expan>with</expan>
+          </choice>
+        </egXML>
+          </p>
+        </div>
       </div>
       <div xml:id="U5-names">
-	<head>Names, Dates, and Numbers</head>
-	<p>The TEI scheme defines elements for a large number of <soCalled>data-like</soCalled> features
-	which may appear almost anywhere within almost any kind of text. These features may be of
-	particular interest in a range of disciplines; they all relate to objects external to the text
-	itself, such as the names of persons and places, numbers and dates. They also pose particular
-	problems for many natural language processing (NLP) applications because of the variety of ways
-	in which they may be presented within a text. The elements described here, by making such
-	features explicit, reduce the complexity of processing texts containing them.</p>
-	<div xml:id="nomen">
-	  <head>Names and Referring Strings</head>
-	  <p>A <term>referring string</term> is a phrase which refers to some person, place, object, etc.
-	  Two elements are provided to mark such strings: <specList>
-	  <specDesc key="rs"/>
-	  <specDesc key="name"/>
-	</specList>
-	  </p>
-	  <p> The <att>type</att> attribute is used to distinguish amongst (for example) names of
-	  persons, places and organizations, where this is possible: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <q>My dear <rs type="person">Mr. Bennet</rs>, </q>
-	  said his lady to him one day, <q>have you heard that <rs type="place">Netherfield Park</rs>
-	  is let at last?</q>
-	</egXML>
-	<egXML xmlns="http://www.tei-c.org/ns/Examples">It being one of the principles of the <rs type="organization">Circumlocution Office</rs> never, on any account whatsoever, to give a
-	straightforward answer, <rs type="person">Mr Barnacle</rs> said, <q>Possibly.</q>
-	</egXML>
-	  </p>
-	  <p>As the following example shows, the <gi>rs</gi> element may be used for any reference to a
-	  person, place, etc, not necessarily one in the form of a proper noun or noun phrase. <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <q>My dear <rs type="person">Mr. Bennet</rs>,</q>
-	  said <rs type="person">his lady</rs> to him one day...</egXML>
-	  </p>
-	  <p>The <gi>name</gi> element by contrast is provided for the special case of referencing
-	  strings which consist only of proper nouns; it may be used synonymously with the <gi>rs</gi>
-	  element, or nested within it if a referring string contains a mixture of common and proper
-	  nouns.</p>
-	  <p>Simply tagging something as a name is rarely enough to enable automatic processing of
-	  personal names into the canonical forms usually required for reference purposes. The name as
-	  it appears in the text may be inconsistently spelled, partial, or vague. Moreover, name
-	  prefixes such as <mentioned>van</mentioned> or <mentioned>de la</mentioned>, may or may not be
-	  included as part of the reference form of a name, depending on the language and country of
-	  origin of the bearer.</p>
-	  <p>The <att>key</att> attribute provides an alternative normalized identifier for the object
-	  being named, like a database record key. It may thus be useful as a means of gathering
-	  together all references to the same individual or location scattered throughout a document:
-	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <q>My dear <rs type="person" key="BENM1">Mr.
-	    Bennet</rs>, </q> said <rs type="person" key="BENM2">his lady</rs> to him one day, <q>have
-	    you heard that <rs type="place" key="NETP1">Netherfield Park</rs> is let at
-	    last?</q>
-	  </egXML>
-	  </p>
-	  <p>This use should be distinguished from the case of the <gi>reg</gi> (regularization) element,
-	  which provides a means of marking the standard form of a referencing string as demonstrated
-	  below: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <name type="person" key="WADLM1">
-	    <choice>
-	      <sic>Walter de la Mare</sic>
-	      <reg>de la Mare, Walter</reg>
-	    </choice>
-	    </name> was
-	    born at <name key="Ch1" type="place">Charlton</name>, in <name key="KT1" type="county">Kent</name>, in 1873.</egXML>
-	  </p>
-	  <p>The <gi>index</gi> element discussed in <ptr target="indexing"/> may be more appropriate if
-	  the function of the regularization is to provide a consistent index: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <p>
-	    <name type="place">Montaillou</name> is not a
-	    large parish. At the time of the events which led to <name type="person">Fournier</name>'s
-	    <index>
-	      <term>Benedict XII, Pope of Avignon (Jacques Fournier)</term>
-	    </index>
-	    investigations, the local population consisted of between 200 and 250
-	  inhabitants.</p>
-	  </egXML> Although adequate for many simple applications, these methods have
-	  two inconveniences: if the name occurs many times, then its regularised form must be repeated
-	  many times; and the burden of additional XML markup in the body of the text may be
-	  inconvenient to maintain and complex to process. For applications such as onomastics, relating
-	  to persons or places named rather than the name itself, or wherever a detailed analysis of the
-	  component parts of a name is needed, the full TEI Guidelines provide a range of other
-	  solutions.</p>
-	</div>
-	<div>
-	  <head>Dates and Times</head>
-	  <p>Tags for the more detailed encoding of times and dates include the following: <specList>
-	  <specDesc key="date"/>
-	  <specDesc key="time"/>
-	</specList>
-	  </p>
-	  <p>These elements have a number of attributes which can be used to provide normalised versions
-	  of their values. <specList>
-	  <specDesc key="att.datable" atts="period when"/>
-	  </specList> The <att>when</att>
-	  attribute specifies a normalized form for the date or time, using one of the standard formats
-	  defined by ISO 8601. Partial dates or times (e.g. <q>1990</q>, <q>September 1990</q>,
-	  <q>twelvish</q>) can be expressed by omitting a part of the value supplied, as in the
-	  following examples: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <date when="1980-02-21">21
-	  Feb 1980</date>
-	  <date when="1990">1990</date>
-	  <date when="1990-09">September 1990</date>
-	  <date when="--09">September</date>
-	  <date when="2001-09-11T12:48:00">Sept 11th, 12 minutes before 9
-	  am</date>
-	  </egXML>Note in the last example the use of a normalized representation for the
-	  date string which includes a time: this example could thus equally well be tagged using the
-	  <gi>time</gi> element. </p>
-	  <p>
-	    <egXML xmlns="http://www.tei-c.org/ns/Examples">Given on the <date when="1977-06-12">Twelfth
-	    Day of June in the Year of Our Lord One Thousand Nine Hundred and Seventy-seven of the
-	    Republic the Two Hundredth and first and of the University the Eighty-Sixth.</date>
-	    </egXML>
-	    <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	      <l>specially when it's nine below zero</l>
-	      <l>and <time when="15:00:00">three o'clock in the afternoon</time>
-	      </l>
-	    </egXML>
-	  </p>
-	</div>
-	<div>
-	  <head>Numbers </head>
-	  <p>Numbers can be written with either letters or digits (<code>twenty-one</code>,
-	  <code>xxi</code>, and <code>21</code>) and their presentation is language-dependent (e.g.
-	  English <mentioned>5th</mentioned> becomes Greek <mentioned>5.</mentioned>; English
-	  <mentioned>123,456.78</mentioned> equals French <mentioned>123.456,78</mentioned>). In
-	  natural-language processing or machine-translation applications, it is often helpful to
-	  distinguish them from other, more <soCalled>lexical</soCalled> parts of the text. In other
-	  applications, the ability to record a number's value in standard notation is important. The
-	  <gi>num</gi> element provides this possibility: <specList>
-	  <specDesc key="num"/>
-	</specList>
-	  </p>
-	  <p>For example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <num value="33">xxxiii</num>
-	  <num type="cardinal" value="21">twenty-one</num>
-	  <num type="percentage" value="10">ten percent</num>
-	  <num type="percentage" value="10">10%</num>
-	  <num type="ordinal" value="5">5th</num>
-	</egXML>
-	  </p>
-	</div>
+        <head>Names, Dates, and Numbers</head>
+        <p>The TEI scheme defines elements for a large number of <soCalled>data-like</soCalled> features
+        which may appear almost anywhere within almost any kind of text. These features may be of
+        particular interest in a range of disciplines; they all relate to objects external to the text
+        itself, such as the names of persons and places, numbers and dates. They also pose particular
+        problems for many natural language processing (NLP) applications because of the variety of ways
+        in which they may be presented within a text. The elements described here, by making such
+        features explicit, reduce the complexity of processing texts containing them.</p>
+        <div xml:id="nomen">
+          <head>Names and Referring Strings</head>
+          <p>A <term>referring string</term> is a phrase which refers to some person, place, object, etc.
+          Two elements are provided to mark such strings: <specList>
+          <specDesc key="rs"/>
+          <specDesc key="name"/>
+        </specList>
+          </p>
+          <p> The <att>type</att> attribute is used to distinguish amongst (for example) names of
+          persons, places and organizations, where this is possible: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <q>My dear <rs type="person">Mr. Bennet</rs>, </q>
+          said his lady to him one day, <q>have you heard that <rs type="place">Netherfield Park</rs>
+          is let at last?</q>
+        </egXML>
+        <egXML xmlns="http://www.tei-c.org/ns/Examples">It being one of the principles of the <rs type="organization">Circumlocution Office</rs> never, on any account whatsoever, to give a
+        straightforward answer, <rs type="person">Mr Barnacle</rs> said, <q>Possibly.</q>
+        </egXML>
+          </p>
+          <p>As the following example shows, the <gi>rs</gi> element may be used for any reference to a
+          person, place, etc, not necessarily one in the form of a proper noun or noun phrase. <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <q>My dear <rs type="person">Mr. Bennet</rs>,</q>
+          said <rs type="person">his lady</rs> to him one day...</egXML>
+          </p>
+          <p>The <gi>name</gi> element by contrast is provided for the special case of referencing
+          strings which consist only of proper nouns; it may be used synonymously with the <gi>rs</gi>
+          element, or nested within it if a referring string contains a mixture of common and proper
+          nouns.</p>
+          <p>Simply tagging something as a name is rarely enough to enable automatic processing of
+          personal names into the canonical forms usually required for reference purposes. The name as
+          it appears in the text may be inconsistently spelled, partial, or vague. Moreover, name
+          prefixes such as <mentioned>van</mentioned> or <mentioned>de la</mentioned>, may or may not be
+          included as part of the reference form of a name, depending on the language and country of
+          origin of the bearer.</p>
+          <p>The <att>key</att> attribute provides an alternative normalized identifier for the object
+          being named, like a database record key. It may thus be useful as a means of gathering
+          together all references to the same individual or location scattered throughout a document:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <q>My dear <rs type="person" key="BENM1">Mr.
+            Bennet</rs>, </q> said <rs type="person" key="BENM2">his lady</rs> to him one day, <q>have
+            you heard that <rs type="place" key="NETP1">Netherfield Park</rs> is let at
+            last?</q>
+          </egXML>
+          </p>
+          <p>This use should be distinguished from the case of the <gi>reg</gi> (regularization) element,
+          which provides a means of marking the standard form of a referencing string as demonstrated
+          below: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <name type="person" key="WADLM1">
+            <choice>
+              <sic>Walter de la Mare</sic>
+              <reg>de la Mare, Walter</reg>
+            </choice>
+            </name> was
+            born at <name key="Ch1" type="place">Charlton</name>, in <name key="KT1" type="county">Kent</name>, in 1873.</egXML>
+          </p>
+          <p>The <gi>index</gi> element discussed in <ptr target="indexing"/> may be more appropriate if
+          the function of the regularization is to provide a consistent index: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <p>
+            <name type="place">Montaillou</name> is not a
+            large parish. At the time of the events which led to <name type="person">Fournier</name>'s
+            <index>
+              <term>Benedict XII, Pope of Avignon (Jacques Fournier)</term>
+            </index>
+            investigations, the local population consisted of between 200 and 250
+          inhabitants.</p>
+          </egXML> Although adequate for many simple applications, these methods have
+          two inconveniences: if the name occurs many times, then its regularised form must be repeated
+          many times; and the burden of additional XML markup in the body of the text may be
+          inconvenient to maintain and complex to process. For applications such as onomastics, relating
+          to persons or places named rather than the name itself, or wherever a detailed analysis of the
+          component parts of a name is needed, the full TEI Guidelines provide a range of other
+          solutions.</p>
+        </div>
+        <div>
+          <head>Dates and Times</head>
+          <p>Tags for the more detailed encoding of times and dates include the following: <specList>
+          <specDesc key="date"/>
+          <specDesc key="time"/>
+        </specList>
+          </p>
+          <p>These elements have a number of attributes which can be used to provide normalised versions
+          of their values. <specList>
+          <specDesc key="att.datable" atts="period when"/>
+          </specList> The <att>when</att>
+          attribute specifies a normalized form for the date or time, using one of the standard formats
+          defined by ISO 8601. Partial dates or times (e.g. <q>1990</q>, <q>September 1990</q>,
+          <q>twelvish</q>) can be expressed by omitting a part of the value supplied, as in the
+          following examples: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <date when="1980-02-21">21
+          Feb 1980</date>
+          <date when="1990">1990</date>
+          <date when="1990-09">September 1990</date>
+          <date when="--09">September</date>
+          <date when="2001-09-11T12:48:00">Sept 11th, 12 minutes before 9
+          am</date>
+          </egXML>Note in the last example the use of a normalized representation for the
+          date string which includes a time: this example could thus equally well be tagged using the
+          <gi>time</gi> element. </p>
+          <p>
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">Given on the <date when="1977-06-12">Twelfth
+            Day of June in the Year of Our Lord One Thousand Nine Hundred and Seventy-seven of the
+            Republic the Two Hundredth and first and of the University the Eighty-Sixth.</date>
+            </egXML>
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <l>specially when it's nine below zero</l>
+              <l>and <time when="15:00:00">three o'clock in the afternoon</time>
+              </l>
+            </egXML>
+          </p>
+        </div>
+        <div>
+          <head>Numbers </head>
+          <p>Numbers can be written with either letters or digits (<code>twenty-one</code>,
+          <code>xxi</code>, and <code>21</code>) and their presentation is language-dependent (e.g.
+          English <mentioned>5th</mentioned> becomes Greek <mentioned>5.</mentioned>; English
+          <mentioned>123,456.78</mentioned> equals French <mentioned>123.456,78</mentioned>). In
+          natural-language processing or machine-translation applications, it is often helpful to
+          distinguish them from other, more <soCalled>lexical</soCalled> parts of the text. In other
+          applications, the ability to record a number's value in standard notation is important. The
+          <gi>num</gi> element provides this possibility: <specList>
+          <specDesc key="num"/>
+        </specList>
+          </p>
+          <p>For example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <num value="33">xxxiii</num>
+          <num type="cardinal" value="21">twenty-one</num>
+          <num type="percentage" value="10">ten percent</num>
+          <num type="percentage" value="10">10%</num>
+          <num type="ordinal" value="5">5th</num>
+        </egXML>
+          </p>
+        </div>
       </div>
       <div xml:id="U5-lists">
-	<head>Lists</head>
-	<p>The element <gi>list</gi> is used to mark any kind of <term>list</term>. A list is a sequence
-	of text items, which may be numbered, bulleted, or arranged as a glossary list. Each item may be preceded
-	by an item label (in a glossary list, this label is the term being defined): <specList>
-	<specDesc key="list"/>
-	<specDesc key="item"/>
-	<specDesc key="label"/>
+        <head>Lists</head>
+        <p>The element <gi>list</gi> is used to mark any kind of <term>list</term>. A list is a sequence
+        of text items, which may be numbered, bulleted, or arranged as a glossary list. Each item may be preceded
+        by an item label (in a glossary list, this label is the term being defined): <specList>
+        <specDesc key="list"/>
+        <specDesc key="item"/>
+        <specDesc key="label"/>
       </specList>
-	</p>
-	<p>Individual list items are tagged with <gi>item</gi>. The first <gi>item</gi> may optionally
-	be preceded by a <gi>head</gi>, which gives a heading for the list. The numbering of a list may
-	be omitted, indicated using the <att>n</att> attribute on each item, or (rarely) tagged as
-	content using the <gi>label</gi> element. The following are all thus equivalent: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	<list>
-	  <head>A short list</head>
-	  <item>First item in list.</item>
-	  <item>Second item in list.</item>
-	  <item>Third item in list.</item>
-	</list>
-	<list>
-	  <head>A short list</head>
-	  <item n="1">First item in list.</item>
-	  <item n="2">Second item in list.</item>
-	  <item n="3">Third item in list.</item>
-	</list>
-	<list>
-	  <head>A short list</head>
-	  <label>1</label>
-	  <item>First item in list.</item>
-	  <label>2</label>
-	  <item>Second item in list.</item>
-	  <label>3</label>
-	  <item>Third item in list.</item>
-	</list>
-	</egXML> The styles should not be mixed in the same list.</p>
-	<p>A simple two-column table may be treated as a <term>glossary list</term>, tagged
-	<code>&lt;list type="gloss"&gt;</code>. Here, each item comprises a <term>term</term> and a
-	<term>gloss</term>, marked with <gi>label</gi> and <gi>item</gi> respectively. These
-	correspond to the elements <gi>term</gi> and <gi>gloss</gi>, which can occur anywhere in prose
-	text. <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	<list type="gloss">
-	  <head>Vocabulary</head>
-	  <label xml:lang="enm">nu</label>
-	  <item>now</item>
-	  <label xml:lang="enm">lhude</label>
-	  <item>loudly</item>
-	  <label xml:lang="enm">bloweth</label>
-	  <item>blooms</item>
-	  <label xml:lang="enm">med</label>
-	  <item>meadow</item>
-	  <label xml:lang="enm">wude</label>
-	  <item>wood</item>
-	  <label xml:lang="enm">awe</label>
-	  <item>ewe</item>
-	  <label xml:lang="enm">lhouth</label>
-	  <item>lows</item>
-	  <label xml:lang="enm">sterteth</label>
-	  <item>bounds, frisks</item>
-	  <label xml:lang="enm">verteth</label>
-	  <item xml:lang="la">pedit</item>
-	  <label xml:lang="enm">murie</label>
-	  <item>merrily</item>
-	  <label xml:lang="enm">swik</label>
-	  <item>cease</item>
-	  <label xml:lang="enm">naver</label>
-	  <item>never</item>
-	</list>
+        </p>
+        <p>Individual list items are tagged with <gi>item</gi>. The first <gi>item</gi> may optionally
+        be preceded by a <gi>head</gi>, which gives a heading for the list. The numbering of a list may
+        be omitted, indicated using the <att>n</att> attribute on each item, or (rarely) tagged as
+        content using the <gi>label</gi> element. The following are all thus equivalent: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+        <list>
+          <head>A short list</head>
+          <item>First item in list.</item>
+          <item>Second item in list.</item>
+          <item>Third item in list.</item>
+        </list>
+        <list>
+          <head>A short list</head>
+          <item n="1">First item in list.</item>
+          <item n="2">Second item in list.</item>
+          <item n="3">Third item in list.</item>
+        </list>
+        <list>
+          <head>A short list</head>
+          <label>1</label>
+          <item>First item in list.</item>
+          <label>2</label>
+          <item>Second item in list.</item>
+          <label>3</label>
+          <item>Third item in list.</item>
+        </list>
+        </egXML> The styles should not be mixed in the same list.</p>
+        <p>A simple two-column table may be treated as a <term>glossary list</term>, tagged
+        <code>&lt;list type="gloss"&gt;</code>. Here, each item comprises a <term>term</term> and a
+        <term>gloss</term>, marked with <gi>label</gi> and <gi>item</gi> respectively. These
+        correspond to the elements <gi>term</gi> and <gi>gloss</gi>, which can occur anywhere in prose
+        text. <egXML xmlns="http://www.tei-c.org/ns/Examples">
+        <list type="gloss">
+          <head>Vocabulary</head>
+          <label xml:lang="enm">nu</label>
+          <item>now</item>
+          <label xml:lang="enm">lhude</label>
+          <item>loudly</item>
+          <label xml:lang="enm">bloweth</label>
+          <item>blooms</item>
+          <label xml:lang="enm">med</label>
+          <item>meadow</item>
+          <label xml:lang="enm">wude</label>
+          <item>wood</item>
+          <label xml:lang="enm">awe</label>
+          <item>ewe</item>
+          <label xml:lang="enm">lhouth</label>
+          <item>lows</item>
+          <label xml:lang="enm">sterteth</label>
+          <item>bounds, frisks</item>
+          <label xml:lang="enm">verteth</label>
+          <item xml:lang="la">pedit</item>
+          <label xml:lang="enm">murie</label>
+          <item>merrily</item>
+          <label xml:lang="enm">swik</label>
+          <item>cease</item>
+          <label xml:lang="enm">naver</label>
+          <item>never</item>
+        </list>
       </egXML>
-	</p>
-	<p>Where the internal structure of a list item is more complex, it may be preferable to regard
-	the list as a <term>table</term>, for which special-purpose tagging is defined below (<ptr target="#U5-tables"/>). </p>
-	<p>Lists of whatever kind can, of course, nest within list items to any depth required. Here,
-	for example, a glossary list contains two items, each of which is itself a simple list: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	<list type="gloss">
-	  <label>EVIL</label>
-	  <item>
-	    <list type="simple">
-	      <item>I am cast upon a horrible desolate island, void of all hope of recovery.</item>
-	      <item>I am singled out and separated as it were from all the world to be miserable.</item>
-	      <item>I am divided from mankind — a solitaire; one banished from human society.</item>
-	    </list>
-	  </item>
-	  <label>GOOD</label>
-	  <item>
-	    <list type="simple">
-	      <item>But I am alive; and not drowned, as all my ship's company were.</item>
-	      <item>But I am singled out, too, from all the ship's crew, to be spared from
-	      death...</item>
-	      <item>But I am not starved, and perishing on a barren place, affording no
-	      sustenances....</item>
-	    </list>
-	  </item>
-	</list>
+        </p>
+        <p>Where the internal structure of a list item is more complex, it may be preferable to regard
+        the list as a <term>table</term>, for which special-purpose tagging is defined below (<ptr target="#U5-tables"/>). </p>
+        <p>Lists of whatever kind can, of course, nest within list items to any depth required. Here,
+        for example, a glossary list contains two items, each of which is itself a simple list: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+        <list type="gloss">
+          <label>EVIL</label>
+          <item>
+            <list type="simple">
+              <item>I am cast upon a horrible desolate island, void of all hope of recovery.</item>
+              <item>I am singled out and separated as it were from all the world to be miserable.</item>
+              <item>I am divided from mankind — a solitaire; one banished from human society.</item>
+            </list>
+          </item>
+          <label>GOOD</label>
+          <item>
+            <list type="simple">
+              <item>But I am alive; and not drowned, as all my ship's company were.</item>
+              <item>But I am singled out, too, from all the ship's crew, to be spared from
+              death...</item>
+              <item>But I am not starved, and perishing on a barren place, affording no
+              sustenances....</item>
+            </list>
+          </item>
+        </list>
       </egXML>
-	</p>
-	<p>A list need not necessarily be displayed in list format. For example, <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	<p>On those remote pages it is written that animals
-	are divided into <list rend="run-on">
-	<item n="a">those that belong to the Emperor,</item>
-	<item n="b"> embalmed ones, </item>
-	<item n="c"> those that are trained, </item>
-	<item n="d"> suckling pigs, </item>
-	<item n="e"> mermaids, </item>
-	<item n="f"> fabulous ones, </item>
-	<item n="g"> stray dogs, </item>
-	<item n="h"> those that are included in this classification, </item>
-	<item n="i"> those that tremble as if they were mad, </item>
-	<item n="j"> innumerable ones, </item>
-	<item n="k"> those drawn with a very fine camel's-hair brush, </item>
-	<item n="l"> others, </item>
-	<item n="m"> those that have just broken a flower vase, </item>
-	<item n="n"> those that resemble flies from a distance.</item>
+        </p>
+        <p>A list need not necessarily be displayed in list format. For example, <egXML xmlns="http://www.tei-c.org/ns/Examples">
+        <p>On those remote pages it is written that animals
+        are divided into <list rend="run-on">
+        <item n="a">those that belong to the Emperor,</item>
+        <item n="b"> embalmed ones, </item>
+        <item n="c"> those that are trained, </item>
+        <item n="d"> suckling pigs, </item>
+        <item n="e"> mermaids, </item>
+        <item n="f"> fabulous ones, </item>
+        <item n="g"> stray dogs, </item>
+        <item n="h"> those that are included in this classification, </item>
+        <item n="i"> those that tremble as if they were mad, </item>
+        <item n="j"> innumerable ones, </item>
+        <item n="k"> those drawn with a very fine camel's-hair brush, </item>
+        <item n="l"> others, </item>
+        <item n="m"> those that have just broken a flower vase, </item>
+        <item n="n"> those that resemble flies from a distance.</item>
       </list>
-	</p>
+        </p>
       </egXML>
-	</p>
-	<p>Lists of bibliographic items should be tagged using the <gi>listBibl</gi> element, described
-	in the next section.</p>
+        </p>
+        <p>Lists of bibliographic items should be tagged using the <gi>listBibl</gi> element, described
+        in the next section.</p>
       </div>
       <div xml:id="U5-bibls">
-	<head>Bibliographic Citations</head>
-	<p>It is often useful to distinguish bibliographic citations where they occur within texts being
-	transcribed for research, if only so that they will be properly formatted when the text is
-	printed out. The element <gi>bibl</gi> is provided for this purpose. Where the components of a
-	bibliographic reference are to be distinguished, the following elements may be used as
-	appropriate. It is generally useful to mark at least those parts (such as the titles of
-	articles, books, and journals) which will need special formatting. The other elements are
-	provided for cases where particular interest attaches to such details. <specList>
-	<specDesc key="bibl"/>
-	<specDesc key="author"/>
-	<specDesc key="biblScope"/>
-	<specDesc key="date"/>
-	<specDesc key="editor"/>
-	<specDesc key="publisher"/>
-	<specDesc key="pubPlace"/>
-	<specDesc key="title"/>
+        <head>Bibliographic Citations</head>
+        <p>It is often useful to distinguish bibliographic citations where they occur within texts being
+        transcribed for research, if only so that they will be properly formatted when the text is
+        printed out. The element <gi>bibl</gi> is provided for this purpose. Where the components of a
+        bibliographic reference are to be distinguished, the following elements may be used as
+        appropriate. It is generally useful to mark at least those parts (such as the titles of
+        articles, books, and journals) which will need special formatting. The other elements are
+        provided for cases where particular interest attaches to such details. <specList>
+        <specDesc key="bibl"/>
+        <specDesc key="author"/>
+        <specDesc key="biblScope"/>
+        <specDesc key="date"/>
+        <specDesc key="editor"/>
+        <specDesc key="publisher"/>
+        <specDesc key="pubPlace"/>
+        <specDesc key="title"/>
       </specList>
-	</p>
-	<p>For example, the following editorial note might be transcribed as shown: <q rend="display">He
-	was a member of Parliament for Warwickshire in 1445, and died March 14, 1470 (according to
-	Kittredge, <title>Harvard Studies</title> 5. 88ff).</q>
-	<egXML xmlns="http://www.tei-c.org/ns/Examples">He was a member of Parliament for Warwickshire
-	in 1445, and died March 14, 1470 (according to <bibl>
-	<author>Kittredge</author>,
-	<title>Harvard Studies</title>
-	<biblScope>5. 88ff</biblScope>
-	</bibl>).</egXML>
-	</p>
-	<p>For lists of bibliographic citations, the <gi>listBibl</gi> element should be used; it may
-	contain a series of <gi>bibl</gi> elements. </p>
+        </p>
+        <p>For example, the following editorial note might be transcribed as shown: <q rend="display">He
+        was a member of Parliament for Warwickshire in 1445, and died March 14, 1470 (according to
+        Kittredge, <title>Harvard Studies</title> 5. 88ff).</q>
+        <egXML xmlns="http://www.tei-c.org/ns/Examples">He was a member of Parliament for Warwickshire
+        in 1445, and died March 14, 1470 (according to <bibl>
+        <author>Kittredge</author>,
+        <title>Harvard Studies</title>
+        <biblScope>5. 88ff</biblScope>
+        </bibl>).</egXML>
+        </p>
+        <p>For lists of bibliographic citations, the <gi>listBibl</gi> element should be used; it may
+        contain a series of <gi>bibl</gi> elements. </p>
       </div>
       <div xml:id="U5-tables">
-	<head>Tables</head>
-	<p>Tables represent a challenge for any text processing system, but simple tables, at least,
-	appear in so many texts that even in the simplified TEI tag set presented here, markup for
-	tables is necessary. The following elements are provided for this purpose: <specList>
-	<specDesc key="table"/>
-	<specDesc key="row"/>
-	<specDesc key="cell"/>
+        <head>Tables</head>
+        <p>Tables represent a challenge for any text processing system, but simple tables, at least,
+        appear in so many texts that even in the simplified TEI tag set presented here, markup for
+        tables is necessary. The following elements are provided for this purpose: <specList>
+        <specDesc key="table"/>
+        <specDesc key="row"/>
+        <specDesc key="cell"/>
       </specList>
-	</p>
-	<p>For example, Defoe uses mortality tables like the following in the <title level="m">Journal
-	of the Plague Year</title> to show the rise and ebb of the epidemic:<egXML xmlns="http://www.tei-c.org/ns/Examples">
-	<p>It was indeed coming on amain, for the burials
-	that same week were in the next adjoining parishes thus:— <table rows="5" cols="4">
-	<row role="data">
-	  <cell role="label">St. Leonard's, Shoreditch</cell>
-	  <cell>64</cell>
-	  <cell>84</cell>
-	  <cell>119</cell>
-	</row>
-	<row role="data">
-	  <cell role="label">St. Botolph's, Bishopsgate</cell>
-	  <cell>65</cell>
-	  <cell>105</cell>
-	  <cell>116</cell>
-	</row>
-	<row role="data">
-	  <cell role="label">St. Giles's, Cripplegate</cell>
-	  <cell>213</cell>
-	  <cell>421</cell>
-	  <cell>554</cell>
-	</row>
+        </p>
+        <p>For example, Defoe uses mortality tables like the following in the <title level="m">Journal
+        of the Plague Year</title> to show the rise and ebb of the epidemic:<egXML xmlns="http://www.tei-c.org/ns/Examples">
+        <p>It was indeed coming on amain, for the burials
+        that same week were in the next adjoining parishes thus:— <table rows="5" cols="4">
+        <row role="data">
+          <cell role="label">St. Leonard's, Shoreditch</cell>
+          <cell>64</cell>
+          <cell>84</cell>
+          <cell>119</cell>
+        </row>
+        <row role="data">
+          <cell role="label">St. Botolph's, Bishopsgate</cell>
+          <cell>65</cell>
+          <cell>105</cell>
+          <cell>116</cell>
+        </row>
+        <row role="data">
+          <cell role="label">St. Giles's, Cripplegate</cell>
+          <cell>213</cell>
+          <cell>421</cell>
+          <cell>554</cell>
+        </row>
       </table>
-	</p>
-	<p>This shutting up of houses was at first counted a very cruel and unchristian
-	method, and the poor people so confined made bitter lamentations. ... </p>
+        </p>
+        <p>This shutting up of houses was at first counted a very cruel and unchristian
+        method, and the poor people so confined made bitter lamentations. ... </p>
       </egXML>
-	</p>
+        </p>
       </div>
       <div xml:id="U5-figs">
-	<head>Figures and Graphics</head>
-	<p>Not all the components of a document are necessarily textual. The most straightforward text
-	will often contain diagrams or illustrations, to say nothing of documents in which image and
-	text are inextricably intertwined, or electronic resources in which the two are complementary. </p>
-	<p>The encoder may simply record the presence of a graphic within the text, possibly with a
-	brief description of its content, and may also provide a link to a digitized version of the
-	graphic, using the following elements: <specList>
-	<specDesc key="graphic"/>
-	<specDesc key="figure"/>
-	<specDesc key="figDesc"/>
+        <head>Figures and Graphics</head>
+        <p>Not all the components of a document are necessarily textual. The most straightforward text
+        will often contain diagrams or illustrations, to say nothing of documents in which image and
+        text are inextricably intertwined, or electronic resources in which the two are complementary. </p>
+        <p>The encoder may simply record the presence of a graphic within the text, possibly with a
+        brief description of its content, and may also provide a link to a digitized version of the
+        graphic, using the following elements: <specList>
+        <specDesc key="graphic"/>
+        <specDesc key="figure"/>
+        <specDesc key="figDesc"/>
       </specList>
-	</p>
-	<p>Any textual information accompanying the graphic, such as a heading and/or caption, may be
-	included within the <gi>figure</gi> element itself, in a <gi>head</gi> and one or more
-	<gi>p</gi> elements, as also may any text appearing within the graphic itself. It is strongly
-	recommended that a prose description of the image be supplied, as the content of a
-	<gi>figDesc</gi> element, for the use of applications which are not able to render the
-	graphic, and to render the document accessible to vision-impaired readers. (Such text is not
-	normally considered part of the document proper.)</p>
-	<p>The simplest use for these elements is to mark the position of a graphic and provide a link
-	to it, as in this example; <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	<pb n="412"/>
-	<figure>
-	  <graphic url="p412fig.png"/>
-	</figure>
-	<pb n="413"/>
-	</egXML> This indicates that the
-	graphic contained by the file <ident>p412fig.png</ident> appears between pages 412 and 413. </p>
-	<p>The <gi>graphic</gi> element can appear anywhere that textual content is permitted, within
-	but not between paragraphs or headings. In the following example, the encoder has decided to
-	treat a specific printer's ornament as a heading: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	<head>
-	  <graphic url="http://www.iath.virginia.edu/gants/Ornaments/Heads/hp-ral02.gif"/>
-	</head>
+        </p>
+        <p>Any textual information accompanying the graphic, such as a heading and/or caption, may be
+        included within the <gi>figure</gi> element itself, in a <gi>head</gi> and one or more
+        <gi>p</gi> elements, as also may any text appearing within the graphic itself. It is strongly
+        recommended that a prose description of the image be supplied, as the content of a
+        <gi>figDesc</gi> element, for the use of applications which are not able to render the
+        graphic, and to render the document accessible to vision-impaired readers. (Such text is not
+        normally considered part of the document proper.)</p>
+        <p>The simplest use for these elements is to mark the position of a graphic and provide a link
+        to it, as in this example; <egXML xmlns="http://www.tei-c.org/ns/Examples">
+        <pb n="412"/>
+        <figure>
+          <graphic url="p412fig.png"/>
+        </figure>
+        <pb n="413"/>
+        </egXML> This indicates that the
+        graphic contained by the file <ident>p412fig.png</ident> appears between pages 412 and 413. </p>
+        <p>The <gi>graphic</gi> element can appear anywhere that textual content is permitted, within
+        but not between paragraphs or headings. In the following example, the encoder has decided to
+        treat a specific printer's ornament as a heading: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+        <head>
+          <graphic url="http://www.iath.virginia.edu/gants/Ornaments/Heads/hp-ral02.gif"/>
+        </head>
       </egXML>
-	</p>
-	<p>More usually, a graphic will have at the least an identifying title, which may be encoded
-	using the <gi>head</gi> element, or a number of figures may be grouped together in a particular
-	structure. It is also often convenient to include a brief description of the image. The
-	<gi>figure</gi> element provides a means of wrapping one or more such elements together as a
-	kind of graphic <soCalled>block</soCalled>: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	<figure>
-	  <graphic url="fessipic.png"/>
-	  <head>Mr Fezziwig's Ball</head>
-	  <figDesc>A Cruikshank
-	  engraving showing Mr Fezziwig leading a group of revellers.</figDesc>
-	</figure>
+        </p>
+        <p>More usually, a graphic will have at the least an identifying title, which may be encoded
+        using the <gi>head</gi> element, or a number of figures may be grouped together in a particular
+        structure. It is also often convenient to include a brief description of the image. The
+        <gi>figure</gi> element provides a means of wrapping one or more such elements together as a
+        kind of graphic <soCalled>block</soCalled>: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+        <figure>
+          <graphic url="fessipic.png"/>
+          <head>Mr Fezziwig's Ball</head>
+          <figDesc>A Cruikshank
+          engraving showing Mr Fezziwig leading a group of revellers.</figDesc>
+        </figure>
       </egXML>
-	</p>
-	<p>These cases should be carefully distinguished from the case where an encoded text is
-	complemented by a collection of digital images, maintained as a distinct resource. The
-	<att>facs</att> attribute may be used to associate any element in an encoded text with a
-	digital facsimile of it. In the simple case where only page images are available, the
-	<att>facs</att> attribute on the <gi>pb</gi> element may be used to associate each image with
-	an appropriate point in the text: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	<text>
-	  <pb facs="page1.png" n="1"/>
-	  <!-- text contained on page 1 is encoded here -->
-	  <pb facs="page2.png" n="2"/>
-	  <!-- text contained on page 2 is encoded here -->
-	</text>
-	</egXML> This method is only appropriate in the simple case where each digital image file
-	<ident>page1.png</ident> etc. corresponds with a single transcribed and encoded page. If more
-	detailed alignment of image and transcription is required, for example because the image files
-	actually represent double page spreads, more sophisticated mechanisms are provided in the full
-	TEI Guidelines. </p>
+        </p>
+        <p>These cases should be carefully distinguished from the case where an encoded text is
+        complemented by a collection of digital images, maintained as a distinct resource. The
+        <att>facs</att> attribute may be used to associate any element in an encoded text with a
+        digital facsimile of it. In the simple case where only page images are available, the
+        <att>facs</att> attribute on the <gi>pb</gi> element may be used to associate each image with
+        an appropriate point in the text: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+        <text>
+          <pb facs="page1.png" n="1"/>
+          <!-- text contained on page 1 is encoded here -->
+          <pb facs="page2.png" n="2"/>
+          <!-- text contained on page 2 is encoded here -->
+        </text>
+        </egXML> This method is only appropriate in the simple case where each digital image file
+        <ident>page1.png</ident> etc. corresponds with a single transcribed and encoded page. If more
+        detailed alignment of image and transcription is required, for example because the image files
+        actually represent double page spreads, more sophisticated mechanisms are provided in the full
+        TEI Guidelines. </p>
       </div>
       <div xml:id="U5-anal">
-	<head>Interpretation and Analysis</head>
-	<p>It is often said that <emph>all</emph> markup is a form of interpretation or analysis. While
-	it is certainly difficult, and may be impossible, to distinguish firmly between
-	<soCalled>objective</soCalled> and <soCalled>subjective</soCalled> information in any
-	universal way, it remains true that judgments concerning the latter are typically regarded as
-	more likely to provide controversy than those concerning the former. Many scholars therefore
-	prefer to record such interpretations only if it is possible to alert the reader that they are
-	considered more open to dispute, than the rest of the markup. This section describes some of
-	the elements provided by the TEI scheme to meet this need. </p>
-	<div>
-	  <head>Orthographic Sentences</head>
-	  <p>Interpretation typically ranges across the whole of a text, with no particular respect to
-	  other structural units. A useful preliminary to intensive interpretation is therefore to
-	  segment the text into discrete and identifiable units, each of which can then bear a label for
-	  use as a sort of <soCalled>canonical reference</soCalled>. To facilitate such uses, these
-	  units may not cross each other, nor nest within each other. They may conveniently be
-	  represented using the following element: <specList>
-	  <specDesc key="s"/>
-	</specList>
-	  </p>
-	  <p>As the name suggests, the <gi>s</gi> element is most commonly used (in linguistic
-	  applications at least) for marking <term>orthographic sentences</term>, that is, units defined
-	  by orthographic features such as punctuation. For example, the passage from <title>Jane
-	  Eyre</title> discussed earlier might be divided into s-units as follows:<egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <pb n="474"/>
-	  <div type="chapter" n="38">
-	    <p>
-	      <s n="001">Reader, I married him.</s>
-	      <s n="002">A quiet wedding we had:</s>
-	      <s n="003">he
-	      and I, the parson and clerk, were alone present.</s>
-	      <s n="004">When we got back from
-	      church, I went into the kitchen of the manor-house, where Mary was cooking the dinner, and
-	      John cleaning the knives, and I said —</s>
-	    </p>
-	    <p>
-	      <q>
-		<s n="005">Mary, I have been married to Mr Rochester this morning.</s>
-	    </q> ... </p>
-	  </div>
-	  </egXML> Note that <gi>s</gi> elements cannot nest: the beginning of one <gi>s</gi>
-	  element implies that the previous one has finished. When s-units are tagged as shown above, it
-	  is advisable to tag the entire text end-to-end, so that every word in the text being analysed
-	  will be contained by exactly one <gi>s</gi> element, whose identifier can then be used to
-	  specify a unique reference for it. If the identifiers used are unique within the document,
-	  then the <att>xml:id</att> attribute might be used in preference to the <att>n</att> used in
-	  the above example.</p>
-	</div>
-	<div>
-	  <head>Words and punctuation</head>
-	  <p>Tokenization, that is, the identification of
-	  lexical or non-lexical tokens within a text, is a very common requirement for all kinds of
-	  textual analysis, and not an entirely trivial one. The decision as to whether, for example,
-	  <q>can't</q> in English or <q>du</q> in French should be treated as one word or two is not
-	  simple. Consequently it is often useful to make explicit the preferred tokenization in a
-	  marked up text. The following elements are available for this purpose: <specList>
-	  <specDesc key="w"/>
-	  <specDesc key="pc"/>
-	</specList>
-	  </p>
-	  <p>For example, the output from a part of speech tagger might be recorded in TEI Lite as
-	  follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <s n="1">
-	    <w ana="#NP0">Marley</w>
-	    <w ana="#VBD">was</w>
-	    <w ana="#AJ0">dead</w>
-	    <pc>:</pc>
-	    <w ana="#TO0">to</w>
-	    <w ana="#VBB">begin</w>
-	    <w ana="#PRP">with</w>
-	    <pc>. </pc>
-	  </s>
-	</egXML>
-	  </p>
-	  <p>In this example, each word has been decorated with an automatically generated part of
-	  speech code, using the <att>ana</att> attribute discussed in section <ptr target="#xatts"/>
-	  above. The <gi>w</gi> also provides for each word to be associated with a root form or lemma,
-	  either explicitly using the <att>lemma</att> attribute, or by reference, using the
-	  <att>lemmaRef</att> attribute, as in this example: <egXML xmlns="http://www.tei-c.org/ns/Examples">...<w ana="#VBD" lemma="be" lemmaRef="http://www.myLexicon.com/be">was</w> ... </egXML>
-	  </p>
-	</div>
-	<div>
-	  <head>General-Purpose Interpretation Elements</head>
-	  <p>The <gi>w</gi> element is a specialisation of the <gi>seg</gi> element which has already
-	  been introduced for use in identifying otherwise unmarked targets of cross references and
-	  hypertext links (see section <ptr target="#U5-ptrs"/>); it identifies some phrase-level
-	  portion of text to which the encoder may assign a user-specified <att>type</att>, as well as a
-	  unique identifier; it may thus be used to tag textual features for which there is no other
-	  provision in the published TEI Guidelines.</p>
-	  <p>For example, the Guidelines provide no <soCalled>apostrophe</soCalled> element to mark parts
-	  of a literary text in which the narrator addresses the reader (or hearer) directly. One
-	  approach might be to regard these as instances of the <gi>q</gi> element, distinguished from
-	  others by an appropriate value for the <att>who</att> attribute. A possibly simpler, and
-	  certainly more general, solution would however be to use the <gi>seg</gi> element as follows:
-	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <div type="chapter" n="38">
-	      <p>
-	      <seg type="apostrophe">Reader, I married him.</seg> A quiet wedding we had: ...</p>
-	    </div>
-	    </egXML> The <att>type</att> attribute on the <gi>seg</gi> element can take any value,
-	    and so can be used to record phrase-level phenomena of any kind; it is good practice to record
-	  the values used and their significance in the header.</p>
-	  <p>A <gi>seg</gi> element of one type (unlike the <gi>s</gi> element which it superficially
-	  resembles) can be nested within a <gi>seg</gi> element of the same or another type. This
-	  enables quite complex structures to be represented; some examples were given in section <ptr target="#xatts"/> above. However, because it must respect the requirement that elements be
-	  properly nested and may not cut across each other, it cannot cope with the common requirement
-	  to associate an interpretation with arbitrary segments of a text which may completely ignore
-	  the document hierarchy. It also requires that the interpretation itself be represented by a
-	  single coded value in the <att>type</att> attribute.</p>
-	  <p>Neither restriction applies to the <gi>interp</gi> element, which provides powerful features
-	  for the encoding of quite complex interpretive information in a relatively straightforward
-	  manner. <specList>
-	  <specDesc key="interp"/>
-	  <specDesc key="interpGrp"/>
-	  </specList> These elements allow the encoder to specify both the class of an interpretation,
-	  and the particular instance of that class which the interpretation involves. Thus, whereas
-	  with <gi>seg</gi> one can say simply that something is an apostrophe, with <gi>interp</gi> one
-	  can say that it is an instance (apostrophe) of a larger class (rhetorical figures).</p>
-	  <p>Moreover, <gi>interp</gi> is a <soCalled>stand off</soCalled>
-	  element: it does not surround the segments of text which it
-	  describes, but instead is  linked to the passage in question
-	  either by means of the <att>ana</att> attribute discussed in section <ptr target="#xatts"/> above, or by means of its own <att>inst</att> attribute. This means that
-	  any kind of analysis can be represented, independently of the
-	  document hierarchy, as well as
-	  facilitating the grouping of analyses of a particular type together. A special purpose
-	  <gi>interpGrp</gi> element is provided for the latter purpose.</p>
-	  <p>For example, suppose that you wish to mark such diverse aspects of a text as themes or
-	  subject matter, rhetorical figures, and the locations of individual scenes of the narrative.
-	  Different portions of our sample passage from <title>Jane Eyre</title> for example, might be
-	  associated with the rhetorical figures of apostrophe, hyperbole, and metaphor; with
-	  subject-matter references to churches, servants, cooking, postal service, and honeymoons; and
-	  with scenes located in the church, in the kitchen, and in an unspecified location (drawing
-	  room?).</p>
-	  <p>These interpretations could be placed anywhere within the <gi>text</gi> element; it is
-	  however good practice to put them all in the same place (e.g. a separate section of the front
-	  or back matter), as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <back>
-	    <div type="Interpretations">
-	      <p>
-		<interp xml:id="fig-apos-1" resp="#LB-MSM" type="figureOfSpeech">apostrophe</interp>
-		<interp xml:id="fig-hyp-1" resp="#LB-MSM" type="figureOfSpeech">hyperbole</interp>
-		<interp xml:id="set-church-1" resp="#LB-MSM" type="setting">church</interp>
-		<interp xml:id="ref-church-1" resp="#LB-MSM" type="reference">church</interp>
-		<interp xml:id="ref-serv-1" resp="#LB-MSM" type="reference">servants</interp>
-	      </p>
-	    </div>
-	  </back>
-	</egXML>
-	  </p>
-	  <p>The evident redundancy of this encoding can be considerably reduced by using the
-	  <gi>interpGrp</gi> element to group together all those <gi>interp</gi> elements which share
-	  common attribute values, as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <back>
-	    <div type="Interpretations">
-	      <p>
-		<interpGrp type="figureOfSpeech" resp="#LB-MSM">
-		  <interp xml:id="fig-apos">apostrophe</interp>
-		  <interp xml:id="fig-hyp">hyperbole</interp>
-		  <interp xml:id="fig-meta">metaphor</interp>
-		</interpGrp>
-		<interpGrp type="scene-setting" resp="#LB-MSM">
-		  <interp xml:id="set-church">church</interp>
-		  <interp xml:id="set-kitch">kitchen</interp>
-		  <interp xml:id="set-unspec">unspecified</interp>
-		</interpGrp>
-		<interpGrp type="reference" resp="#LB-MSM">
-		  <interp xml:id="ref-church">church</interp>
-		  <interp xml:id="ref-serv">servants</interp>
-		  <interp xml:id="ref-cook">cooking</interp>
-		</interpGrp>
-	      </p>
-	    </div>
-	  </back>
-	</egXML>
-	  </p>
-	  <p>Once these interpretation elements have been defined, they can be linked with the parts of
-	  the text to which they apply in either or both of two ways. The <att>ana</att> attribute can
-	  be used on whichever element is appropriate: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <div type="chapter" n="38">
-	    <p xml:id="P38.1" ana="#set-church #set-kitch">
-	      <s xml:id="P38.1.1" ana="#fig-apos">Reader, I
-	      married him.</s>
-	    </p>
-	  </div>
-	  </egXML> Note in this example that since the paragraph has two settings (in the church
-	  and in the kitchen), the identifiers of both have been supplied.</p>
-	  <p>Alternatively, the <gi>interp</gi> elements can point to all the parts of the text to which
-	  they apply, using their <att>inst</att> attribute: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <interp xml:id="fig-apos-2"
-		  type="figureOfSpeech"
-		  resp="#LB-MSM"
-		  inst="#P38.1.1">apostrophe</interp>
-	  <interp xml:id="set-church-2"
-		  type="scene-setting"
-		  inst="#P38.1"
-		  resp="#LB-MSM">church</interp>
-	  <interp xml:id="set-kitchen-2"
-		  type="scene-setting"
-		  inst="#P38.1"
-		  resp="#LB-MSM">kitchen</interp>
-	</egXML>
-	  </p>
-	  <p>The <gi>interp</gi> element is not limited to any particular type of analysis. The literary
-	  analysis shown above is but one possibility; one could equally well use <gi>interp</gi> to
-	  capture a linguistic part-of-speech analysis. For example, the example sentence given in
-	  section <ptr target="#xatts"/> assumes a linguistic analysis which might be represented as
-	  follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <interp xml:id="NP1" type="pos">noun
-	  phrase, singular</interp>
-	  <interp xml:id="VV1" type="pos">inflected verb, present-tense
-	  singular</interp> ... </egXML>
-	  </p>
-	</div>
+        <head>Interpretation and Analysis</head>
+        <p>It is often said that <emph>all</emph> markup is a form of interpretation or analysis. While
+        it is certainly difficult, and may be impossible, to distinguish firmly between
+        <soCalled>objective</soCalled> and <soCalled>subjective</soCalled> information in any
+        universal way, it remains true that judgments concerning the latter are typically regarded as
+        more likely to provide controversy than those concerning the former. Many scholars therefore
+        prefer to record such interpretations only if it is possible to alert the reader that they are
+        considered more open to dispute, than the rest of the markup. This section describes some of
+        the elements provided by the TEI scheme to meet this need. </p>
+        <div>
+          <head>Orthographic Sentences</head>
+          <p>Interpretation typically ranges across the whole of a text, with no particular respect to
+          other structural units. A useful preliminary to intensive interpretation is therefore to
+          segment the text into discrete and identifiable units, each of which can then bear a label for
+          use as a sort of <soCalled>canonical reference</soCalled>. To facilitate such uses, these
+          units may not cross each other, nor nest within each other. They may conveniently be
+          represented using the following element: <specList>
+          <specDesc key="s"/>
+        </specList>
+          </p>
+          <p>As the name suggests, the <gi>s</gi> element is most commonly used (in linguistic
+          applications at least) for marking <term>orthographic sentences</term>, that is, units defined
+          by orthographic features such as punctuation. For example, the passage from <title>Jane
+          Eyre</title> discussed earlier might be divided into s-units as follows:<egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <pb n="474"/>
+          <div type="chapter" n="38">
+            <p>
+              <s n="001">Reader, I married him.</s>
+              <s n="002">A quiet wedding we had:</s>
+              <s n="003">he
+              and I, the parson and clerk, were alone present.</s>
+              <s n="004">When we got back from
+              church, I went into the kitchen of the manor-house, where Mary was cooking the dinner, and
+              John cleaning the knives, and I said —</s>
+            </p>
+            <p>
+              <q>
+                <s n="005">Mary, I have been married to Mr Rochester this morning.</s>
+            </q> ... </p>
+          </div>
+          </egXML> Note that <gi>s</gi> elements cannot nest: the beginning of one <gi>s</gi>
+          element implies that the previous one has finished. When s-units are tagged as shown above, it
+          is advisable to tag the entire text end-to-end, so that every word in the text being analysed
+          will be contained by exactly one <gi>s</gi> element, whose identifier can then be used to
+          specify a unique reference for it. If the identifiers used are unique within the document,
+          then the <att>xml:id</att> attribute might be used in preference to the <att>n</att> used in
+          the above example.</p>
+        </div>
+        <div>
+          <head>Words and punctuation</head>
+          <p>Tokenization, that is, the identification of
+          lexical or non-lexical tokens within a text, is a very common requirement for all kinds of
+          textual analysis, and not an entirely trivial one. The decision as to whether, for example,
+          <q>can't</q> in English or <q>du</q> in French should be treated as one word or two is not
+          simple. Consequently it is often useful to make explicit the preferred tokenization in a
+          marked up text. The following elements are available for this purpose: <specList>
+          <specDesc key="w"/>
+          <specDesc key="pc"/>
+        </specList>
+          </p>
+          <p>For example, the output from a part of speech tagger might be recorded in TEI Lite as
+          follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <s n="1">
+            <w ana="#NP0">Marley</w>
+            <w ana="#VBD">was</w>
+            <w ana="#AJ0">dead</w>
+            <pc>:</pc>
+            <w ana="#TO0">to</w>
+            <w ana="#VBB">begin</w>
+            <w ana="#PRP">with</w>
+            <pc>. </pc>
+          </s>
+        </egXML>
+          </p>
+          <p>In this example, each word has been decorated with an automatically generated part of
+          speech code, using the <att>ana</att> attribute discussed in section <ptr target="#xatts"/>
+          above. The <gi>w</gi> also provides for each word to be associated with a root form or lemma,
+          either explicitly using the <att>lemma</att> attribute, or by reference, using the
+          <att>lemmaRef</att> attribute, as in this example: <egXML xmlns="http://www.tei-c.org/ns/Examples">...<w ana="#VBD" lemma="be" lemmaRef="http://www.myLexicon.com/be">was</w> ... </egXML>
+          </p>
+        </div>
+        <div>
+          <head>General-Purpose Interpretation Elements</head>
+          <p>The <gi>w</gi> element is a specialisation of the <gi>seg</gi> element which has already
+          been introduced for use in identifying otherwise unmarked targets of cross references and
+          hypertext links (see section <ptr target="#U5-ptrs"/>); it identifies some phrase-level
+          portion of text to which the encoder may assign a user-specified <att>type</att>, as well as a
+          unique identifier; it may thus be used to tag textual features for which there is no other
+          provision in the published TEI Guidelines.</p>
+          <p>For example, the Guidelines provide no <soCalled>apostrophe</soCalled> element to mark parts
+          of a literary text in which the narrator addresses the reader (or hearer) directly. One
+          approach might be to regard these as instances of the <gi>q</gi> element, distinguished from
+          others by an appropriate value for the <att>who</att> attribute. A possibly simpler, and
+          certainly more general, solution would however be to use the <gi>seg</gi> element as follows:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <div type="chapter" n="38">
+              <p>
+              <seg type="apostrophe">Reader, I married him.</seg> A quiet wedding we had: ...</p>
+            </div>
+            </egXML> The <att>type</att> attribute on the <gi>seg</gi> element can take any value,
+            and so can be used to record phrase-level phenomena of any kind; it is good practice to record
+          the values used and their significance in the header.</p>
+          <p>A <gi>seg</gi> element of one type (unlike the <gi>s</gi> element which it superficially
+          resembles) can be nested within a <gi>seg</gi> element of the same or another type. This
+          enables quite complex structures to be represented; some examples were given in section <ptr target="#xatts"/> above. However, because it must respect the requirement that elements be
+          properly nested and may not cut across each other, it cannot cope with the common requirement
+          to associate an interpretation with arbitrary segments of a text which may completely ignore
+          the document hierarchy. It also requires that the interpretation itself be represented by a
+          single coded value in the <att>type</att> attribute.</p>
+          <p>Neither restriction applies to the <gi>interp</gi> element, which provides powerful features
+          for the encoding of quite complex interpretive information in a relatively straightforward
+          manner. <specList>
+          <specDesc key="interp"/>
+          <specDesc key="interpGrp"/>
+          </specList> These elements allow the encoder to specify both the class of an interpretation,
+          and the particular instance of that class which the interpretation involves. Thus, whereas
+          with <gi>seg</gi> one can say simply that something is an apostrophe, with <gi>interp</gi> one
+          can say that it is an instance (apostrophe) of a larger class (rhetorical figures).</p>
+          <p>Moreover, <gi>interp</gi> is a <soCalled>stand off</soCalled>
+          element: it does not surround the segments of text which it
+          describes, but instead is  linked to the passage in question
+          either by means of the <att>ana</att> attribute discussed in section <ptr target="#xatts"/> above, or by means of its own <att>inst</att> attribute. This means that
+          any kind of analysis can be represented, independently of the
+          document hierarchy, as well as
+          facilitating the grouping of analyses of a particular type together. A special purpose
+          <gi>interpGrp</gi> element is provided for the latter purpose.</p>
+          <p>For example, suppose that you wish to mark such diverse aspects of a text as themes or
+          subject matter, rhetorical figures, and the locations of individual scenes of the narrative.
+          Different portions of our sample passage from <title>Jane Eyre</title> for example, might be
+          associated with the rhetorical figures of apostrophe, hyperbole, and metaphor; with
+          subject-matter references to churches, servants, cooking, postal service, and honeymoons; and
+          with scenes located in the church, in the kitchen, and in an unspecified location (drawing
+          room?).</p>
+          <p>These interpretations could be placed anywhere within the <gi>text</gi> element; it is
+          however good practice to put them all in the same place (e.g. a separate section of the front
+          or back matter), as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <back>
+            <div type="Interpretations">
+              <p>
+                <interp xml:id="fig-apos-1" resp="#LB-MSM" type="figureOfSpeech">apostrophe</interp>
+                <interp xml:id="fig-hyp-1" resp="#LB-MSM" type="figureOfSpeech">hyperbole</interp>
+                <interp xml:id="set-church-1" resp="#LB-MSM" type="setting">church</interp>
+                <interp xml:id="ref-church-1" resp="#LB-MSM" type="reference">church</interp>
+                <interp xml:id="ref-serv-1" resp="#LB-MSM" type="reference">servants</interp>
+              </p>
+            </div>
+          </back>
+        </egXML>
+          </p>
+          <p>The evident redundancy of this encoding can be considerably reduced by using the
+          <gi>interpGrp</gi> element to group together all those <gi>interp</gi> elements which share
+          common attribute values, as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <back>
+            <div type="Interpretations">
+              <p>
+                <interpGrp type="figureOfSpeech" resp="#LB-MSM">
+                  <interp xml:id="fig-apos">apostrophe</interp>
+                  <interp xml:id="fig-hyp">hyperbole</interp>
+                  <interp xml:id="fig-meta">metaphor</interp>
+                </interpGrp>
+                <interpGrp type="scene-setting" resp="#LB-MSM">
+                  <interp xml:id="set-church">church</interp>
+                  <interp xml:id="set-kitch">kitchen</interp>
+                  <interp xml:id="set-unspec">unspecified</interp>
+                </interpGrp>
+                <interpGrp type="reference" resp="#LB-MSM">
+                  <interp xml:id="ref-church">church</interp>
+                  <interp xml:id="ref-serv">servants</interp>
+                  <interp xml:id="ref-cook">cooking</interp>
+                </interpGrp>
+              </p>
+            </div>
+          </back>
+        </egXML>
+          </p>
+          <p>Once these interpretation elements have been defined, they can be linked with the parts of
+          the text to which they apply in either or both of two ways. The <att>ana</att> attribute can
+          be used on whichever element is appropriate: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <div type="chapter" n="38">
+            <p xml:id="P38.1" ana="#set-church #set-kitch">
+              <s xml:id="P38.1.1" ana="#fig-apos">Reader, I
+              married him.</s>
+            </p>
+          </div>
+          </egXML> Note in this example that since the paragraph has two settings (in the church
+          and in the kitchen), the identifiers of both have been supplied.</p>
+          <p>Alternatively, the <gi>interp</gi> elements can point to all the parts of the text to which
+          they apply, using their <att>inst</att> attribute: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <interp xml:id="fig-apos-2"
+                  type="figureOfSpeech"
+                  resp="#LB-MSM"
+                  inst="#P38.1.1">apostrophe</interp>
+          <interp xml:id="set-church-2"
+                  type="scene-setting"
+                  inst="#P38.1"
+                  resp="#LB-MSM">church</interp>
+          <interp xml:id="set-kitchen-2"
+                  type="scene-setting"
+                  inst="#P38.1"
+                  resp="#LB-MSM">kitchen</interp>
+        </egXML>
+          </p>
+          <p>The <gi>interp</gi> element is not limited to any particular type of analysis. The literary
+          analysis shown above is but one possibility; one could equally well use <gi>interp</gi> to
+          capture a linguistic part-of-speech analysis. For example, the example sentence given in
+          section <ptr target="#xatts"/> assumes a linguistic analysis which might be represented as
+          follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <interp xml:id="NP1" type="pos">noun
+          phrase, singular</interp>
+          <interp xml:id="VV1" type="pos">inflected verb, present-tense
+          singular</interp> ... </egXML>
+          </p>
+        </div>
       </div>
       <div xml:id="U5-techdoc">
-	<head>Technical Documentation</head>
-	<p>Although the focus of this document is on the use of the TEI scheme for the encoding of
-	existing <soCalled>pre-electronic</soCalled> documents, the same scheme may also be used for
-	the encoding of new documents. In the preparation of new documents (such as this one), XML has
-	much to recommend it: the document's structure can be clearly represented, and the same
-	electronic text can be re-used for many purposes — to provide both online hypertext or
-	browsable versions and well-formatted typeset versions from a common source for example. </p>
-	<p>To facilitate this, the TEI Lite schema includes some elements for marking features of
-	technical documents in general, and of XML-related documents in particular.</p>
-	<div>
-	  <head>Additional Elements for Technical Documents</head>
-	  <p>The following elements may be used to mark particular features of technical documents: <specList>
-	  <specDesc key="eg"/>
-	  <specDesc key="code"/>
-	  <specDesc key="ident"/>
-	  <specDesc key="gi"/>
-	  <specDesc key="att"/>
-	  <specDesc key="formula"/>
-	  <specDesc key="val"/>
-	</specList>
-	  </p>
-	  <p>The following example shows how these elements might be used to encode a passage from a
-	  tutorial introducing the Fortran programming language: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <p>It is traditional to introduce a language with a
-	  program like the following: <eg xml:space="preserve"> CHAR*12 GRTG
-	  GRTG = 'HELLO WORLD' 
-	  PRINT *, GRTG 
-	  END
-	</eg>
-	  </p>
-	  <p>This simple example first declares a variable <ident>GRTG</ident>, in the line
-	  <code>CHAR*12 GRTG</code>, which identifies <ident>GRTG</ident> as consisting of 12 bytes
-	  of type <ident>CHAR</ident>. To this variable, the value <val>HELLO WORLD</val> is then
-	  assigned.</p>
-	</egXML>
-	  </p>
-	  <p>A formatting application, given a text like that above, can be instructed to format examples
-	  appropriately (e.g. to preserve line breaks, or to use a distinctive font). Similarly, the use
-	  of tags such as <gi>ident</gi> greatly facilitates the construction of a useful index.</p>
-	  <p>The <gi>formula</gi> element should be used to enclose a mathematical or chemical formula
-	  presented within the text as a distinct item. Since formulae generally include a large variety
-	  of special typographic features not otherwise present in ordinary text, it will usually be
-	  necessary to present the body of the formula in a specialized notation. The notation used
-	  should be specified by the <att>notation</att> attribute, as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <formula notation="tex"> \begin{math}E =
-	  mc^{2}\end{math} </formula>
-	</egXML>
-	  </p>
-	  <p>A particular problem arises when XML encoding is the subject of discussion within a
-	  technical document, itself encoded in XML. In such a document, it is clearly essential to
-	  distinguish clearly the markup occurring within examples from that marking up the document
-	  itself, and end-tags are highly likely to occur. One simple solution is to use the predefined
-	  entity reference <code>&amp;lt;</code> to represent each &lt; character which marks the start
-	  of an XML tag within the examples. A more general solution is to mark off the whole body of
-	  each example as containing data which is not to be scanned for XML mark-up by the parser. This
-	  is achieved by enclosing it within a special XML construct called a <term>
-	  <code>CDATA</code>
-	  marked section</term>, as in the following example: <eg xml:space="preserve">&lt;p&gt;A list should be encoded as
-	  follows: &lt;eg&gt;&lt;![ CDATA [ &lt;list&gt; &lt;item&gt;First item in the
-	  list&lt;/item&gt; &lt;item&gt;Second item&lt;/item&gt; &lt;/list&gt; ]]&gt; &lt;/eg&gt; The
-	  &lt;gi&gt;list&lt;/gi&gt; element consists of a series of &lt;gi&gt;item&lt;/gi&gt;
-	  elements.</eg>
-	  </p>
-	  <p>The <gi>list</gi> element used within the example above will not be regarded as forming part
-	  of the document proper, because it is embedded within a marked section (beginning with the
-	  special markup declaration <val>&lt;![CDATA[ </val>, and ending with <val>]]&gt;</val>).</p>
-	  <p>Note also the use of the <gi>gi</gi> element to tag references to element names (or
-	  <term>generic identifiers</term>) within the body of the text.</p>
-	</div>
-	<div>
-	  <head>Generated Divisions</head>
-	  <p>Most modern document production systems have the ability to generate automatically whole
-	  sections such as a table of contents or an index. The TEI Lite scheme provides an element to
-	  mark the location at which such a generated section should be placed. <specList>
-	  <specDesc key="divGen"/>
-	</specList>
-	  </p>
-	  <p>The <gi>divGen</gi> element can be placed anywhere that a division element would be legal,
-	  as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <front>
-	    <titlePage>
-	      <!-- ... -->
-	    </titlePage>
-	    <divGen type="toc"/>
-	    <div>
-	      <head>Preface</head>
-	      <!-- ... -->
-	    </div>
-	  </front>
-	  <body>
-	    <!-- ... -->
-	  </body>
-	  <back>
-	    <div>
-	      <head>Appendix</head>
-	      <!-- ... -->
-	    </div>
-	    <divGen type="index" n="Index"/>
-	  </back>
-	</egXML>
-	  </p>
-	  <p>This example also demonstrates the use of the <att>type</att> attribute to distinguish the
-	  different kinds of division to be generated: in the first case a table of contents (a
-	  <mentioned>toc</mentioned>) and in the second an index.</p>
-	  <p>When an existing index or table of contents is to be encoded (rather than one being
-	  generated) for some reason, the <gi>list</gi> element discussed in section <ptr target="#U5-lists"/> should be used. </p>
-	</div>
-	<div xml:id="indexing">
-	  <head>Index Generation</head>
-	  <p>While production of a table of contents from a properly tagged document is generally
-	  unproblematic for an automatic processor, the production of a good quality index will often
-	  require more careful tagging. It may not be enough simply to produce a list of all parts
-	  tagged in some particular way, although extracting (for example) all occurrences of elements
-	  such as <gi>term</gi> or <gi>name</gi> will often be a good departure point for an index. </p>
-	  <p>The TEI schema provides a special purpose <gi>index</gi> tag which may be used to mark both
-	  the parts of the document which should be indexed, and how the indexing should be done. <specList>
-	  <specDesc key="index"/>
-	</specList>
-	  </p>
-	  <p>For example, the second paragraph of this section might include the following:<egXML xmlns="http://www.tei-c.org/ns/Examples">... TEI lite also provides a special purpose
-	  <gi>index</gi> tag <index>
-	  <term>indexing</term>
-	</index>
-	<index>
-	  <term>index (tag)</term>
-	  <index>
-	    <term>use in index generation</term>
-	  </index>
-	</index>
-	which may be used ...</egXML>
-	  </p>
-	  <p>The <gi>index</gi> element can also be used to provide a form of interpretive or analytic
-	  information. For example, in a study of Ovid, it might be desired to record all the poet's
-	  references to different figures, for comparative stylistic study. In the following lines of
-	  the <title>Metamorphoses</title>, such a study would record the poet's references to Jupiter
-	  (as <mentioned>deus</mentioned>, <mentioned>se</mentioned>, and as the subject of
-	  <mentioned>confiteor</mentioned> [in inflectional form number 227]), to
-	  Jupiter-in-the-guise-of-a-bull (as <mentioned>imago tauri fallacis</mentioned> and the subject
-	  of <mentioned>teneo</mentioned>), and so on.<note place="foot">The analysis is taken, with
-	  permission, from Willard McCarty and Burton Wright, <title>An Analytical Onomasticon to the
-	  Metamorphoses of Ovid</title> (Princeton: Princeton University Press, forthcoming). Some
-	  simplifications have been undertaken.</note>
-	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <l n="3.001">iamque deus posita fallacis
-	    imagine tauri</l>
-	    <l n="3.002">se confessus erat Dictaeaque rura tenebat</l>
-	    </egXML> This
-	    need might be met using the <gi>note</gi> element discussed in section in <ptr target="#U5-notes"/>, or with the <gi>interp</gi> element discussed in section <ptr target="#U5-anal"/>. Here we demonstrate how it might also be satisfied by using the
-	  <gi>index</gi> element.</p>
-	  <p>We assume that the object is to generate more than one index: one for names of deities
-	  (called <att>dn</att>), another for onomastic references (called <att>on</att>), a third for
-	  pronominal references (called <att>pr</att>) and so forth. One way of achieving this might be
-	  as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <l n="3.001">iamque deus posita
-	  fallacis imagine tauri <index indexName="dn">
-	  <term>Iuppiter</term>
-	  <index>
-	    <term>deus</term>
-	  </index>
-	</index>
-	<index indexName="on">
-	  <term>Iuppiter (taurus)</term>
-	  <index>
-	    <term>imago tauri
-	    fallacis</term>
-	  </index>
-	</index>
-	  </l>
-	  <l n="3.002">se confessus erat Dictaeaque rura tenebat
-	  <index indexName="pr">
-	    <term>Iuppiter</term>
-	    <index>
-	      <term>se</term>
-	    </index>
-	  </index>
-	  <index indexName="v">
-	    <term>Iuppiter</term>
-	    <index>
-	      <term>confiteor
-	      (v227)</term>
-	    </index>
-	  </index>
-	  </l>
-	  </egXML> For each <gi>index</gi> element above, an entry
-	  will be generated in the appropriate index, using as headword the content of the <gi>term</gi>
-	  element it contains; the <gi>term</gi> elements nested within the secondary <gi>index</gi>
-	  element in each case provide a secondary keyword. The actual reference will be taken from the
-	  context in which the <gi>index</gi> element appears, i.e. in this case the identifier of the
-	  <gi>l</gi> element containing it. </p>
-	</div>
-	<div>
-	  <head>Addresses</head>
-	  <p>The <gi>address</gi> element is used to mark a postal address of any kind. It contains one
-	  or more <gi>addrLine</gi> elements, one for each line of the address. <specList>
-	  <specDesc key="address"/>
-	  <specDesc key="addrLine"/>
-	</specList>
-	  </p>
-	  <p>Here is a simple example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <address>
-	    <addrLine>Computer Center (M/C 135)</addrLine>
-	    <addrLine>1940 W. Taylor, Room 124</addrLine>
-	    <addrLine>Chicago, IL 60612-7352</addrLine>
-	    <addrLine>U.S.A.</addrLine>
-	  </address>
-	</egXML>
-	  </p>
-	  <p>The individual parts of an address may be further distinguished by using the <gi>name</gi>
-	  element discussed above (section <ptr target="#nomen"/>). <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <address>
-	    <addrLine>Computer Center (M/C 135)</addrLine>
-	    <addrLine>1940 W. Taylor, Room 124</addrLine>
-	    <addrLine>
-	    <name type="city">Chicago</name>, IL 60612-7352</addrLine>
-	    <addrLine>
-	      <name type="country">USA</name>
-	    </addrLine>
-	  </address>
-	</egXML>
-	  </p>
-	</div>
+        <head>Technical Documentation</head>
+        <p>Although the focus of this document is on the use of the TEI scheme for the encoding of
+        existing <soCalled>pre-electronic</soCalled> documents, the same scheme may also be used for
+        the encoding of new documents. In the preparation of new documents (such as this one), XML has
+        much to recommend it: the document's structure can be clearly represented, and the same
+        electronic text can be re-used for many purposes — to provide both online hypertext or
+        browsable versions and well-formatted typeset versions from a common source for example. </p>
+        <p>To facilitate this, the TEI Lite schema includes some elements for marking features of
+        technical documents in general, and of XML-related documents in particular.</p>
+        <div>
+          <head>Additional Elements for Technical Documents</head>
+          <p>The following elements may be used to mark particular features of technical documents: <specList>
+          <specDesc key="eg"/>
+          <specDesc key="code"/>
+          <specDesc key="ident"/>
+          <specDesc key="gi"/>
+          <specDesc key="att"/>
+          <specDesc key="formula"/>
+          <specDesc key="val"/>
+        </specList>
+          </p>
+          <p>The following example shows how these elements might be used to encode a passage from a
+          tutorial introducing the Fortran programming language: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <p>It is traditional to introduce a language with a
+          program like the following: <eg xml:space="preserve"> CHAR*12 GRTG
+          GRTG = 'HELLO WORLD' 
+          PRINT *, GRTG 
+          END
+        </eg>
+          </p>
+          <p>This simple example first declares a variable <ident>GRTG</ident>, in the line
+          <code>CHAR*12 GRTG</code>, which identifies <ident>GRTG</ident> as consisting of 12 bytes
+          of type <ident>CHAR</ident>. To this variable, the value <val>HELLO WORLD</val> is then
+          assigned.</p>
+        </egXML>
+          </p>
+          <p>A formatting application, given a text like that above, can be instructed to format examples
+          appropriately (e.g. to preserve line breaks, or to use a distinctive font). Similarly, the use
+          of tags such as <gi>ident</gi> greatly facilitates the construction of a useful index.</p>
+          <p>The <gi>formula</gi> element should be used to enclose a mathematical or chemical formula
+          presented within the text as a distinct item. Since formulae generally include a large variety
+          of special typographic features not otherwise present in ordinary text, it will usually be
+          necessary to present the body of the formula in a specialized notation. The notation used
+          should be specified by the <att>notation</att> attribute, as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <formula notation="tex"> \begin{math}E =
+          mc^{2}\end{math} </formula>
+        </egXML>
+          </p>
+          <p>A particular problem arises when XML encoding is the subject of discussion within a
+          technical document, itself encoded in XML. In such a document, it is clearly essential to
+          distinguish clearly the markup occurring within examples from that marking up the document
+          itself, and end-tags are highly likely to occur. One simple solution is to use the predefined
+          entity reference <code>&amp;lt;</code> to represent each &lt; character which marks the start
+          of an XML tag within the examples. A more general solution is to mark off the whole body of
+          each example as containing data which is not to be scanned for XML mark-up by the parser. This
+          is achieved by enclosing it within a special XML construct called a <term>
+          <code>CDATA</code>
+          marked section</term>, as in the following example: <eg xml:space="preserve">&lt;p&gt;A list should be encoded as
+          follows: &lt;eg&gt;&lt;![ CDATA [ &lt;list&gt; &lt;item&gt;First item in the
+          list&lt;/item&gt; &lt;item&gt;Second item&lt;/item&gt; &lt;/list&gt; ]]&gt; &lt;/eg&gt; The
+          &lt;gi&gt;list&lt;/gi&gt; element consists of a series of &lt;gi&gt;item&lt;/gi&gt;
+          elements.</eg>
+          </p>
+          <p>The <gi>list</gi> element used within the example above will not be regarded as forming part
+          of the document proper, because it is embedded within a marked section (beginning with the
+          special markup declaration <val>&lt;![CDATA[ </val>, and ending with <val>]]&gt;</val>).</p>
+          <p>Note also the use of the <gi>gi</gi> element to tag references to element names (or
+          <term>generic identifiers</term>) within the body of the text.</p>
+        </div>
+        <div>
+          <head>Generated Divisions</head>
+          <p>Most modern document production systems have the ability to generate automatically whole
+          sections such as a table of contents or an index. The TEI Lite scheme provides an element to
+          mark the location at which such a generated section should be placed. <specList>
+          <specDesc key="divGen"/>
+        </specList>
+          </p>
+          <p>The <gi>divGen</gi> element can be placed anywhere that a division element would be legal,
+          as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <front>
+            <titlePage>
+              <!-- ... -->
+            </titlePage>
+            <divGen type="toc"/>
+            <div>
+              <head>Preface</head>
+              <!-- ... -->
+            </div>
+          </front>
+          <body>
+            <!-- ... -->
+          </body>
+          <back>
+            <div>
+              <head>Appendix</head>
+              <!-- ... -->
+            </div>
+            <divGen type="index" n="Index"/>
+          </back>
+        </egXML>
+          </p>
+          <p>This example also demonstrates the use of the <att>type</att> attribute to distinguish the
+          different kinds of division to be generated: in the first case a table of contents (a
+          <mentioned>toc</mentioned>) and in the second an index.</p>
+          <p>When an existing index or table of contents is to be encoded (rather than one being
+          generated) for some reason, the <gi>list</gi> element discussed in section <ptr target="#U5-lists"/> should be used. </p>
+        </div>
+        <div xml:id="indexing">
+          <head>Index Generation</head>
+          <p>While production of a table of contents from a properly tagged document is generally
+          unproblematic for an automatic processor, the production of a good quality index will often
+          require more careful tagging. It may not be enough simply to produce a list of all parts
+          tagged in some particular way, although extracting (for example) all occurrences of elements
+          such as <gi>term</gi> or <gi>name</gi> will often be a good departure point for an index. </p>
+          <p>The TEI schema provides a special purpose <gi>index</gi> tag which may be used to mark both
+          the parts of the document which should be indexed, and how the indexing should be done. <specList>
+          <specDesc key="index"/>
+        </specList>
+          </p>
+          <p>For example, the second paragraph of this section might include the following:<egXML xmlns="http://www.tei-c.org/ns/Examples">... TEI lite also provides a special purpose
+          <gi>index</gi> tag <index>
+          <term>indexing</term>
+        </index>
+        <index>
+          <term>index (tag)</term>
+          <index>
+            <term>use in index generation</term>
+          </index>
+        </index>
+        which may be used ...</egXML>
+          </p>
+          <p>The <gi>index</gi> element can also be used to provide a form of interpretive or analytic
+          information. For example, in a study of Ovid, it might be desired to record all the poet's
+          references to different figures, for comparative stylistic study. In the following lines of
+          the <title>Metamorphoses</title>, such a study would record the poet's references to Jupiter
+          (as <mentioned>deus</mentioned>, <mentioned>se</mentioned>, and as the subject of
+          <mentioned>confiteor</mentioned> [in inflectional form number 227]), to
+          Jupiter-in-the-guise-of-a-bull (as <mentioned>imago tauri fallacis</mentioned> and the subject
+          of <mentioned>teneo</mentioned>), and so on.<note place="foot">The analysis is taken, with
+          permission, from Willard McCarty and Burton Wright, <title>An Analytical Onomasticon to the
+          Metamorphoses of Ovid</title> (Princeton: Princeton University Press, forthcoming). Some
+          simplifications have been undertaken.</note>
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <l n="3.001">iamque deus posita fallacis
+            imagine tauri</l>
+            <l n="3.002">se confessus erat Dictaeaque rura tenebat</l>
+            </egXML> This
+            need might be met using the <gi>note</gi> element discussed in section in <ptr target="#U5-notes"/>, or with the <gi>interp</gi> element discussed in section <ptr target="#U5-anal"/>. Here we demonstrate how it might also be satisfied by using the
+          <gi>index</gi> element.</p>
+          <p>We assume that the object is to generate more than one index: one for names of deities
+          (called <att>dn</att>), another for onomastic references (called <att>on</att>), a third for
+          pronominal references (called <att>pr</att>) and so forth. One way of achieving this might be
+          as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <l n="3.001">iamque deus posita
+          fallacis imagine tauri <index indexName="dn">
+          <term>Iuppiter</term>
+          <index>
+            <term>deus</term>
+          </index>
+        </index>
+        <index indexName="on">
+          <term>Iuppiter (taurus)</term>
+          <index>
+            <term>imago tauri
+            fallacis</term>
+          </index>
+        </index>
+          </l>
+          <l n="3.002">se confessus erat Dictaeaque rura tenebat
+          <index indexName="pr">
+            <term>Iuppiter</term>
+            <index>
+              <term>se</term>
+            </index>
+          </index>
+          <index indexName="v">
+            <term>Iuppiter</term>
+            <index>
+              <term>confiteor
+              (v227)</term>
+            </index>
+          </index>
+          </l>
+          </egXML> For each <gi>index</gi> element above, an entry
+          will be generated in the appropriate index, using as headword the content of the <gi>term</gi>
+          element it contains; the <gi>term</gi> elements nested within the secondary <gi>index</gi>
+          element in each case provide a secondary keyword. The actual reference will be taken from the
+          context in which the <gi>index</gi> element appears, i.e. in this case the identifier of the
+          <gi>l</gi> element containing it. </p>
+        </div>
+        <div>
+          <head>Addresses</head>
+          <p>The <gi>address</gi> element is used to mark a postal address of any kind. It contains one
+          or more <gi>addrLine</gi> elements, one for each line of the address. <specList>
+          <specDesc key="address"/>
+          <specDesc key="addrLine"/>
+        </specList>
+          </p>
+          <p>Here is a simple example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <address>
+            <addrLine>Computer Center (M/C 135)</addrLine>
+            <addrLine>1940 W. Taylor, Room 124</addrLine>
+            <addrLine>Chicago, IL 60612-7352</addrLine>
+            <addrLine>U.S.A.</addrLine>
+          </address>
+        </egXML>
+          </p>
+          <p>The individual parts of an address may be further distinguished by using the <gi>name</gi>
+          element discussed above (section <ptr target="#nomen"/>). <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <address>
+            <addrLine>Computer Center (M/C 135)</addrLine>
+            <addrLine>1940 W. Taylor, Room 124</addrLine>
+            <addrLine>
+            <name type="city">Chicago</name>, IL 60612-7352</addrLine>
+            <addrLine>
+              <name type="country">USA</name>
+            </addrLine>
+          </address>
+        </egXML>
+          </p>
+        </div>
       </div>
       <div xml:id="U5-chars">
-	<head>Character Sets, Diacritics, etc.</head>
-	<p>With the advent of XML and its adoption of Unicode as the required character set for all
-	documents, most problems previously associated with the representation of the divers languages
-	and writing systems of the world are greatly reduced. For those working with standard forms of
-	the European languages in particular, almost no special action is needed: any XML editor should
-	enable you to input accented letters or other <soCalled>non-ASCII</soCalled> characters
-	directly, and they should be stored in the resulting file in a way which is transferable
-	directly between different systems. </p>
-	<p>There are two important exceptions: the characters &amp; and &lt; may not be entered directly
-	in an XML document, since they have a special significance as initiating markup. They must
-	always be represented as <term>entity references</term>, like this: <code>&amp;amp;</code> or
-	<code>&amp;lt;</code>. Other characters may also be represented by means of entity reference
-	where necessary, for example to retain compatibility with a pre-Unicode processing system. </p>
+        <head>Character Sets, Diacritics, etc.</head>
+        <p>With the advent of XML and its adoption of Unicode as the required character set for all
+        documents, most problems previously associated with the representation of the divers languages
+        and writing systems of the world are greatly reduced. For those working with standard forms of
+        the European languages in particular, almost no special action is needed: any XML editor should
+        enable you to input accented letters or other <soCalled>non-ASCII</soCalled> characters
+        directly, and they should be stored in the resulting file in a way which is transferable
+        directly between different systems. </p>
+        <p>There are two important exceptions: the characters &amp; and &lt; may not be entered directly
+        in an XML document, since they have a special significance as initiating markup. They must
+        always be represented as <term>entity references</term>, like this: <code>&amp;amp;</code> or
+        <code>&amp;lt;</code>. Other characters may also be represented by means of entity reference
+        where necessary, for example to retain compatibility with a pre-Unicode processing system. </p>
       </div>
       <div xml:id="U5-fronbac">
-	<head>Front and Back Matter</head>
-	<div>
-	  <head>Front Matter</head>
-	  <p>For many purposes, particularly in older texts, the preliminary material such as title
-	  pages, prefatory epistles, etc., may provide very useful additional linguistic or social
-	  information. P5 provides a set of recommendations for distinguishing the textual elements most
-	  commonly encountered in front matter, which are summarized here.</p>
-	  <div xml:id="h51">
-	    <head>Title Page</head>
-	    <p>The start of a title page should be marked with the element <gi>titlePage</gi>. All text
-	    contained on the page should be transcribed and tagged with the appropriate element from the
-	    following list: <specList>
-	    <specDesc key="titlePage"/>
-	    <specDesc key="docTitle"/>
-	    <specDesc key="titlePart"/>
-	    <specDesc key="byline"/>
-	    <specDesc key="docAuthor"/>
-	    <specDesc key="docDate"/>
-	    <specDesc key="docEdition"/>
-	    <specDesc key="docImprint"/>
-	    <specDesc key="epigraph"/>
-	  </specList>
-	    </p>
-	    <p>Typeface distinctions should be marked with the <att>rend</att> attribute when necessary,
-	    as described above. Very detailed description of the letter spacing and sizing used in
-	    ornamental titles is not as yet provided for by the Guidelines. Changes of language should be
-	    marked by appropriate use of the <att>xml:lang</att> attribute or the <gi>foreign</gi>
-	    element, as necessary. Names of people, places, or organizations, may be tagged using the
-	    <gi>name</gi> element wherever they appear if no other more specific element is
-	    available.</p>
-	    <p>Two example title pages follow: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <titlePage rend="Roman">
-	      <docTitle>
-		<titlePart type="main"> PARADISE REGAIN'D. A POEM In IV <hi>BOOKS</hi>. </titlePart>
-		<titlePart> To which is added <title>SAMSON AGONISTES</title>. </titlePart>
-	      </docTitle>
-	      <byline>The Author <docAuthor>JOHN MILTON</docAuthor>
-	      </byline>
-	      <docImprint>
-		<name>LONDON</name>, Printed by <name>J.M.</name> for <name>John Starkey</name>
-		at the <name>Mitre</name> in <name>Fleetstreet</name>, near
-		<name>Temple-Bar.</name>
-	      </docImprint>
-	      <docDate>MDCLXXI</docDate>
-	    </titlePage>
-	  </egXML>
-	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <titlePage>
-	      <docTitle>
-		<titlePart type="main"> Lives of the Queens of England, from the Norman
-		Conquest;</titlePart>
-		<titlePart type="sub">with anecdotes of their courts. </titlePart>
-	      </docTitle>
-	      <titlePart>Now first published from Official Records and other authentic documents private
-	      as well as public.</titlePart>
-	      <docEdition>New edition, with corrections and additions</docEdition>
-	      <byline>By <docAuthor>Agnes Strickland</docAuthor>
-	      </byline>
-	      <epigraph>
-		<q>The treasures of antiquity laid up in old historic rolls, I opened.</q>
-		<bibl>BEAUMONT</bibl>
-	      </epigraph>
-	      <docImprint>Philadelphia: Blanchard and Lea</docImprint>
-	      <docDate>1860.</docDate>
-	    </titlePage>
-	  </egXML>
-	    </p>
-	    <p>As elsewhere, the <att>ref</att> attribute may be used to link a name with a canonical
-	    definition of the entity being named. For example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <byline>By <docAuthor>
-	    <name ref="http://en.wikipedia.org/wiki/Agnes_Strickland">Agnes
-	    Strickland</name>
-	  </docAuthor>
-	    </byline>
-	  </egXML>
-	    </p>
-	  </div>
-	  <div xml:id="h52">
-	    <head>Prefatory Matter</head>
-	    <p>Major blocks of text within the front matter should be marked using
-	    <gi>div</gi> elements; the following suggested values for the <att>type</att> attribute may
-	    be used to distinguish various common types of prefatory matter: <list type="gloss">
-	    <label>preface</label>
-	    <item>A foreword or preface addressed to the reader in which the author or publisher
-	    explains the content, purpose, or origin of the text</item>
-	    <label>dedication</label>
-	    <item>A formal offering or dedication of a text to one or more persons or institutions by
-	    the author.</item>
-	    <label>abstract</label>
-	    <item>A summary of the content of a text as continuous prose</item>
-	    <label>ack</label>
-	    <item>A formal declaration of acknowledgment by the author in which persons and institutions
-	    are thanked for their part in the creation of a text</item>
-	    <label>contents</label>
-	    <item>A table of contents, specifying the structure of a work and listing its constituents.
-	    The <gi>list</gi> element should be used to mark its structure.</item>
-	    <label>frontispiece</label>
-	    <item>A pictorial frontispiece, possibly including some text.</item>
-	  </list>
-	    </p>
-	    <p>Where other kinds of prefatory matter are encountered, the encoder is at liberty to invent
-	    other values for the <att>type</att> attribute.</p>
-	    <p>Like any text division, those in front matter may contain low level structural or
-	    non-structural elements as described elsewhere. They will generally begin with a heading or
-	    title of some kind which should be tagged using the <gi>head</gi> element. Epistles will
-	    contain the following additional elements: <specList>
-	    <specDesc key="salute"/>
-	    <specDesc key="signed"/>
-	    <specDesc key="byline"/>
-	    <specDesc key="dateline"/>
-	    <specDesc key="argument"/>
-	    <specDesc key="cit"/>
-	    <specDesc key="imprimatur"/>
-	    <specDesc key="opener"/>
-	    <specDesc key="closer"/>
-	  </specList>
-	    </p>
-	    <p> Epistles which appear elsewhere in a text will, of course, contain these same
-	    elements.</p>
-	    <p>As an example, the dedication at the start of Milton's <title>Comus</title> should be
-	    marked up as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <div type="dedication">
-	      <head>To the Right Honourable <name>JOHN Lord Viscount BRACLY</name>, Son and Heir apparent
-	      to the Earl of Bridgewater, &amp;c.</head>
-	      <salute>MY LORD,</salute>
-	      <p>THis <hi>Poem</hi>, which receiv'd its first occasion of Birth from your Self, and
-	      others of your Noble Family .... and as in this representation your attendant
-	      <name>Thyrsis</name>, so now in all reall expression</p>
-	      <closer>
-		<salute>Your faithfull, and most humble servant</salute>
-		<signed>
-		  <name>H. LAWES.</name>
-		</signed>
-	      </closer>
-	    </div>
-	  </egXML>
-	    </p>
-	  </div>
-	</div>
-	<div>
-	  <head>Back Matter</head>
-	  <div>
-	    <head>Structural Divisions of Back Matter</head>
-	    <p>Because of variations in publishing practice, back matter can contain virtually any of the
-	    elements listed above for front matter, and the same elements should be used where this is
-	    so. Additionally, back matter may contain the following types of matter within the
-	    <gi>back</gi> element. Like the structural divisions of the body, these should be marked as
-	    <gi>div</gi> elements, and distinguished by the following suggested values of the
-	    <att>type</att> attribute: <list type="gloss">
-	    <label>appendix</label>
-	    <item>An ancillary self-contained section of a work, often providing additional but in some
-	    sense extra-canonical text.</item>
-	    <label>glossary</label>
-	    <item>A list of terms associated with definition texts (‘glosses’): this should be encoded
-	    as a <tag>&lt;list type="gloss"&gt;</tag> element</item>
-	    <label>notes</label>
-	    <item>A section in which textual or other kinds of notes are gathered together.</item>
-	    <label>bibliogr</label>
-	    <item>A list of bibliographic citations: this should be encoded as a <gi>listBibl</gi>
-	    </item>
-	    <label>index</label>
-	    <item>Any form of pre-existing index to the work (An index may also be generated for a
-	    document by using the <gi>index</gi> element described above).</item>
-	    <label>colophon</label>
-	    <item>A statement appearing at the end of a book describing the conditions of its physical
-	    production.</item>
-	  </list>
-	    </p>
-	  </div>
-	</div>
+        <head>Front and Back Matter</head>
+        <div>
+          <head>Front Matter</head>
+          <p>For many purposes, particularly in older texts, the preliminary material such as title
+          pages, prefatory epistles, etc., may provide very useful additional linguistic or social
+          information. P5 provides a set of recommendations for distinguishing the textual elements most
+          commonly encountered in front matter, which are summarized here.</p>
+          <div xml:id="h51">
+            <head>Title Page</head>
+            <p>The start of a title page should be marked with the element <gi>titlePage</gi>. All text
+            contained on the page should be transcribed and tagged with the appropriate element from the
+            following list: <specList>
+            <specDesc key="titlePage"/>
+            <specDesc key="docTitle"/>
+            <specDesc key="titlePart"/>
+            <specDesc key="byline"/>
+            <specDesc key="docAuthor"/>
+            <specDesc key="docDate"/>
+            <specDesc key="docEdition"/>
+            <specDesc key="docImprint"/>
+            <specDesc key="epigraph"/>
+          </specList>
+            </p>
+            <p>Typeface distinctions should be marked with the <att>rend</att> attribute when necessary,
+            as described above. Very detailed description of the letter spacing and sizing used in
+            ornamental titles is not as yet provided for by the Guidelines. Changes of language should be
+            marked by appropriate use of the <att>xml:lang</att> attribute or the <gi>foreign</gi>
+            element, as necessary. Names of people, places, or organizations, may be tagged using the
+            <gi>name</gi> element wherever they appear if no other more specific element is
+            available.</p>
+            <p>Two example title pages follow: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <titlePage rend="Roman">
+              <docTitle>
+                <titlePart type="main"> PARADISE REGAIN'D. A POEM In IV <hi>BOOKS</hi>. </titlePart>
+                <titlePart> To which is added <title>SAMSON AGONISTES</title>. </titlePart>
+              </docTitle>
+              <byline>The Author <docAuthor>JOHN MILTON</docAuthor>
+              </byline>
+              <docImprint>
+                <name>LONDON</name>, Printed by <name>J.M.</name> for <name>John Starkey</name>
+                at the <name>Mitre</name> in <name>Fleetstreet</name>, near
+                <name>Temple-Bar.</name>
+              </docImprint>
+              <docDate>MDCLXXI</docDate>
+            </titlePage>
+          </egXML>
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <titlePage>
+              <docTitle>
+                <titlePart type="main"> Lives of the Queens of England, from the Norman
+                Conquest;</titlePart>
+                <titlePart type="sub">with anecdotes of their courts. </titlePart>
+              </docTitle>
+              <titlePart>Now first published from Official Records and other authentic documents private
+              as well as public.</titlePart>
+              <docEdition>New edition, with corrections and additions</docEdition>
+              <byline>By <docAuthor>Agnes Strickland</docAuthor>
+              </byline>
+              <epigraph>
+                <q>The treasures of antiquity laid up in old historic rolls, I opened.</q>
+                <bibl>BEAUMONT</bibl>
+              </epigraph>
+              <docImprint>Philadelphia: Blanchard and Lea</docImprint>
+              <docDate>1860.</docDate>
+            </titlePage>
+          </egXML>
+            </p>
+            <p>As elsewhere, the <att>ref</att> attribute may be used to link a name with a canonical
+            definition of the entity being named. For example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <byline>By <docAuthor>
+            <name ref="http://en.wikipedia.org/wiki/Agnes_Strickland">Agnes
+            Strickland</name>
+          </docAuthor>
+            </byline>
+          </egXML>
+            </p>
+          </div>
+          <div xml:id="h52">
+            <head>Prefatory Matter</head>
+            <p>Major blocks of text within the front matter should be marked using
+            <gi>div</gi> elements; the following suggested values for the <att>type</att> attribute may
+            be used to distinguish various common types of prefatory matter: <list type="gloss">
+            <label>preface</label>
+            <item>A foreword or preface addressed to the reader in which the author or publisher
+            explains the content, purpose, or origin of the text</item>
+            <label>dedication</label>
+            <item>A formal offering or dedication of a text to one or more persons or institutions by
+            the author.</item>
+            <label>abstract</label>
+            <item>A summary of the content of a text as continuous prose</item>
+            <label>ack</label>
+            <item>A formal declaration of acknowledgment by the author in which persons and institutions
+            are thanked for their part in the creation of a text</item>
+            <label>contents</label>
+            <item>A table of contents, specifying the structure of a work and listing its constituents.
+            The <gi>list</gi> element should be used to mark its structure.</item>
+            <label>frontispiece</label>
+            <item>A pictorial frontispiece, possibly including some text.</item>
+          </list>
+            </p>
+            <p>Where other kinds of prefatory matter are encountered, the encoder is at liberty to invent
+            other values for the <att>type</att> attribute.</p>
+            <p>Like any text division, those in front matter may contain low level structural or
+            non-structural elements as described elsewhere. They will generally begin with a heading or
+            title of some kind which should be tagged using the <gi>head</gi> element. Epistles will
+            contain the following additional elements: <specList>
+            <specDesc key="salute"/>
+            <specDesc key="signed"/>
+            <specDesc key="byline"/>
+            <specDesc key="dateline"/>
+            <specDesc key="argument"/>
+            <specDesc key="cit"/>
+            <specDesc key="imprimatur"/>
+            <specDesc key="opener"/>
+            <specDesc key="closer"/>
+          </specList>
+            </p>
+            <p> Epistles which appear elsewhere in a text will, of course, contain these same
+            elements.</p>
+            <p>As an example, the dedication at the start of Milton's <title>Comus</title> should be
+            marked up as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <div type="dedication">
+              <head>To the Right Honourable <name>JOHN Lord Viscount BRACLY</name>, Son and Heir apparent
+              to the Earl of Bridgewater, &amp;c.</head>
+              <salute>MY LORD,</salute>
+              <p>THis <hi>Poem</hi>, which receiv'd its first occasion of Birth from your Self, and
+              others of your Noble Family .... and as in this representation your attendant
+              <name>Thyrsis</name>, so now in all reall expression</p>
+              <closer>
+                <salute>Your faithfull, and most humble servant</salute>
+                <signed>
+                  <name>H. LAWES.</name>
+                </signed>
+              </closer>
+            </div>
+          </egXML>
+            </p>
+          </div>
+        </div>
+        <div>
+          <head>Back Matter</head>
+          <div>
+            <head>Structural Divisions of Back Matter</head>
+            <p>Because of variations in publishing practice, back matter can contain virtually any of the
+            elements listed above for front matter, and the same elements should be used where this is
+            so. Additionally, back matter may contain the following types of matter within the
+            <gi>back</gi> element. Like the structural divisions of the body, these should be marked as
+            <gi>div</gi> elements, and distinguished by the following suggested values of the
+            <att>type</att> attribute: <list type="gloss">
+            <label>appendix</label>
+            <item>An ancillary self-contained section of a work, often providing additional but in some
+            sense extra-canonical text.</item>
+            <label>glossary</label>
+            <item>A list of terms associated with definition texts (‘glosses’): this should be encoded
+            as a <tag>&lt;list type="gloss"&gt;</tag> element</item>
+            <label>notes</label>
+            <item>A section in which textual or other kinds of notes are gathered together.</item>
+            <label>bibliogr</label>
+            <item>A list of bibliographic citations: this should be encoded as a <gi>listBibl</gi>
+            </item>
+            <label>index</label>
+            <item>Any form of pre-existing index to the work (An index may also be generated for a
+            document by using the <gi>index</gi> element described above).</item>
+            <label>colophon</label>
+            <item>A statement appearing at the end of a book describing the conditions of its physical
+            production.</item>
+          </list>
+            </p>
+          </div>
+        </div>
       </div>
       <div xml:id="U5-header">
-	<head>The Electronic Title Page</head>
-	<p>Every TEI text has a header which provides information analogous to that provided by the
-	title page of printed text. The header is introduced by the element <gi>teiHeader</gi> and has
-	four major parts: <specList>
-	<specDesc key="fileDesc"/>
-	<specDesc key="encodingDesc"/>
-	<specDesc key="profileDesc"/>
-	<specDesc key="revisionDesc"/>
+        <head>The Electronic Title Page</head>
+        <p>Every TEI text has a header which provides information analogous to that provided by the
+        title page of printed text. The header is introduced by the element <gi>teiHeader</gi> and has
+        four major parts: <specList>
+        <specDesc key="fileDesc"/>
+        <specDesc key="encodingDesc"/>
+        <specDesc key="profileDesc"/>
+        <specDesc key="revisionDesc"/>
       </specList>
-	</p>
-	<p> A corpus or collection of texts with many shared characteristics may have one header for
-	the corpus and individual headers for each component of the corpus. In this case the
-	<att>type</att> attribute indicates the type of header. <code>&lt;teiHeader
-	type="corpus"&gt;</code> introduces the header for corpus-level information.</p>
-	<p>Some of the header elements contain running prose which consists of one or more <gi>p</gi>s.
-	Others are grouped: <list>
-	<item>Elements whose names end in <mentioned>Stmt</mentioned> (for statement) usually enclose a
-	group of elements recording some structured information.</item>
-	<item>Elements whose names end in <mentioned>Decl</mentioned> (for declaration) enclose
-	information about specific encoding practices.</item>
-	<item>Elements whose names end in <mentioned>Desc</mentioned> (for description) contain a
-	prose description.</item>
+        </p>
+        <p> A corpus or collection of texts with many shared characteristics may have one header for
+        the corpus and individual headers for each component of the corpus. In this case the
+        <att>type</att> attribute indicates the type of header. <code>&lt;teiHeader
+        type="corpus"&gt;</code> introduces the header for corpus-level information.</p>
+        <p>Some of the header elements contain running prose which consists of one or more <gi>p</gi>s.
+        Others are grouped: <list>
+        <item>Elements whose names end in <mentioned>Stmt</mentioned> (for statement) usually enclose a
+        group of elements recording some structured information.</item>
+        <item>Elements whose names end in <mentioned>Decl</mentioned> (for declaration) enclose
+        information about specific encoding practices.</item>
+        <item>Elements whose names end in <mentioned>Desc</mentioned> (for description) contain a
+        prose description.</item>
       </list>
-	</p>
-	<div>
-	  <head>The File Description</head>
-	  <p>The <gi>fileDesc</gi> element is mandatory. It contains a full bibliographic description of
-	  the file with the following elements: <specList>
-	  <specDesc key="titleStmt"/>
-	  <specDesc key="editionStmt"/>
-	  <specDesc key="extent"/>
-	  <specDesc key="publicationStmt"/>
-	  <specDesc key="seriesStmt"/>
-	  <specDesc key="notesStmt"/>
-	  <specDesc key="sourceDesc"/>
-	</specList>
-	  </p>
-	  <p> A minimal header has the following structure: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <teiHeader>
-	    <fileDesc>
-	      <titleStmt>
-		<!-- bibliographic description of the digital resource -->
-	      </titleStmt>
-	      <publicationStmt>
-		<!-- information about how the resource is distributed -->
-	      </publicationStmt>
-	      <sourceDesc>
-		<!-- information about the sources from which the digital resource is derived -->
-	      </sourceDesc>
-	    </fileDesc>
-	  </teiHeader>
-	</egXML>
-	  </p>
-	  <div>
-	    <head>The Title Statement</head>
-	    <p>The following elements can be used in the <gi>titleStmt</gi>: <specList>
-	    <specDesc key="title"/>
-	    <specDesc key="author"/>
-	    <specDesc key="sponsor"/>
-	    <specDesc key="funder"/>
-	    <specDesc key="principal"/>
-	    <specDesc key="respStmt"/>
-	  </specList>
-	    </p>
-	    <p> The title of a digital resource derived from a non-digital one will obviously be similar.
-	    However, it is important to distinguish the title of the computer file from that of the
-	    source text, for example: <eg>[title of source]: a machine readable transcription [title of
-	    source]: electronic edition A machine readable version of: [title of source]</eg> The
-	    <gi>respStmt</gi> element contains the following subcomponents: <specList>
-	    <specDesc key="resp"/>
-	    <specDesc key="name"/>
-	    </specList> Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <titleStmt>
-	      <title>Two stories by Edgar Allen Poe: a machine readable transcription</title>
-	      <author>Poe, Edgar Allen (1809-1849)</author>
-	      <respStmt>
-		<resp>compiled by</resp>
-		<name>James D. Benson</name>
-	      </respStmt>
-	    </titleStmt>
-	  </egXML>
-	    </p>
-	  </div>
-	  <div>
-	    <head>The Edition Statement</head>
-	    <p>The <gi>editionStmt</gi> groups information relating to one edition of the digital resource
-	    (where <mentioned>edition</mentioned> is used as elsewhere in bibliography), and may include
-	    the following elements: <specList>
-	    <specDesc key="edition"/>
-	    <specDesc key="respStmt"/>
-	  </specList>
-	    </p>
-	    <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <editionStmt>
-	      <edition n="U2">Third
-	      draft, substantially revised <date>1987</date>
-	      </edition>
-	    </editionStmt>
-	  </egXML>
-	    </p>
-	    <p>Determining exactly what constitutes a new edition of an electronic text is left to the
-	    encoder.</p>
-	  </div>
-	  <div>
-	    <head>The Extent Statement</head>
-	    <p>The <gi>extent</gi> statement describes the approximate size of the digital resource.</p>
-	    <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <extent>4532
-	    bytes</extent>
-	  </egXML>
-	    </p>
-	  </div>
-	  <div>
-	    <head>The Publication Statement</head>
-	    <p>The <gi>publicationStmt</gi> is mandatory. It may contain a simple prose description or
-	    groups of the elements described below: <specList>
-	    <specDesc key="publisher"/>
-	    <specDesc key="distributor"/>
-	    <specDesc key="authority"/>
-	  </specList>
-	    </p>
-	    <p>At least one of these three elements must be present, unless the entire publication
-	    statement is in prose. The following elements may occur within them: <specList>
-	    <specDesc key="pubPlace"/>
-	    <specDesc key="address"/>
-	    <specDesc key="idno"/>
-	    <specDesc key="availability"/>
-	    <specDesc key="licence"/>
-	    <specDesc key="date"/>
-	  </specList>
-	    </p>
-	    <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <publicationStmt>
-	      <publisher>University of Victoria Humanities Computing and Media Centre</publisher>
-	      <pubPlace>Victoria, BC</pubPlace>
-	      <date>2011</date>
-	      <availability status="restricted">
-		<licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a
-		Creative Commons Attribution-ShareAlike 3.0 Unported License </licence>
-	      </availability>
-	    </publicationStmt>
-	  </egXML>
-	    </p>
-	  </div>
-	  <div>
-	    <head>Series and Notes Statements</head>
-	    <p>The <gi>seriesStmt</gi> element groups information about the series, if any, to which a
-	    publication belongs. It may contain <gi>title</gi>, <gi>idno</gi>, or <gi>respStmt</gi>
-	    elements.</p>
-	    <p>The <gi>notesStmt</gi>, if used, contains one or more <gi>note</gi> elements which contain
-	    a note or annotation. Some information found in the notes area in conventional bibliography
-	    has been assigned specific elements in the TEI scheme.</p>
-	  </div>
-	  <div>
-	    <head>The Source Description</head>
-	    <p>The <gi>sourceDesc</gi> is a mandatory element which records details of the source or
-	    sources from which the computer file is derived. It may contain simple prose or a
-	    bibliographic citation, using one or more of the following elements: <specList>
-	    <specDesc key="bibl"/>
-	    <specDesc key="listBibl"/>
-	  </specList>
-	    </p>
-	    <p>Examples: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <sourceDesc>
-	      <bibl>The first folio of Shakespeare, prepared by Charlton Hinman (The Norton Facsimile,
-	      1968)</bibl>
-	    </sourceDesc>
-	  </egXML>
-	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <sourceDesc>
-	      <bibl>
-		<author>CNN Network News</author>
-		<title>News headlines</title>
-		<date>12 Jun
-		1989</date>
-	      </bibl>
-	    </sourceDesc>
-	  </egXML>
-	    </p>
-	  </div>
-	</div>
-	<div>
-	  <head>The Encoding Description</head>
-	  <p>The <gi>encodingDesc</gi> element specifies the methods and editorial principles which
-	  governed the transcription of the text. Its use is highly recommended. It may be prose
-	  description or may contain elements from the following list: <specList>
-	  <specDesc key="projectDesc"/>
-	  <specDesc key="samplingDecl"/>
-	  <specDesc key="editorialDecl"/>
-	  <specDesc key="refsDecl"/>
-	  <specDesc key="classDecl"/>
-	</specList>
-	  </p>
-	  <div>
-	    <head>Project and Sampling Descriptions</head>
-	    <p>Examples of <gi>projectDesc</gi> and <gi>samplingDesc</gi>: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <encodingDesc>
-	      <projectDesc>
-		<p>Texts collected for
-		use in the Claremont Shakespeare Clinic, June 1990.
-		</p>
-	      </projectDesc>
-	    </encodingDesc>
-	  </egXML>
-	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <encodingDesc>
-	      <samplingDecl>
-		<p>Samples of
-		2000 words taken from the beginning of the text</p>
-	      </samplingDecl>
-	    </encodingDesc>
-	  </egXML>
-	    </p>
-	  </div>
-	  <div>
-	    <head>Editorial Declarations</head>
-	    <p>The <gi>editorialDecl</gi> contains a prose description of the practices used when encoding
-	    the text. Typically this description should cover such topics as the following, each of which
-	    may conveniently be given as a separate paragraph. <list type="gloss">
-	    <label>correction </label>
-	    <item>how and under what circumstances corrections have been made in the text.</item>
-	    <label>normalization</label>
-	    <item>the extent to which the original source has been regularized or normalized.</item>
-	    <label>quotation</label>
-	    <item>what has been done with quotation marks in the original -- have they been retained or
-	    replaced by entity references, are opening and closing quotes distinguished, etc. </item>
-	    <label>hyphenation</label>
-	    <item>what has been done with hyphens (especially end-of-line hyphens) in the original --
-	    have they been retained, replaced by entity references, etc.</item>
-	    <label>segmentation</label>
-	    <item>how has the text has been segmented, for example into sentences, tone-units, graphemic
-	    strata, etc.</item>
-	    <label>interpretation</label>
-	    <item>what analytic or interpretive information has been added to the text. </item>
-	  </list>
-	    </p>
-	    <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <editorialDecl>
-	      <p>The part of
-	      speech analysis applied throughout section 4 was added by hand and has not been
-	      checked.</p>
-	      <p>Errors in transcription controlled by using the WordPerfect spelling
-	      checker.</p>
-	      <p>All words converted to Modern American spelling using Webster's 9th
-	      Collegiate dictionary.</p>
-	    </editorialDecl>
-	  </egXML>
-	    </p>
-	  </div>
-	  <div xml:id="refsdecl">
-	    <head>Reference and Classification Declarations</head>
-	    <p>The <gi>refsDecl</gi> element is used to document the way in which any standard referencing
-	    scheme built into the encoding works. In its simplest form, it consists of prose
-	    description.</p>
-	    <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <refsDecl>
-	      <p>The <att>n</att>
-	      attribute on each <gi>div</gi> contains the canonical reference for each division in the
-	      form XX.yyy where XX is the book number in roman numeral and yyy is the section number in
-	      arabic.</p>
-	      <p>Milestone tags refer to the edition of 1830 as E30 and that of 1850 as E50.
-	      </p>
-	    </refsDecl>
-	  </egXML>
-	    </p>
-	    <p>The <gi>classDecl</gi> element groups together definitions or sources for any descriptive
-	    classification schemes used by other parts of the header. At least one such scheme must be
-	    provided, encoded using the following elements: <specList>
-	    <specDesc key="taxonomy"/>
-	    <specDesc key="bibl"/>
-	    <specDesc key="category"/>
-	    <specDesc key="catDesc"/>
-	  </specList>
-	    </p>
-	    <p> In the simplest case, the taxonomy may be defined by a bibliographic reference, as in the
-	    following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <classDecl>
-	      <taxonomy xml:id="LC-SH">
-		<bibl>Library of Congress Subject Headings
-		</bibl>
-	      </taxonomy>
-	    </classDecl>
-	  </egXML>
-	    </p>
-	    <p>Alternatively, or in addition, the encoder may define a special purpose classification
-	    scheme, as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <taxonomy xml:id="B">
-	      <bibl>Brown Corpus</bibl>
-	      <category xml:id="B.A">
-		<catDesc>Press
-		Reportage</catDesc>
-		<category xml:id="B.A1">
-		  <catDesc>Daily</catDesc>
-		</category>
-		<category xml:id="B.A2">
-		  <catDesc>Sunday</catDesc>
-		</category>
-		<category xml:id="B.A3">
-		  <catDesc>National</catDesc>
-		</category>
-		<category xml:id="B.A4">
-		  <catDesc>Provincial</catDesc>
-		</category>
-		<category xml:id="B.A5">
-		  <catDesc>Political</catDesc>
-		</category>
-		<category xml:id="B.A6">
-		  <catDesc>Sports</catDesc>
-		</category>
-	      </category>
-	      <category xml:id="B.D">
-		<catDesc>Religion</catDesc>
-		<category xml:id="B.D1">
-		  <catDesc>Books</catDesc>
-		</category>
-		<category xml:id="B.D2">
-		  <catDesc>Periodicals and
-		  tracts</catDesc>
-		</category>
-	      </category>
-	    </taxonomy>
-	  </egXML>
-	    </p>
-	    <p>Linkage between a particular text and a category within such a taxonomy is made by means of
-	    the <gi>catRef</gi> element within the <gi>textClass</gi> element, as described in the next
-	    section below.</p>
-	  </div>
-	</div>
-	<div>
-	  <head>The Profile Description</head>
-	  <p>The <gi>profileDesc</gi> element enables information characterizing various descriptive
-	  aspects of a text to be recorded within a single framework. It has three optional components: <specList>
-	  <specDesc key="creation"/>
-	  <specDesc key="langUsage"/>
-	  <specDesc key="textClass"/>
-	</specList>
-	  </p>
-	  <p>The <gi>creation</gi> element is useful for documenting where a work was created, even
-	  though it may not have been published or recorded there.</p>
-	  <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <creation>
-	    <date when="1992-08">August 1992</date>
-	    <name type="place">Taos, New Mexico</name>
-	  </creation>
-	</egXML>
-	  </p>
-	  <p>The <gi>langUsage</gi> element is useful where a text contains many different languages. It
-	  may contain <gi>language</gi> elements to document each particular language used: <specList>
-	  <specDesc key="language"/>
-	  </specList> For example, a text containing predominantly text in French as spoken in Quebec,
-	  but also smaller amounts of British and Canadian English might be documented as follows:
-	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <langUsage>
-	      <language ident="fr-CA" usage="60">Québecois</language>
-	      <language ident="en-CA" usage="20">Canadian business English</language>
-	      <language ident="en-GB" usage="20">British English</language>
-	    </langUsage>
-	  </egXML>
-	  </p>
-	  <p>The <gi>textClass</gi> element classifies a text. This may be done with reference to a
-	  classification system locally defined by means of the <gi>classDecl</gi> element, or by
-	  reference to some externally defined established scheme such as the Universal Decimal
-	  Classification. Texts may also be classified using lists of keywords, which may themselves be
-	  drawn from locally or externally defined control lists. The following elements are used to
-	  supply such classifications: <specList>
-	  <specDesc key="classCode"/>
-	  <specDesc key="catRef"/>
-	  <specDesc key="keywords"/>
-	</specList>
-	  </p>
-	  <p>The simplest way of classifying a text is by means of the <gi>classCode</gi> element. For
-	  example, a text with classification 410 in the Universal Decimal Classification might be
-	  documented as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <classCode scheme="http://www.udc.org">410</classCode>
-	</egXML>
-	  </p>
-	  <p>When a classification scheme has been locally defined using the <gi>taxonomy</gi> element
-	  discussed in the preceding subsection, the <gi>catRef</gi> element should be used to reference
-	  it. To continue the earlier example, a work classified in the Brown Corpus as <code>Press
-	  reportage - Sunday</code> and also as <code>Religion</code> might be documented as follows:
-	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	    <catRef target="#B.A3 #B.D"/>
-	  </egXML>
-	  </p>
-	  <p>The element <gi>keywords</gi> contains a list of keywords or phrases identifying the topic
-	  or nature of a text. As usual, the attribute <att>scheme</att> identifies the source from
-	  which these terms are taken. For example, if the LC Subject Headings are used, following
-	  declaration of that classification system in a <gi>taxonomy</gi> element as above : <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <textClass>
-	    <keywords scheme="#LCSH">
-	      <list>
-		<item>English literature -- History and criticism -- Data processing.</item>
-		<item>English literature -- History and criticism -- Theory etc.</item>
-		<item>English language -- Style -- Data processing.</item>
-	      </list>
-	    </keywords>
-	  </textClass>
-	</egXML>
-	  </p>
-	  <p>Multiple classifications may be supplied using
-	  any of the mechanisms described in this section.</p>
-	</div>
-	<div>
-	  <head>The Revision Description</head>
-	  <p>The <gi>revisionDesc</gi> element provides a change log in which each change made to a text
-	  may be recorded. The log may be recorded as a sequence of <gi>change</gi> elements each of
-	  which contains a brief description of the change. The attributes <att>when</att> and
-	  <att>who</att> may be used to identify when the change was carried out and the agency
-	  responsible for it. </p>
-	  <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-	  <revisionDesc>
-	    <change when="1991-03-06" who="#EMB">File format updated</change>
-	    <change when="1990-05-25" who="#EMB">Stuart's corrections entered</change>
-	  </revisionDesc>
-	</egXML>
-	  </p>
-	  <p>In a production environment it will usually be found preferable to use some kind of
-	  automated system to track and record changes. Many such <term>version control systems</term>,
-	  as they are known, can also be configured to update the TEI Header of a file automatically.
-	  </p>
-	</div>
+        </p>
+        <div>
+          <head>The File Description</head>
+          <p>The <gi>fileDesc</gi> element is mandatory. It contains a full bibliographic description of
+          the file with the following elements: <specList>
+          <specDesc key="titleStmt"/>
+          <specDesc key="editionStmt"/>
+          <specDesc key="extent"/>
+          <specDesc key="publicationStmt"/>
+          <specDesc key="seriesStmt"/>
+          <specDesc key="notesStmt"/>
+          <specDesc key="sourceDesc"/>
+        </specList>
+          </p>
+          <p> A minimal header has the following structure: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <teiHeader>
+            <fileDesc>
+              <titleStmt>
+                <!-- bibliographic description of the digital resource -->
+              </titleStmt>
+              <publicationStmt>
+                <!-- information about how the resource is distributed -->
+              </publicationStmt>
+              <sourceDesc>
+                <!-- information about the sources from which the digital resource is derived -->
+              </sourceDesc>
+            </fileDesc>
+          </teiHeader>
+        </egXML>
+          </p>
+          <div>
+            <head>The Title Statement</head>
+            <p>The following elements can be used in the <gi>titleStmt</gi>: <specList>
+            <specDesc key="title"/>
+            <specDesc key="author"/>
+            <specDesc key="sponsor"/>
+            <specDesc key="funder"/>
+            <specDesc key="principal"/>
+            <specDesc key="respStmt"/>
+          </specList>
+            </p>
+            <p> The title of a digital resource derived from a non-digital one will obviously be similar.
+            However, it is important to distinguish the title of the computer file from that of the
+            source text, for example: <eg>[title of source]: a machine readable transcription [title of
+            source]: electronic edition A machine readable version of: [title of source]</eg> The
+            <gi>respStmt</gi> element contains the following subcomponents: <specList>
+            <specDesc key="resp"/>
+            <specDesc key="name"/>
+            </specList> Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <titleStmt>
+              <title>Two stories by Edgar Allen Poe: a machine readable transcription</title>
+              <author>Poe, Edgar Allen (1809-1849)</author>
+              <respStmt>
+                <resp>compiled by</resp>
+                <name>James D. Benson</name>
+              </respStmt>
+            </titleStmt>
+          </egXML>
+            </p>
+          </div>
+          <div>
+            <head>The Edition Statement</head>
+            <p>The <gi>editionStmt</gi> groups information relating to one edition of the digital resource
+            (where <mentioned>edition</mentioned> is used as elsewhere in bibliography), and may include
+            the following elements: <specList>
+            <specDesc key="edition"/>
+            <specDesc key="respStmt"/>
+          </specList>
+            </p>
+            <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <editionStmt>
+              <edition n="U2">Third
+              draft, substantially revised <date>1987</date>
+              </edition>
+            </editionStmt>
+          </egXML>
+            </p>
+            <p>Determining exactly what constitutes a new edition of an electronic text is left to the
+            encoder.</p>
+          </div>
+          <div>
+            <head>The Extent Statement</head>
+            <p>The <gi>extent</gi> statement describes the approximate size of the digital resource.</p>
+            <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <extent>4532
+            bytes</extent>
+          </egXML>
+            </p>
+          </div>
+          <div>
+            <head>The Publication Statement</head>
+            <p>The <gi>publicationStmt</gi> is mandatory. It may contain a simple prose description or
+            groups of the elements described below: <specList>
+            <specDesc key="publisher"/>
+            <specDesc key="distributor"/>
+            <specDesc key="authority"/>
+          </specList>
+            </p>
+            <p>At least one of these three elements must be present, unless the entire publication
+            statement is in prose. The following elements may occur within them: <specList>
+            <specDesc key="pubPlace"/>
+            <specDesc key="address"/>
+            <specDesc key="idno"/>
+            <specDesc key="availability"/>
+            <specDesc key="licence"/>
+            <specDesc key="date"/>
+          </specList>
+            </p>
+            <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <publicationStmt>
+              <publisher>University of Victoria Humanities Computing and Media Centre</publisher>
+              <pubPlace>Victoria, BC</pubPlace>
+              <date>2011</date>
+              <availability status="restricted">
+                <licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a
+                Creative Commons Attribution-ShareAlike 3.0 Unported License </licence>
+              </availability>
+            </publicationStmt>
+          </egXML>
+            </p>
+          </div>
+          <div>
+            <head>Series and Notes Statements</head>
+            <p>The <gi>seriesStmt</gi> element groups information about the series, if any, to which a
+            publication belongs. It may contain <gi>title</gi>, <gi>idno</gi>, or <gi>respStmt</gi>
+            elements.</p>
+            <p>The <gi>notesStmt</gi>, if used, contains one or more <gi>note</gi> elements which contain
+            a note or annotation. Some information found in the notes area in conventional bibliography
+            has been assigned specific elements in the TEI scheme.</p>
+          </div>
+          <div>
+            <head>The Source Description</head>
+            <p>The <gi>sourceDesc</gi> is a mandatory element which records details of the source or
+            sources from which the computer file is derived. It may contain simple prose or a
+            bibliographic citation, using one or more of the following elements: <specList>
+            <specDesc key="bibl"/>
+            <specDesc key="listBibl"/>
+          </specList>
+            </p>
+            <p>Examples: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <sourceDesc>
+              <bibl>The first folio of Shakespeare, prepared by Charlton Hinman (The Norton Facsimile,
+              1968)</bibl>
+            </sourceDesc>
+          </egXML>
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <sourceDesc>
+              <bibl>
+                <author>CNN Network News</author>
+                <title>News headlines</title>
+                <date>12 Jun
+                1989</date>
+              </bibl>
+            </sourceDesc>
+          </egXML>
+            </p>
+          </div>
+        </div>
+        <div>
+          <head>The Encoding Description</head>
+          <p>The <gi>encodingDesc</gi> element specifies the methods and editorial principles which
+          governed the transcription of the text. Its use is highly recommended. It may be prose
+          description or may contain elements from the following list: <specList>
+          <specDesc key="projectDesc"/>
+          <specDesc key="samplingDecl"/>
+          <specDesc key="editorialDecl"/>
+          <specDesc key="refsDecl"/>
+          <specDesc key="classDecl"/>
+        </specList>
+          </p>
+          <div>
+            <head>Project and Sampling Descriptions</head>
+            <p>Examples of <gi>projectDesc</gi> and <gi>samplingDesc</gi>: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <encodingDesc>
+              <projectDesc>
+                <p>Texts collected for
+                use in the Claremont Shakespeare Clinic, June 1990.
+                </p>
+              </projectDesc>
+            </encodingDesc>
+          </egXML>
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <encodingDesc>
+              <samplingDecl>
+                <p>Samples of
+                2000 words taken from the beginning of the text</p>
+              </samplingDecl>
+            </encodingDesc>
+          </egXML>
+            </p>
+          </div>
+          <div>
+            <head>Editorial Declarations</head>
+            <p>The <gi>editorialDecl</gi> contains a prose description of the practices used when encoding
+            the text. Typically this description should cover such topics as the following, each of which
+            may conveniently be given as a separate paragraph. <list type="gloss">
+            <label>correction </label>
+            <item>how and under what circumstances corrections have been made in the text.</item>
+            <label>normalization</label>
+            <item>the extent to which the original source has been regularized or normalized.</item>
+            <label>quotation</label>
+            <item>what has been done with quotation marks in the original -- have they been retained or
+            replaced by entity references, are opening and closing quotes distinguished, etc. </item>
+            <label>hyphenation</label>
+            <item>what has been done with hyphens (especially end-of-line hyphens) in the original --
+            have they been retained, replaced by entity references, etc.</item>
+            <label>segmentation</label>
+            <item>how has the text has been segmented, for example into sentences, tone-units, graphemic
+            strata, etc.</item>
+            <label>interpretation</label>
+            <item>what analytic or interpretive information has been added to the text. </item>
+          </list>
+            </p>
+            <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <editorialDecl>
+              <p>The part of
+              speech analysis applied throughout section 4 was added by hand and has not been
+              checked.</p>
+              <p>Errors in transcription controlled by using the WordPerfect spelling
+              checker.</p>
+              <p>All words converted to Modern American spelling using Webster's 9th
+              Collegiate dictionary.</p>
+            </editorialDecl>
+          </egXML>
+            </p>
+          </div>
+          <div xml:id="refsdecl">
+            <head>Reference and Classification Declarations</head>
+            <p>The <gi>refsDecl</gi> element is used to document the way in which any standard referencing
+            scheme built into the encoding works. In its simplest form, it consists of prose
+            description.</p>
+            <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <refsDecl>
+              <p>The <att>n</att>
+              attribute on each <gi>div</gi> contains the canonical reference for each division in the
+              form XX.yyy where XX is the book number in roman numeral and yyy is the section number in
+              arabic.</p>
+              <p>Milestone tags refer to the edition of 1830 as E30 and that of 1850 as E50.
+              </p>
+            </refsDecl>
+          </egXML>
+            </p>
+            <p>The <gi>classDecl</gi> element groups together definitions or sources for any descriptive
+            classification schemes used by other parts of the header. At least one such scheme must be
+            provided, encoded using the following elements: <specList>
+            <specDesc key="taxonomy"/>
+            <specDesc key="bibl"/>
+            <specDesc key="category"/>
+            <specDesc key="catDesc"/>
+          </specList>
+            </p>
+            <p> In the simplest case, the taxonomy may be defined by a bibliographic reference, as in the
+            following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <classDecl>
+              <taxonomy xml:id="LC-SH">
+                <bibl>Library of Congress Subject Headings
+                </bibl>
+              </taxonomy>
+            </classDecl>
+          </egXML>
+            </p>
+            <p>Alternatively, or in addition, the encoder may define a special purpose classification
+            scheme, as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <taxonomy xml:id="B">
+              <bibl>Brown Corpus</bibl>
+              <category xml:id="B.A">
+                <catDesc>Press
+                Reportage</catDesc>
+                <category xml:id="B.A1">
+                  <catDesc>Daily</catDesc>
+                </category>
+                <category xml:id="B.A2">
+                  <catDesc>Sunday</catDesc>
+                </category>
+                <category xml:id="B.A3">
+                  <catDesc>National</catDesc>
+                </category>
+                <category xml:id="B.A4">
+                  <catDesc>Provincial</catDesc>
+                </category>
+                <category xml:id="B.A5">
+                  <catDesc>Political</catDesc>
+                </category>
+                <category xml:id="B.A6">
+                  <catDesc>Sports</catDesc>
+                </category>
+              </category>
+              <category xml:id="B.D">
+                <catDesc>Religion</catDesc>
+                <category xml:id="B.D1">
+                  <catDesc>Books</catDesc>
+                </category>
+                <category xml:id="B.D2">
+                  <catDesc>Periodicals and
+                  tracts</catDesc>
+                </category>
+              </category>
+            </taxonomy>
+          </egXML>
+            </p>
+            <p>Linkage between a particular text and a category within such a taxonomy is made by means of
+            the <gi>catRef</gi> element within the <gi>textClass</gi> element, as described in the next
+            section below.</p>
+          </div>
+        </div>
+        <div>
+          <head>The Profile Description</head>
+          <p>The <gi>profileDesc</gi> element enables information characterizing various descriptive
+          aspects of a text to be recorded within a single framework. It has three optional components: <specList>
+          <specDesc key="creation"/>
+          <specDesc key="langUsage"/>
+          <specDesc key="textClass"/>
+        </specList>
+          </p>
+          <p>The <gi>creation</gi> element is useful for documenting where a work was created, even
+          though it may not have been published or recorded there.</p>
+          <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <creation>
+            <date when="1992-08">August 1992</date>
+            <name type="place">Taos, New Mexico</name>
+          </creation>
+        </egXML>
+          </p>
+          <p>The <gi>langUsage</gi> element is useful where a text contains many different languages. It
+          may contain <gi>language</gi> elements to document each particular language used: <specList>
+          <specDesc key="language"/>
+          </specList> For example, a text containing predominantly text in French as spoken in Quebec,
+          but also smaller amounts of British and Canadian English might be documented as follows:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <langUsage>
+              <language ident="fr-CA" usage="60">Québecois</language>
+              <language ident="en-CA" usage="20">Canadian business English</language>
+              <language ident="en-GB" usage="20">British English</language>
+            </langUsage>
+          </egXML>
+          </p>
+          <p>The <gi>textClass</gi> element classifies a text. This may be done with reference to a
+          classification system locally defined by means of the <gi>classDecl</gi> element, or by
+          reference to some externally defined established scheme such as the Universal Decimal
+          Classification. Texts may also be classified using lists of keywords, which may themselves be
+          drawn from locally or externally defined control lists. The following elements are used to
+          supply such classifications: <specList>
+          <specDesc key="classCode"/>
+          <specDesc key="catRef"/>
+          <specDesc key="keywords"/>
+        </specList>
+          </p>
+          <p>The simplest way of classifying a text is by means of the <gi>classCode</gi> element. For
+          example, a text with classification 410 in the Universal Decimal Classification might be
+          documented as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <classCode scheme="http://www.udc.org">410</classCode>
+        </egXML>
+          </p>
+          <p>When a classification scheme has been locally defined using the <gi>taxonomy</gi> element
+          discussed in the preceding subsection, the <gi>catRef</gi> element should be used to reference
+          it. To continue the earlier example, a work classified in the Brown Corpus as <code>Press
+          reportage - Sunday</code> and also as <code>Religion</code> might be documented as follows:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <catRef target="#B.A3 #B.D"/>
+          </egXML>
+          </p>
+          <p>The element <gi>keywords</gi> contains a list of keywords or phrases identifying the topic
+          or nature of a text. As usual, the attribute <att>scheme</att> identifies the source from
+          which these terms are taken. For example, if the LC Subject Headings are used, following
+          declaration of that classification system in a <gi>taxonomy</gi> element as above : <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <textClass>
+            <keywords scheme="#LCSH">
+              <list>
+                <item>English literature -- History and criticism -- Data processing.</item>
+                <item>English literature -- History and criticism -- Theory etc.</item>
+                <item>English language -- Style -- Data processing.</item>
+              </list>
+            </keywords>
+          </textClass>
+        </egXML>
+          </p>
+          <p>Multiple classifications may be supplied using
+          any of the mechanisms described in this section.</p>
+        </div>
+        <div>
+          <head>The Revision Description</head>
+          <p>The <gi>revisionDesc</gi> element provides a change log in which each change made to a text
+          may be recorded. The log may be recorded as a sequence of <gi>change</gi> elements each of
+          which contains a brief description of the change. The attributes <att>when</att> and
+          <att>who</att> may be used to identify when the change was carried out and the agency
+          responsible for it. </p>
+          <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <revisionDesc>
+            <change when="1991-03-06" who="#EMB">File format updated</change>
+            <change when="1990-05-25" who="#EMB">Stuart's corrections entered</change>
+          </revisionDesc>
+        </egXML>
+          </p>
+          <p>In a production environment it will usually be found preferable to use some kind of
+          automated system to track and record changes. Many such <term>version control systems</term>,
+          as they are known, can also be configured to update the TEI Header of a file automatically.
+          </p>
+        </div>
       </div>
     </body>
     <back>
       <div>
-	<head>List of Elements Described</head>
-	<p>The TEI Lite schema is a pure subset of TEI P5. In the following list of elements and classes
-	used, some information, notably the examples, derives from the canonical definition for the
-	element in TEI P5 and may therefore refer to elements or attributes not provided by TEI Lite.
-	Note however that only the elements listed here are available within the TEI Lite schema. These
-	specifications also refer to many attributes which although available in TEI Lite are not
-	discussed in this tutorial for lack of space. </p>
-	<schemaSpec ident="tei_lite" start="TEI teiCorpus">
-	  <moduleRef key="tei"/>
-	  <moduleRef key="core"
-		     include="abbr add addrLine address author bibl biblScope choice cit corr date del desc divGen editor emph expan foreign gap gloss graphic head hi index item l label lb lg list listBibl  mentioned milestone name note num orig p pb ptr pubPlace publisher q ref reg relatedItem resp respStmt rs sic soCalled sp speaker stage teiCorpus term time title unclear"/>
-	  <moduleRef key="header"
-		     include="authority availability catDesc catRef category change classCode classDecl creation distributor edition editionStmt editorialDecl encodingDesc extent fileDesc funder idno keywords langUsage language licence notesStmt principal profileDesc projectDesc publicationStmt refsDecl revisionDesc samplingDecl seriesStmt sourceDesc sponsor taxonomy teiHeader textClass titleStmt"/>
-	  <moduleRef key="textstructure"
-		     include="TEI argument back body byline closer dateline div         docAuthor docDate docEdition docImprint docTitle         epigraph front group imprimatur opener postscript salute signed text titlePage titlePart trailer"/>
-	  <moduleRef key="figures" include="cell figure figDesc formula row table"/>
-	  <moduleRef key="linking" include="anchor seg"/>
-	  <moduleRef key="analysis" include="interp interpGrp pc s w"/>
-	  <moduleRef key="tagdocs" include="att code eg gi ident val"/>
-	  <!-- this version is compiled against P5 2.1 and no other, so we suppress @version  -->
-	  <elementSpec ident="TEI" mode="change">
-	    <attList>
-	      <attDef ident="version" mode="delete"/>
-	    </attList>
-	  </elementSpec>
-	  <classRef key="att.global.facs"/>
-	  <classSpec ident="att.global" type="atts" mode="change" module="tei">
-	    <attList>
-	      <attDef ident="xml:base" mode="delete"/>
-	    </attList>
-	  </classSpec>
-	  <classSpec ident="att.global.rendition"
-		     type="atts"
-		     mode="change"
-		     module="tei">
-	    <!-- not much use having @rendition or @style without tagsDecl -->
-	    <attList>
-	      <attDef ident="style" mode="delete"/>
-	      <attDef ident="rendition" mode="delete"/>
-	    </attList>
-	  </classSpec>
+        <head>List of Elements Described</head>
+        <p>The TEI Lite schema is a pure subset of TEI P5. In the following list of elements and classes
+        used, some information, notably the examples, derives from the canonical definition for the
+        element in TEI P5 and may therefore refer to elements or attributes not provided by TEI Lite.
+        Note however that only the elements listed here are available within the TEI Lite schema. These
+        specifications also refer to many attributes which although available in TEI Lite are not
+        discussed in this tutorial for lack of space. </p>
+        <schemaSpec ident="tei_lite" start="TEI teiCorpus">
+          <moduleRef key="tei"/>
+          <moduleRef key="core"
+                     include="abbr add addrLine address author bibl biblScope choice cit corr date del desc divGen editor emph expan foreign gap gloss graphic head hi index item l label lb lg list listBibl  mentioned milestone name note num orig p pb ptr pubPlace publisher q ref reg relatedItem resp respStmt rs sic soCalled sp speaker stage teiCorpus term time title unclear"/>
+          <moduleRef key="header"
+                     include="authority availability catDesc catRef category change classCode classDecl creation distributor edition editionStmt editorialDecl encodingDesc extent fileDesc funder idno keywords langUsage language licence notesStmt principal profileDesc projectDesc publicationStmt refsDecl revisionDesc samplingDecl seriesStmt sourceDesc sponsor taxonomy teiHeader textClass titleStmt"/>
+          <moduleRef key="textstructure"
+                     include="TEI argument back body byline closer dateline div         docAuthor docDate docEdition docImprint docTitle         epigraph front group imprimatur opener postscript salute signed text titlePage titlePart trailer"/>
+          <moduleRef key="figures" include="cell figure figDesc formula row table"/>
+          <moduleRef key="linking" include="anchor seg"/>
+          <moduleRef key="analysis" include="interp interpGrp pc s w"/>
+          <moduleRef key="tagdocs" include="att code eg gi ident val"/>
+          <!-- this version is compiled against P5 2.1 and no other, so we suppress @version  -->
+          <elementSpec ident="TEI" mode="change">
+            <attList>
+              <attDef ident="version" mode="delete"/>
+            </attList>
+          </elementSpec>
+          <classRef key="att.global.facs"/>
+          <classSpec ident="att.global" type="atts" mode="change" module="tei">
+            <attList>
+              <attDef ident="xml:base" mode="delete"/>
+            </attList>
+          </classSpec>
+          <classSpec ident="att.global.rendition"
+                     type="atts"
+                     mode="change"
+                     module="tei">
+            <!-- not much use having @rendition or @style without tagsDecl -->
+            <attList>
+              <attDef ident="style" mode="delete"/>
+              <attDef ident="rendition" mode="delete"/>
+            </attList>
+          </classSpec>
 
-	  <classSpec type="atts"
-		     ident="att.global.linking"
-		     module="linking"
-		     mode="change">
-	    <attList>
-	      <attDef ident="synch" mode="delete"/>
-	      <attDef ident="sameAs" mode="delete"/>
-	      <attDef ident="copyOf" mode="delete"/>
-	      <attDef ident="exclude" mode="delete"/>
-	      <attDef ident="select" mode="delete"/>
-	    </attList>
-	  </classSpec>
-	  <classSpec type="atts" ident="att.datable.w3c" module="tei" mode="change">
-	    <attList>
-	      <attDef ident="notBefore" mode="delete"/>
-	      <attDef ident="notAfter" mode="delete"/>
-	      <attDef ident="from" mode="delete"/>
-	      <attDef ident="to" mode="delete"/>
-	    </attList>
-	  </classSpec>
-	  <classSpec type="atts" ident="att.datable" module="tei" mode="change">
-	    <attList>
-	      <attDef ident="calendar" mode="delete"/>
-	    </attList>
-	  </classSpec>
-	  <classSpec type="atts"
-		     ident="att.internetMedia"
-		     module="tei"
-		     mode="delete"/>
-	  <classSpec type="model"
-		     ident="model.msItemPart"
-		     module="tei"
-		     mode="delete"/>
-	  <!-- ??? -->
-	  <classSpec type="model"
-		     ident="model.msQuoteLike"
-		     module="tei"
-		     mode="delete"/>
-	  <classSpec type="model"
-		     ident="model.personPart"
-		     module="tei"
-		     mode="delete"/>
-	  
-	  
-	  <!--     MH 2014-11-19: 
-	       From http://sourceforge.net/p/tei/bugs/688/
-	       Since we have to replace the examples in P5, which contain elements not 
-	       permitted in TEI Lite, we might as well fix the confusing content model
-	       at the same time.
-	  -->
-	  <elementSpec module="header" ident="editorialDecl" mode="change">
-	    <content>
-	      <alternate minOccurs="1" maxOccurs="unbounded">
-		<classRef key="model.pLike"/>
-	      </alternate>
-	    </content>
-	    
-	    <exemplum xml:lang="en">
-	      <egXML xmlns="http://www.tei-c.org/ns/Examples">
-		<editorialDecl>
-		  <p>All words converted to Modern American spelling using
-		  Websters 9th Collegiate dictionary</p>
-		  <p>All opening quotation marks converted to “ all closing
-		  quotation marks converted to &amp;cdq;.</p>
-		</editorialDecl>
-	      </egXML>
-	    </exemplum>
-	    <exemplum versionDate="2008-04-06" xml:lang="fr">
-	      <egXML xmlns="http://www.tei-c.org/ns/Examples">
-		<editorialDecl>
-		  <p>Certains mots coupés par accident typographique en fin de ligne ont été réassemblés
-		  sans commentaire.</p>
-		  <p>Les "guillements français" ont été remplacée par des "guillemets droits" (sans
-		  symétrie)</p>
-		</editorialDecl>
-	      </egXML>
-	    </exemplum>
-	    <exemplum xml:lang="zh-TW">
-	      <egXML xmlns="http://www.tei-c.org/ns/Examples">
-		<editorialDecl>
-		  <p> 所有字皆轉換為源自Websters 9th Collegiate字典的現代美語拼法</p>
-		  <p>所有的前括號都改成" 後括號都改成 "</p>
-		</editorialDecl>
-	      </egXML>
-	    </exemplum>
-	    
-	  </elementSpec>
-	  <!-- changed this example per bug #1266 but I fear
-	       there are many more similar cases and that the
-	       effort is probably not worth making LB 2015-10-03
-	  -->
-	  
-	  <elementSpec module="core" ident="cit" mode="change">  
-	    <exemplum xml:lang="en">
-	      <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#DSHD-eg-30">
-		<cit>
-		  <q>and the breath of the whale is frequently attended with such an insupportable smell,
-		  as to bring on disorder of the brain.</q>
-		  <bibl>Ulloa's South America</bibl>
-		</cit>
-	      </egXML>
-	    </exemplum>
-	    <exemplum versionDate="2008-04-06" xml:lang="fr">
-	      <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#fr-ex-Perec-vie">
-		<cit>
-		  <q>Regarde de tous tes yeux, regarde</q>
-		  <bibl>Jules Verne, Michel Strogof</bibl>
-		</cit>
-	      </egXML>
-	    </exemplum>
-	  </elementSpec>
-	</schemaSpec>
+          <classSpec type="atts"
+                     ident="att.global.linking"
+                     module="linking"
+                     mode="change">
+            <attList>
+              <attDef ident="synch" mode="delete"/>
+              <attDef ident="sameAs" mode="delete"/>
+              <attDef ident="copyOf" mode="delete"/>
+              <attDef ident="exclude" mode="delete"/>
+              <attDef ident="select" mode="delete"/>
+            </attList>
+          </classSpec>
+          <classSpec type="atts" ident="att.datable.w3c" module="tei" mode="change">
+            <attList>
+              <attDef ident="notBefore" mode="delete"/>
+              <attDef ident="notAfter" mode="delete"/>
+              <attDef ident="from" mode="delete"/>
+              <attDef ident="to" mode="delete"/>
+            </attList>
+          </classSpec>
+          <classSpec type="atts" ident="att.datable" module="tei" mode="change">
+            <attList>
+              <attDef ident="calendar" mode="delete"/>
+            </attList>
+          </classSpec>
+          <classSpec type="atts"
+                     ident="att.internetMedia"
+                     module="tei"
+                     mode="delete"/>
+          <classSpec type="model"
+                     ident="model.msItemPart"
+                     module="tei"
+                     mode="delete"/>
+          <!-- ??? -->
+          <classSpec type="model"
+                     ident="model.msQuoteLike"
+                     module="tei"
+                     mode="delete"/>
+          <classSpec type="model"
+                     ident="model.personPart"
+                     module="tei"
+                     mode="delete"/>
+          
+          
+          <!--     MH 2014-11-19: 
+               From http://sourceforge.net/p/tei/bugs/688/
+               Since we have to replace the examples in P5, which contain elements not 
+               permitted in TEI Lite, we might as well fix the confusing content model
+               at the same time.
+          -->
+          <elementSpec module="header" ident="editorialDecl" mode="change">
+            <content>
+              <alternate minOccurs="1" maxOccurs="unbounded">
+                <classRef key="model.pLike"/>
+              </alternate>
+            </content>
+            
+            <exemplum xml:lang="en">
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <editorialDecl>
+                  <p>All words converted to Modern American spelling using
+                  Websters 9th Collegiate dictionary</p>
+                  <p>All opening quotation marks converted to “ all closing
+                  quotation marks converted to &amp;cdq;.</p>
+                </editorialDecl>
+              </egXML>
+            </exemplum>
+            <exemplum versionDate="2008-04-06" xml:lang="fr">
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <editorialDecl>
+                  <p>Certains mots coupés par accident typographique en fin de ligne ont été réassemblés
+                  sans commentaire.</p>
+                  <p>Les "guillements français" ont été remplacée par des "guillemets droits" (sans
+                  symétrie)</p>
+                </editorialDecl>
+              </egXML>
+            </exemplum>
+            <exemplum xml:lang="zh-TW">
+              <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                <editorialDecl>
+                  <p> 所有字皆轉換為源自Websters 9th Collegiate字典的現代美語拼法</p>
+                  <p>所有的前括號都改成" 後括號都改成 "</p>
+                </editorialDecl>
+              </egXML>
+            </exemplum>
+            
+          </elementSpec>
+          <!-- changed this example per bug #1266 but I fear
+               there are many more similar cases and that the
+               effort is probably not worth making LB 2015-10-03
+          -->
+          
+          <elementSpec module="core" ident="cit" mode="change">  
+            <exemplum xml:lang="en">
+              <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#DSHD-eg-30">
+                <cit>
+                  <q>and the breath of the whale is frequently attended with such an insupportable smell,
+                  as to bring on disorder of the brain.</q>
+                  <bibl>Ulloa's South America</bibl>
+                </cit>
+              </egXML>
+            </exemplum>
+            <exemplum versionDate="2008-04-06" xml:lang="fr">
+              <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#fr-ex-Perec-vie">
+                <cit>
+                  <q>Regarde de tous tes yeux, regarde</q>
+                  <bibl>Jules Verne, Michel Strogof</bibl>
+                </cit>
+              </egXML>
+            </exemplum>
+          </elementSpec>
+        </schemaSpec>
       </div>
     </back>
   </text>

--- a/P5/Exemplars/tei_lite.odd
+++ b/P5/Exemplars/tei_lite.odd
@@ -1,2571 +1,3045 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright TEI Consortium.
-    Dual-licensed under CC-by and BSD2 licences
-    See the file COPYING.txt for details
-    $Date$
-    $Id$
+Copyright TEI Consortium.
+Dual-licensed under CC-by and BSD2 licences
+See the file COPYING.txt for details
+$Date$
+$Id$
 -->
-
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0"
- xml:lang="en">
- <teiHeader>
-  <fileDesc>
-   <titleStmt>
-    <title>Encoding for Interchange: an introduction to the TEI</title>
-   </titleStmt>
-   <publicationStmt>
-     <publisher>TEI Consortium</publisher>
-    <availability>
-     <licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a Creative
-      Commons Attribution-ShareAlike 3.0 Unported License </licence>
-     <licence target="http://www.opensource.org/licenses/BSD-2-Clause">
-      <p>Copyright 2013 TEI Consortium.</p>
-      <p>All rights reserved.</p>
-      <p>Redistribution and use in source and binary forms, with or without modification, are
-       permitted provided that the following conditions are met:</p>
-      <list>
-       <item>Redistributions of source code must retain the above copyright notice, this list of
-        conditions and the following disclaimer.</item>
-       <item>Redistributions in binary form must reproduce the above copyright notice, this list of
-        conditions and the following disclaimer in the documentation and/or other materials provided
-        with the distribution.</item>
+<TEI xmlns="http://www.tei-c.org/ns/1.0"
+     xmlns:rng="http://relaxng.org/ns/structure/1.0"
+     xml:lang="en">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+	<title>Encoding for Interchange: an introduction to the TEI</title>
+      </titleStmt>
+      <publicationStmt>
+	<publisher>TEI Consortium</publisher>
+	<availability>
+	  <licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a Creative
+	  Commons Attribution-ShareAlike 3.0 Unported License </licence>
+	  <licence target="http://www.opensource.org/licenses/BSD-2-Clause">
+	    <p>Copyright 2013 TEI Consortium.</p>
+	    <p>All rights reserved.</p>
+	    <p>Redistribution and use in source and binary forms, with or without modification, are
+	    permitted provided that the following conditions are met:</p>
+	    <list>
+	      <item>Redistributions of source code must retain the above copyright notice, this list of
+	      conditions and the following disclaimer.</item>
+	      <item>Redistributions in binary form must reproduce the above copyright notice, this list of
+	      conditions and the following disclaimer in the documentation and/or other materials provided
+	      with the distribution.</item>
+	    </list>
+	    <p>This software is provided by the copyright holders and contributors "as is" and any express
+	    or implied warranties, including, but not limited to, the implied warranties of
+	    merchantability and fitness for a particular purpose are disclaimed. In no event shall the
+	    copyright holder or contributors be liable for any direct, indirect, incidental, special,
+	    exemplary, or consequential damages (including, but not limited to, procurement of substitute
+	    goods or services; loss of use, data, or profits; or business interruption) however caused
+	    and on any theory of liability, whether in contract, strict liability, or tort (including
+	    negligence or otherwise) arising in any way out of the use of this software, even if advised
+	    of the possibility of such damage.</p>
+	  </licence>
+	  <p>TEI material can be licensed differently depending on the use you intend to make of it.
+	  Hence it is made available under both the CC+BY and BSD-2 licences. The CC+BY licence is
+	  generally appropriate for usages which treat TEI content as data or documentation. The BSD-2
+	  licence is generally appropriate for usage of TEI content in a software environment. For
+	  further information or clarification, please contact the <ref target="mailto:info@tei-c.org">TEI Consortium</ref>. </p>
+	</availability>
+      </publicationStmt>
+      <sourceDesc>
+	<bibl>TEI U5 (derived from TEI U1: An Introduction to TEI Tagging (derived from TEI ED W21:
+	Living with the Guidelines)</bibl>
+      </sourceDesc>
+    </fileDesc>
+    <revisionDesc>
+      <change when="2014-11-19" who="MH">changing the content model
+      and simplifying the examples in editorialDecl</change>
+      <change when="2013-07-08" who="KSH">Updated link to legacy versions of Lite, other minor changes.</change>
+      <change when="2012-12-27" who="LB">Remove @style since it's no use
+      without <gi>tagsDecl</gi>; also restored @corresp removed in error
+      and added some discussion of editorial vs authorial change</change>
+      <change when="2012-08-02" who="MDH">Fixed <att>xml:lang</att> values to conform with IANA subtag
+      registry and added svn props to file. Rewrote section on language identification. </change>
+      <change when="2011-03-26" who="LB">rename to tei_lite, convert to new style ODD; remove
+      application appInfo typeNote scriptNote geoDecl</change>
+      <change when="2008-02-01" who="SPQR">remove some unreachable elements, and remove @rendition
+      (since its not useable without <gi>tagsDecl</gi>)</change>
+      <change when="2007-01-25" who="LB">restored quote (under protest) </change>
+      <change when="2006-12-06" who="LB">fix titlePage problem </change>
+      <change when="2006-02-08" who="LB"> more substantive changes: add elements from tagdocs module;
+      kill numbered divs </change>
+      <change when="2006-01-29" who="LB"> first cut conversion to P5 </change>
+      <change when="2004-10" who="SPQR"> reformat, clean up, remove list of translations </change>
+      <change when="2002-08-07" who="LB"> Correct blunder in Gifford example </change>
+      <change when="2002-05-18" who="LB"> First pass for P4/XML revision </change>
+      <change when="2001-01-21" who="LB"> Added IDs to div1s and checked links </change>
+      <change when="2001-01-04" who="SPQR"> Remove TOC, fix a couple of links, change preface to div1
+      not div. Add stylesheet PI, make parse </change>
+      <change when="2000-06-21" who="LB"> Add preface; modify links </change>
+      <change when="1995-09-09" who="CMSMcQ"> fix Oxford links </change>
+      <change when="1995-06-08" who="CMSMcQ"> install on TEI web server (changing DTD subset slightly) </change>
+      <change when="1995-06-07" who="CMSMcQ"> Bring TeX and Script spelling corrections, etc. into SGML
+      form. </change>
+      <change when="1995-06-03" who="CMSMcQ"> Spellcheck, final (! ha!) changes, format, and print.
+      Many changes made only in TeX and Script versions. </change>
+      <change when="1995-05-30" who="LB"> Last (ha!) pass. Cut down intro section. Moved divgen again.
+      Revised interp and index sections extensively and generally hacked. </change>
+      <change when="1995-05-25" who="CMSMcQ"> changes as agreed with LB at ExCommittee meeting: interp
+      section, rev. editorial tags, add def of TEI Lite, add section on Making It Work with software,
+      resettle divGen and index, begin continuous pass through working from LB's notes </change>
+      <change when="1995-05-15" who="CMSMcQ"> begin last push prior to publication </change>
+      <change when="1994-12-01" who="LB"> retagged using TEI Lite </change>
+      <change when="1994-06-23" who="LB"> change to use ODD-style tagdescs </change>
+      <change when="1993-07-20" who="CMSMcQ"> made file from old ED W21 </change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <front>
+      <titlePage>
+	<docTitle>
+	  <titlePart type="main">TEI Lite: Encoding for Interchange: an introduction to the TEI </titlePart>
+	  <titlePart type="sub">Final revised edition for TEI P5</titlePart>
+	</docTitle>
+	<docAuthor>Lou Burnard</docAuthor>
+	<docAuthor>C. M. Sperberg-McQueen</docAuthor>
+	<docDate>August 2012</docDate>
+      </titlePage>
+      <div xml:id="U5-pref">
+	<head>Prefatory note</head>
+	<p>TEI Lite was the name adopted for what the TEI editors originally conceived of as a simple
+	demonstration of how the TEI (Text Encoding Initiative) encoding scheme might be adopted to
+	meet 90% of the needs of 90% of the TEI user community. In retrospect, it was predictable that
+	many people should imagine TEI Lite to be all there is to TEI, or find TEI Lite to be far too
+	heavy for their needs.</p>
+	<p>The original TEI Lite (1996) was based largely on observations of existing and previous
+	practice in the encoding of texts, particularly as manifest in the collections of the <ref target="http://ota.ahds.ac.uk/">Oxford Text Archive</ref> and other collections of the period.
+	It is therefore unsurprising that it seems to have become, if not a <foreign xml:lang="la">de
+	facto</foreign> standard, at least a common point of departure for electronic text centres and
+	encoding projects world wide. Maybe the fact that we actually produced this shortish, readable,
+	manual for it also helped.</p>
+	<p>Early adopters of TEI Lite included a number of <soCalled>Electronic Text Centers</soCalled>
+	<!-- , many
+	     of whom produced their own documentation and
+	     tutorial materials (some examples are listed in
+	     <ref target="http://www.tei-c.org/Tutorials/"> the
+	     TEI Tutorials pages</ref>)-->
+	and digital library initiatives. It was also adopted as the basis for some early TEI-conformant
+	authoring systems, and as the basis for introductory tutorials, many of them in languages other
+	than English (see further the list of legacy versions at <ptr target="http://www.tei-c.org/Vault/P4/Lite/"/>).</p>
+	<p>In 2002, following the publication of TEI P4, the XML version of the TEI Guidelines, which
+	uses the generation of TEI Lite as an example of the TEI modification mechanism, the
+	opportunity was taken to produce a lightly revised XML-conformant version. In 2006, a more
+	substantially revised version based on TEI P5 was produced; this reflected the many changes
+	between TEI P4 and TEI P5, but was not otherwise significantly different. In 2012, the TEI
+	Technical Council, decided that a final revision should be undertaken to ensure that the
+	documentation remained consistent with the latest (2.1) release of TEI P5. This version uses a
+	recently added mechanism in the TEI customization architecture, which permits a customization
+	to define only the TEI elements to be included in a schema, rather than the elements to be
+	excluded from it. As such it is probably more resilient to change than earlier versions. </p>
+	<trailer>Lou Burnard, August 2012</trailer>
+      </div>
+    </front>
+    <body>
+      <p>This document provides an introduction to the recommendations of the Text Encoding Initiative
+      (TEI), by describing a specific subset of the full TEI encoding scheme. The scheme documented
+      here can be used to encode a wide variety of commonly encountered textual features, in such a
+      way as to maximize the usability of electronic transcriptions and to facilitate their
+      interchange among scholars using different computer systems. It is fully compatible with the
+      full TEI scheme, as defined by TEI document P5, <title>Guidelines for Electronic Text Encoding
+      and Interchange</title>, as of February 2006, and available from the TEI Consortium website at
+      <ptr target="http://www.tei-c.org/"/>. </p>
+      <div xml:id="U5-Intro">
+	<head>Introduction</head>
+	<p>The Text Encoding Initiative (TEI) Guidelines are addressed to anyone who wants to
+	interchange information stored in an electronic form. They emphasize the interchange of textual
+	information, but other forms of information such as images and sound are also addressed. The
+	Guidelines are equally applicable in the creation of new resources and in the interchange of
+	existing ones.</p>
+	<p>The Guidelines provide a means of making explicit certain features of a text in such a way as
+	to aid the processing of that text by computer software running on different machines. This
+	process of making explicit we call <term>markup</term> or <term>encoding</term>. Any textual
+	representation on a computer uses some form of markup; the TEI came into being partly because
+	of the enormous variety of mutually incomprehensible encoding schemes currently besetting
+	scholarship, and partly because of the expanding range of scholarly uses now being identified
+	for texts in electronic form.</p>
+	<p>The TEI Guidelines describe an encoding scheme which can be expressed using a number of
+	different formal languages. The first editions of the Guidelines used the <term>Standard
+	Generalized Markup Language</term> (SGML); since 2002, this has been replaced by the use of
+	the Extensible Markup Language (XML). These markup languages have in common the definition of
+	text in terms of <term>elements</term> and <term>attributes</term>, and rules governing their
+	appearance within a text. The TEI's use of XML is ambitious in its complexity and generality,
+	but it is fundamentally no different from that of any other XML markup scheme, and so any
+	general-purpose XML-aware software is able to process TEI-conformant texts.</p>
+	<p>Since 2001, the TEI has been a community initiative supported by an international membership
+	consortium. It was originally an international research project sponsored by the Association
+	for Computers and the Humanities, the Association for Computational Linguistics, and the
+	Association for Literary and Linguistic Computing, with substantial funding over its first five
+	years from the U.S. National Endowment for the Humanities, Directorate General XIII of the
+	Commission of the European Communities, the Andrew W. Mellon Foundation, the Social Science and
+	Humanities Research Council of Canada and others. The Guidelines were first published in May
+	1994, after six years of development involving many hundreds of scholars from different
+	academic disciplines worldwide. During the years that followed, the Guidelines became
+	increasingly influential in the development of the digital library, in the language industries,
+	and even in the development of the World Wide Web itself. The TEI Consortium was set up in
+	January 2001, and a year later produced an edition of the Guidelines entirely revised for XML
+	compatibility. In 2004, it set about a major revision of the Guidelines to take full advantage
+	of new schema languages, the first release of which appeared in 2005. This revision of the TEI
+	Lite document conforms to version 2.1 of this most recent edition of the Guidelines, TEI P5,
+	released in June 2012.</p>
+	<p>At the outset of its work, the overall goals of the TEI were defined by the closing statement
+	of a planning conference held at Vassar College, N.Y., in November, 1987; these
+	<soCalled>Poughkeepsie Principles</soCalled> were further elaborated in a series of design
+	documents. The Guidelines, say these design documents, should: <list>
+	<item>suffice to represent the textual features needed for research;</item>
+	<item>be simple, clear, and concrete;</item>
+	<item>be easy for researchers to use without special-purpose software;</item>
+	<item>allow the rigorous definition and efficient processing of texts;</item>
+	<item>provide for user-defined extensions;</item>
+	<item>conform to existing and emergent standards.</item>
       </list>
-      <p>This software is provided by the copyright holders and contributors "as is" and any express
-       or implied warranties, including, but not limited to, the implied warranties of
-       merchantability and fitness for a particular purpose are disclaimed. In no event shall the
-       copyright holder or contributors be liable for any direct, indirect, incidental, special,
-       exemplary, or consequential damages (including, but not limited to, procurement of substitute
-       goods or services; loss of use, data, or profits; or business interruption) however caused
-       and on any theory of liability, whether in contract, strict liability, or tort (including
-       negligence or otherwise) arising in any way out of the use of this software, even if advised
-       of the possibility of such damage.</p>
-     </licence>
-     <p>TEI material can be licensed differently depending on the use you intend to make of it.
-      Hence it is made available under both the CC+BY and BSD-2 licences. The CC+BY licence is
-      generally appropriate for usages which treat TEI content as data or documentation. The BSD-2
-      licence is generally appropriate for usage of TEI content in a software environment. For
-      further information or clarification, please contact the <ref target="mailto:info@tei-c.org"
-       >TEI Consortium</ref>. </p>
-    </availability>
-   </publicationStmt>
-   <sourceDesc>
-    <bibl>TEI U5 (derived from TEI U1: An Introduction to TEI Tagging (derived from TEI ED W21:
-     Living with the Guidelines)</bibl>
-   </sourceDesc>
-  </fileDesc>
-  <revisionDesc>
-    <change when="2014-11-19" who="MH">changing the content model
-and simplifying the examples in editorialDecl</change>
-    <change when="2013-07-08" who="KSH">Updated link to legacy versions of Lite, other minor changes.</change>
-    <change when="2012-12-27" who="LB">Remove @style since it's no use
-    without <gi>tagsDecl</gi>; also restored @corresp removed in error
-    and added some discussion of editorial vs authorial change</change>
-   <change when="2012-08-02" who="MDH">Fixed <att>xml:lang</att> values to conform with IANA subtag
-    registry and added svn props to file. Rewrote section on language identification. </change>
-   <change when="2011-03-26" who="LB">rename to tei_lite, convert to new style ODD; remove
-    application appInfo typeNote scriptNote geoDecl</change>
-   <change when="2008-02-01" who="SPQR">remove some unreachable elements, and remove @rendition
-    (since its not useable without <gi>tagsDecl</gi>)</change>
-   <change when="2007-01-25" who="LB">restored quote (under protest) </change>
-   <change when="2006-12-06" who="LB">fix titlePage problem </change>
-   <change when="2006-02-08" who="LB"> more substantive changes: add elements from tagdocs module;
-    kill numbered divs </change>
-   <change when="2006-01-29" who="LB"> first cut conversion to P5 </change>
-   <change when="2004-10" who="SPQR"> reformat, clean up, remove list of translations </change>
-   <change when="2002-08-07" who="LB"> Correct blunder in Gifford example </change>
-   <change when="2002-05-18" who="LB"> First pass for P4/XML revision </change>
-   <change when="2001-01-21" who="LB"> Added IDs to div1s and checked links </change>
-   <change when="2001-01-04" who="SPQR"> Remove TOC, fix a couple of links, change preface to div1
-    not div. Add stylesheet PI, make parse </change>
-   <change when="2000-06-21" who="LB"> Add preface; modify links </change>
-   <change when="1995-09-09" who="CMSMcQ"> fix Oxford links </change>
-   <change when="1995-06-08" who="CMSMcQ"> install on TEI web server (changing DTD subset slightly) </change>
-   <change when="1995-06-07" who="CMSMcQ"> Bring TeX and Script spelling corrections, etc. into SGML
-    form. </change>
-   <change when="1995-06-03" who="CMSMcQ"> Spellcheck, final (! ha!) changes, format, and print.
-    Many changes made only in TeX and Script versions. </change>
-   <change when="1995-05-30" who="LB"> Last (ha!) pass. Cut down intro section. Moved divgen again.
-    Revised interp and index sections extensively and generally hacked. </change>
-   <change when="1995-05-25" who="CMSMcQ"> changes as agreed with LB at ExCommittee meeting: interp
-    section, rev. editorial tags, add def of TEI Lite, add section on Making It Work with software,
-    resettle divGen and index, begin continuous pass through working from LB's notes </change>
-   <change when="1995-05-15" who="CMSMcQ"> begin last push prior to publication </change>
-   <change when="1994-12-01" who="LB"> retagged using TEI Lite </change>
-   <change when="1994-06-23" who="LB"> change to use ODD-style tagdescs </change>
-   <change when="1993-07-20" who="CMSMcQ"> made file from old ED W21 </change>
-  </revisionDesc>
- </teiHeader>
- <text>
-  <front>
-   <titlePage>
-    <docTitle>
-     <titlePart type="main">TEI Lite: Encoding for Interchange: an introduction to the TEI </titlePart>
-     <titlePart type="sub">Final revised edition for TEI P5</titlePart>
-    </docTitle>
-    <docAuthor>Lou Burnard</docAuthor>
-    <docAuthor>C. M. Sperberg-McQueen</docAuthor>
-    <docDate>August 2012</docDate>
-   </titlePage>
-   <div xml:id="U5-pref">
-    <head>Prefatory note</head>
-    <p>TEI Lite was the name adopted for what the TEI editors originally conceived of as a simple
-     demonstration of how the TEI (Text Encoding Initiative) encoding scheme might be adopted to
-     meet 90% of the needs of 90% of the TEI user community. In retrospect, it was predictable that
-     many people should imagine TEI Lite to be all there is to TEI, or find TEI Lite to be far too
-     heavy for their needs.</p>
-    <p>The original TEI Lite (1996) was based largely on observations of existing and previous
-     practice in the encoding of texts, particularly as manifest in the collections of the <ref
-      target="http://ota.ahds.ac.uk/">Oxford Text Archive</ref> and other collections of the period.
-     It is therefore unsurprising that it seems to have become, if not a <foreign xml:lang="la">de
-      facto</foreign> standard, at least a common point of departure for electronic text centres and
-     encoding projects world wide. Maybe the fact that we actually produced this shortish, readable,
-     manual for it also helped.</p>
-    <p>Early adopters of TEI Lite included a number of <soCalled>Electronic Text Centers</soCalled>
-     <!-- , many
-     of whom produced their own documentation and
-     tutorial materials (some examples are listed in
-     <ref target="http://www.tei-c.org/Tutorials/"> the
-     TEI Tutorials pages</ref>)-->
-     and digital library initiatives. It was also adopted as the basis for some early TEI-conformant
-     authoring systems, and as the basis for introductory tutorials, many of them in languages other
-     than English (see further the list of legacy versions at <ptr
-      target="http://www.tei-c.org/Vault/P4/Lite/"/>).</p>
-    <p>In 2002, following the publication of TEI P4, the XML version of the TEI Guidelines, which
-     uses the generation of TEI Lite as an example of the TEI modification mechanism, the
-     opportunity was taken to produce a lightly revised XML-conformant version. In 2006, a more
-     substantially revised version based on TEI P5 was produced; this reflected the many changes
-     between TEI P4 and TEI P5, but was not otherwise significantly different. In 2012, the TEI
-     Technical Council, decided that a final revision should be undertaken to ensure that the
-     documentation remained consistent with the latest (2.1) release of TEI P5. This version uses a
-     recently added mechanism in the TEI customization architecture, which permits a customization
-     to define only the TEI elements to be included in a schema, rather than the elements to be
-     excluded from it. As such it is probably more resilient to change than earlier versions. </p>
-    <trailer>Lou Burnard, August 2012</trailer>
-   </div>
-  </front>
-  <body>
-   <p>This document provides an introduction to the recommendations of the Text Encoding Initiative
-    (TEI), by describing a specific subset of the full TEI encoding scheme. The scheme documented
-    here can be used to encode a wide variety of commonly encountered textual features, in such a
-    way as to maximize the usability of electronic transcriptions and to facilitate their
-    interchange among scholars using different computer systems. It is fully compatible with the
-    full TEI scheme, as defined by TEI document P5, <title>Guidelines for Electronic Text Encoding
-     and Interchange</title>, as of February 2006, and available from the TEI Consortium website at
-     <ptr target="http://www.tei-c.org/"/>. </p>
-   <div xml:id="U5-Intro">
-    <head>Introduction</head>
-    <p>The Text Encoding Initiative (TEI) Guidelines are addressed to anyone who wants to
-     interchange information stored in an electronic form. They emphasize the interchange of textual
-     information, but other forms of information such as images and sound are also addressed. The
-     Guidelines are equally applicable in the creation of new resources and in the interchange of
-     existing ones.</p>
-    <p>The Guidelines provide a means of making explicit certain features of a text in such a way as
-     to aid the processing of that text by computer software running on different machines. This
-     process of making explicit we call <term>markup</term> or <term>encoding</term>. Any textual
-     representation on a computer uses some form of markup; the TEI came into being partly because
-     of the enormous variety of mutually incomprehensible encoding schemes currently besetting
-     scholarship, and partly because of the expanding range of scholarly uses now being identified
-     for texts in electronic form.</p>
-    <p>The TEI Guidelines describe an encoding scheme which can be expressed using a number of
-     different formal languages. The first editions of the Guidelines used the <term>Standard
-      Generalized Markup Language</term> (SGML); since 2002, this has been replaced by the use of
-     the Extensible Markup Language (XML). These markup languages have in common the definition of
-     text in terms of <term>elements</term> and <term>attributes</term>, and rules governing their
-     appearance within a text. The TEI's use of XML is ambitious in its complexity and generality,
-     but it is fundamentally no different from that of any other XML markup scheme, and so any
-     general-purpose XML-aware software is able to process TEI-conformant texts.</p>
-    <p>Since 2001, the TEI has been a community initiative supported by an international membership
-     consortium. It was originally an international research project sponsored by the Association
-     for Computers and the Humanities, the Association for Computational Linguistics, and the
-     Association for Literary and Linguistic Computing, with substantial funding over its first five
-     years from the U.S. National Endowment for the Humanities, Directorate General XIII of the
-     Commission of the European Communities, the Andrew W. Mellon Foundation, the Social Science and
-     Humanities Research Council of Canada and others. The Guidelines were first published in May
-     1994, after six years of development involving many hundreds of scholars from different
-     academic disciplines worldwide. During the years that followed, the Guidelines became
-     increasingly influential in the development of the digital library, in the language industries,
-     and even in the development of the World Wide Web itself. The TEI Consortium was set up in
-     January 2001, and a year later produced an edition of the Guidelines entirely revised for XML
-     compatibility. In 2004, it set about a major revision of the Guidelines to take full advantage
-     of new schema languages, the first release of which appeared in 2005. This revision of the TEI
-     Lite document conforms to version 2.1 of this most recent edition of the Guidelines, TEI P5,
-     released in June 2012.</p>
-    <p>At the outset of its work, the overall goals of the TEI were defined by the closing statement
-     of a planning conference held at Vassar College, N.Y., in November, 1987; these
-      <soCalled>Poughkeepsie Principles</soCalled> were further elaborated in a series of design
-     documents. The Guidelines, say these design documents, should: <list>
-      <item>suffice to represent the textual features needed for research;</item>
-      <item>be simple, clear, and concrete;</item>
-      <item>be easy for researchers to use without special-purpose software;</item>
-      <item>allow the rigorous definition and efficient processing of texts;</item>
-      <item>provide for user-defined extensions;</item>
-      <item>conform to existing and emergent standards.</item>
-     </list></p>
-    <p>The world of scholarship is large and diverse. For the Guidelines to have wide acceptability,
-     it was important to ensure that: <list type="ordered">
-      <item>the common core of textual features be easily shared;</item>
-      <item>additional specialist features be easy to add to (or remove from) a text;</item>
-      <item>multiple parallel encodings of the same feature should be possible;</item>
-      <item>the richness of markup should be user-defined, with a very small minimal
-       requirement;</item>
-      <item>adequate documentation of the text and its encoding should be provided.</item>
-     </list></p>
-    <p>The present document describes a manageable selection from the extensive set of elements and
-     recommendations resulting from those design goals, which is called <title>TEI Lite</title>.</p>
-    <p>In selecting from the several hundred elements defined by the full TEI scheme, we have tried
-     to identify a useful <soCalled>starter set</soCalled>, comprising the elements which almost
-     every user should know about. Experience working with TEI Lite will be invaluable in
-     understanding the full TEI scheme and in knowing how to integrate specialized parts of it into
-     the general TEI framework.</p>
-    <p>Our goals in defining this subset may be summarized as follows: <list type="simple">
-      <item>it should be able to handle adequately a reasonably wide variety of texts, at the level
-       of detail found in existing practice (as demonstrated in, for example, the holdings of the
-       Oxford Text Archive);</item>
-      <item>it should be useful for the production of new documents (such as this one) as well as
-       the encoding of existing texts;</item>
-      <item>it should be usable with a wide range of existing XML software;</item>
-      <item>it should be a pure subset of the full TEI scheme and defined using the customizaticon
-       methods described in the TEI Guidelines;</item>
-      <item>it should be as small and simple as is consistent with the other goals.</item>
-     </list> The reader may judge our success in meeting these goals for him or herself.</p>
-    <p>Although we have tried to make this document self-contained, as suits a tutorial text, the
-     reader should be aware that it does not cover every detail of the TEI encoding scheme. All of
-     the elements described here are fully documented in the TEI Guidelines themselves, which should
-     be consulted for authoritative reference information on these, and on the many others which are
-     not described here. Some basic knowledge of XML is assumed.</p>
-   </div>
-   <div xml:id="U5-eg">
-    <head>A Short Example</head>
-    <p>We begin with a short example, intended to show what happens when a passage of prose is typed
-     into a computer by someone with little sense of the purpose of mark-up, or the potential of
-     electronic texts. In an ideal world, such output might be generated by a very accurate optical
-     scanner. It attempts to be faithful to the appearance of the printed text, by retaining the
-     original line breaks, by introducing blanks to represent the layout of the original headings
-     and page breaks, and so forth. Where characters not available on the keyboard are needed (such
-     as the accented letter <mentioned>a</mentioned> in <mentioned>faàl</mentioned> or the long
-     dash), it attempts to mimic their appearance.</p>
-    <p>
-     <eg xml:space="preserve">
-                                CHAPTER 38
-
-READER, I married him. A quiet wedding we had: he and I, the par-
-son and clerk, were alone present. When we got back from church, I
-went into the kitchen of the manor-house, where Mary was cooking
-the dinner, and John cleaning the knives, and I said --
-  'Mary, I have been married to Mr Rochester this morning.' The
-housekeeper and her husband were of that decent, phlegmatic
-order of people, to whom one may at any time safely communicate a
-remarkable piece of news without incurring the danger of having
-one's ears pierced by some shrill ejaculation and subsequently stunned
-by a torrent of wordy wonderment. Mary did look up, and she did
-stare at me; the ladle with which she was basting a pair of chickens
-roasting at the fire, did for some three minutes hang suspended in air,
-and for the same space of time John's knives also had rest from the
-polishing process; but Mary, bending again over the roast, said only --
-   'Have you, miss? Well, for sure!'
-   A short time after she pursued, 'I seed you go out with the master,
-but I didn't know you were gone to church to be wed'; and she
-basted away. John, when I turned to him, was grinning from ear to
-ear.
-   'I telled Mary how it would be,' he said: 'I knew what Mr Ed-
-ward' (John was an old servant, and had known his master when he
-was the cadet of the house, therefore he often gave him his Christian
-name) -- 'I knew what Mr Edward would do; and I was certain he
-would not wait long either: and he's done right, for aught I know. I
-wish you joy, miss!' and he politely pulled his forelock.
-   'Thank you, John. Mr Rochester told me to give you and Mary
-this.'
-   I put into his hand a five-pound note.  Without waiting to hear
-more, I left the kitchen. In passing the door of that sanctum some time
-after, I caught the words --
-   'She'll happen do better for him nor ony o' t' grand ladies.' And
-again, 'If she ben't one o' th' handsomest, she's noan faa\l, and varry
-good-natured; and i' his een she's fair beautiful, onybody may see
-that.'
-   I wrote to Moor House and to Cambridge immediately, to say what
-I had done: fully explaining also why I had thus acted. Diana and
-
-                            474
-
-                 JANE EYRE                      475
-
-Mary approved the step unreservedly. Diana announced that she
-would just give me time to get over the honeymoon, and then she
-would come and see me.
-   'She had better not wait till then, Jane,' said Mr Rochester, when I
-read her letter to him; 'if she does, she will be too late, for our honey-
-moon will shine our life long: its beams will only fade over your
-grave or mine.'
-   How St John received the news I don't know: he never answered
-the letter in which I communicated it: yet six months after he wrote
-to me, without, however, mentioning Mr Rochester's name or allud-
-ing to my marriage. His letter was then calm, and though very serious,
-kind. He has maintained a regular, though not very frequent correspond-
-ence ever since: he hopes I am happy, and trusts I am not of those who
-live without God in the world, and only mind earthly things.
-
-      </eg>
+	</p>
+	<p>The world of scholarship is large and diverse. For the Guidelines to have wide acceptability,
+	it was important to ensure that: <list type="ordered">
+	<item>the common core of textual features be easily shared;</item>
+	<item>additional specialist features be easy to add to (or remove from) a text;</item>
+	<item>multiple parallel encodings of the same feature should be possible;</item>
+	<item>the richness of markup should be user-defined, with a very small minimal
+	requirement;</item>
+	<item>adequate documentation of the text and its encoding should be provided.</item>
+      </list>
+	</p>
+	<p>The present document describes a manageable selection from the extensive set of elements and
+	recommendations resulting from those design goals, which is called <title>TEI Lite</title>.</p>
+	<p>In selecting from the several hundred elements defined by the full TEI scheme, we have tried
+	to identify a useful <soCalled>starter set</soCalled>, comprising the elements which almost
+	every user should know about. Experience working with TEI Lite will be invaluable in
+	understanding the full TEI scheme and in knowing how to integrate specialized parts of it into
+	the general TEI framework.</p>
+	<p>Our goals in defining this subset may be summarized as follows: <list type="simple">
+	<item>it should be able to handle adequately a reasonably wide variety of texts, at the level
+	of detail found in existing practice (as demonstrated in, for example, the holdings of the
+	Oxford Text Archive);</item>
+	<item>it should be useful for the production of new documents (such as this one) as well as
+	the encoding of existing texts;</item>
+	<item>it should be usable with a wide range of existing XML software;</item>
+	<item>it should be a pure subset of the full TEI scheme and defined using the customizaticon
+	methods described in the TEI Guidelines;</item>
+	<item>it should be as small and simple as is consistent with the other goals.</item>
+	</list> The reader may judge our success in meeting these goals for him or herself.</p>
+	<p>Although we have tried to make this document self-contained, as suits a tutorial text, the
+	reader should be aware that it does not cover every detail of the TEI encoding scheme. All of
+	the elements described here are fully documented in the TEI Guidelines themselves, which should
+	be consulted for authoritative reference information on these, and on the many others which are
+	not described here. Some basic knowledge of XML is assumed.</p>
+      </div>
+      <div xml:id="U5-eg">
+	<head>A Short Example</head>
+	<p>We begin with a short example, intended to show what happens when a passage of prose is typed
+	into a computer by someone with little sense of the purpose of mark-up, or the potential of
+	electronic texts. In an ideal world, such output might be generated by a very accurate optical
+	scanner. It attempts to be faithful to the appearance of the printed text, by retaining the
+	original line breaks, by introducing blanks to represent the layout of the original headings
+	and page breaks, and so forth. Where characters not available on the keyboard are needed (such
+	as the accented letter <mentioned>a</mentioned> in <mentioned>faàl</mentioned> or the long
+	dash), it attempts to mimic their appearance.</p>
+	<p>
+	  <eg xml:space="preserve">
+	    CHAPTER 38
+	    
+	    READER, I married him. A quiet wedding we had: he and I, the par-
+	    son and clerk, were alone present. When we got back from church, I
+	    went into the kitchen of the manor-house, where Mary was cooking
+	    the dinner, and John cleaning the knives, and I said --
+	    'Mary, I have been married to Mr Rochester this morning.' The
+	    housekeeper and her husband were of that decent, phlegmatic
+	    order of people, to whom one may at any time safely communicate a
+	    remarkable piece of news without incurring the danger of having
+	    one's ears pierced by some shrill ejaculation and subsequently stunned
+	    by a torrent of wordy wonderment. Mary did look up, and she did
+	    stare at me; the ladle with which she was basting a pair of chickens
+	    roasting at the fire, did for some three minutes hang suspended in air,
+	    and for the same space of time John's knives also had rest from the
+	    polishing process; but Mary, bending again over the roast, said only --
+	    'Have you, miss? Well, for sure!'
+	    A short time after she pursued, 'I seed you go out with the master,
+	    but I didn't know you were gone to church to be wed'; and she
+	    basted away. John, when I turned to him, was grinning from ear to
+	    ear.
+	    'I telled Mary how it would be,' he said: 'I knew what Mr Ed-
+	    ward' (John was an old servant, and had known his master when he
+	    was the cadet of the house, therefore he often gave him his Christian
+	    name) -- 'I knew what Mr Edward would do; and I was certain he
+	    would not wait long either: and he's done right, for aught I know. I
+	    wish you joy, miss!' and he politely pulled his forelock.
+	    'Thank you, John. Mr Rochester told me to give you and Mary
+	    this.'
+	    I put into his hand a five-pound note.  Without waiting to hear
+	    more, I left the kitchen. In passing the door of that sanctum some time
+	    after, I caught the words --
+	    'She'll happen do better for him nor ony o' t' grand ladies.' And
+	    again, 'If she ben't one o' th' handsomest, she's noan faa\l, and varry
+	    good-natured; and i' his een she's fair beautiful, onybody may see
+	    that.'
+	    I wrote to Moor House and to Cambridge immediately, to say what
+	    I had done: fully explaining also why I had thus acted. Diana and
+	    
+	    474
+	    
+	    JANE EYRE                      475
+	    
+	    Mary approved the step unreservedly. Diana announced that she
+	    would just give me time to get over the honeymoon, and then she
+	    would come and see me.
+	    'She had better not wait till then, Jane,' said Mr Rochester, when I
+	    read her letter to him; 'if she does, she will be too late, for our honey-
+	    moon will shine our life long: its beams will only fade over your
+	    grave or mine.'
+	    How St John received the news I don't know: he never answered
+	    the letter in which I communicated it: yet six months after he wrote
+	    to me, without, however, mentioning Mr Rochester's name or allud-
+	    ing to my marriage. His letter was then calm, and though very serious,
+	    kind. He has maintained a regular, though not very frequent correspond-
+	    ence ever since: he hopes I am happy, and trusts I am not of those who
+	    live without God in the world, and only mind earthly things.
+	    
+	  </eg>
+	</p>
+	<p>This transcription suffers from a number of shortcomings: <list>
+	<item>the page numbers and running titles are intermingled with the text in a way which makes
+	it difficult for software to disentangle them;</item>
+	<item>no distinction is made between single quotation marks and apostrophe, so it is difficult
+	to know exactly which passages are in direct speech;</item>
+	<item>the preservation of the copy text's hyphenation means that simple-minded search programs
+	will not find the broken words;</item>
+	<item>the accented letter in <mentioned>faàl</mentioned> and the long dash have been rendered
+	by ad hoc keying conventions which follow no standard pattern and will be processed correctly
+	only if the transcriber remembers to mention them in the documentation;</item>
+	<item>paragraph divisions are marked only by the use of white space, and hard carriage returns
+	have been introduced at the end of each line. Consequently, if the size of type used to print
+	the text changes, reformatting will be problematic.</item>
+      </list>
+	</p>
+	<p>We now present the same passage, as it might be encoded using the TEI Guidelines. As we shall
+	see, there are many ways in which this encoding could be extended, but as a minimum, the TEI
+	approach allows us to represent the following distinctions: <list>
+	<item>Paragraph and chapter divisions are now marked explicitly.</item>
+	<item>Apostrophes are distinguished from quotation marks; direct speech is explicitly
+	marked.</item>
+	<item>The accented letter and the long dash are correctly represented.</item>
+	<item>Page divisions have been marked with an empty <gi>pb</gi> element alone.</item>
+	<item>The lineation of the original has not been retained and words broken by typographic
+	accident at the end of a line have been re-assembled without comment.</item>
+	<item>For convenience of proof reading, a new line has been introduced at the start of each
+	paragraph, but the indentation is removed.</item>
+      </list>
+      <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	<pb n="474"/>
+	<div type="chapter" n="38">
+	  <p>Reader, I married him. A quiet wedding we had: he and I, the parson and clerk, were alone
+	  present. When we got back from church, I went into the kitchen of the manor-house, where
+	  Mary was cooking the dinner, and John cleaning the knives, and I said —</p>
+	  <p>
+	    <q>Mary, I have been married to Mr Rochester this morning.</q> The housekeeper and her
+	    husband were of that decent, phlegmatic order of people, to whom one may at any time safely
+	    communicate a remarkable piece of news without incurring the danger of having one's ears
+	    pierced by some shrill ejaculation and subsequently stunned by a torrent of wordy
+	    wonderment. Mary did look up, and she did stare at me; the ladle with which she was basting
+	    a pair of chickens roasting at the fire, did for some three minutes hang suspended in air,
+	    and for the same space of time John's knives also had rest from the polishing process; but
+	  Mary, bending again over the roast, said only —</p>
+	  <p>
+	    <q>Have you, miss? Well, for sure!</q>
+	  </p>
+	  <p>A short time after she pursued, <q>I seed you go out with the master, but I didn't know
+	  you were gone to church to be wed</q>; and she basted away. John, when I turned to him, was
+	  grinning from ear to ear. <q>I telled Mary how it would be,</q> he said: <q>I knew what Mr
+	  Edward</q> (John was an old servant, and had known his master when he was the cadet of the
+	  house, therefore he often gave him his Christian name) — <q>I knew what Mr Edward would do;
+	  and I was certain he would not wait long either: and he's done right, for aught I know. I
+	  wish you joy, miss!</q> and he politely pulled his forelock.</p>
+	  <p>
+	    <q>Thank you, John. Mr Rochester told me to give you and Mary this.</q>
+	  </p>
+	  <p>I put into his hand a five-pound note. Without waiting to hear more, I left the kitchen.
+	  In passing the door of that sanctum some time after, I caught the words —</p>
+	  <p>
+	    <q>She'll happen do better for him nor ony o' t' grand ladies.</q> And again, <q>If she
+	    ben't one o' th' handsomest, she's noan faàl, and varry good-natured; and i' his een she's
+	    fair beautiful, onybody may see that.</q>
+	  </p>
+	  <p>I wrote to Moor House and to Cambridge immediately, to say what I had done: fully
+	  explaining also why I had thus acted. Diana and <pb n="475"/> Mary approved the step
+	  unreservedly. Diana announced that she would just give me time to get over the honeymoon,
+	  and then she would come and see me.</p>
+	  <p>
+	    <q>She had better not wait till then, Jane,</q> said Mr Rochester, when I read her letter
+	    to him; <q>if she does, she will be too late, for our honeymoon will shine our life long:
+	    its beams will only fade over your grave or mine.</q>
+	  </p>
+	  <p>How St John received the news I don't know: he never answered the letter in which I
+	  communicated it: yet six months after he wrote to me, without, however, mentioning Mr
+	  Rochester's name or alluding to my marriage. His letter was then calm, and though very
+	  serious, kind. He has maintained a regular, though not very frequent correspondence ever
+	  since: he hopes I am happy, and trusts I am not of those who live without God in the world,
+	  and only mind earthly things.</p>
+	</div>
+      </egXML>
     </p>
-    <p>This transcription suffers from a number of shortcomings: <list>
-      <item>the page numbers and running titles are intermingled with the text in a way which makes
-       it difficult for software to disentangle them;</item>
-      <item>no distinction is made between single quotation marks and apostrophe, so it is difficult
-       to know exactly which passages are in direct speech;</item>
-      <item>the preservation of the copy text's hyphenation means that simple-minded search programs
-       will not find the broken words;</item>
-      <item>the accented letter in <mentioned>faàl</mentioned> and the long dash have been rendered
-       by ad hoc keying conventions which follow no standard pattern and will be processed correctly
-       only if the transcriber remembers to mention them in the documentation;</item>
-      <item>paragraph divisions are marked only by the use of white space, and hard carriage returns
-       have been introduced at the end of each line. Consequently, if the size of type used to print
-       the text changes, reformatting will be problematic.</item>
-     </list></p>
-    <p>We now present the same passage, as it might be encoded using the TEI Guidelines. As we shall
-     see, there are many ways in which this encoding could be extended, but as a minimum, the TEI
-     approach allows us to represent the following distinctions: <list>
-      <item>Paragraph and chapter divisions are now marked explicitly.</item>
-      <item>Apostrophes are distinguished from quotation marks; direct speech is explicitly
-       marked.</item>
-      <item>The accented letter and the long dash are correctly represented.</item>
-      <item>Page divisions have been marked with an empty <gi>pb</gi> element alone.</item>
-      <item>The lineation of the original has not been retained and words broken by typographic
-       accident at the end of a line have been re-assembled without comment.</item>
-      <item>For convenience of proof reading, a new line has been introduced at the start of each
-       paragraph, but the indentation is removed.</item>
-     </list>
-     <egXML xmlns="http://www.tei-c.org/ns/Examples">
-      <pb n="474"/>
-      <div type="chapter" n="38">
-       <p>Reader, I married him. A quiet wedding we had: he and I, the parson and clerk, were alone
-        present. When we got back from church, I went into the kitchen of the manor-house, where
-        Mary was cooking the dinner, and John cleaning the knives, and I said —</p>
-       <p><q>Mary, I have been married to Mr Rochester this morning.</q> The housekeeper and her
-        husband were of that decent, phlegmatic order of people, to whom one may at any time safely
-        communicate a remarkable piece of news without incurring the danger of having one's ears
-        pierced by some shrill ejaculation and subsequently stunned by a torrent of wordy
-        wonderment. Mary did look up, and she did stare at me; the ladle with which she was basting
-        a pair of chickens roasting at the fire, did for some three minutes hang suspended in air,
-        and for the same space of time John's knives also had rest from the polishing process; but
-        Mary, bending again over the roast, said only —</p>
-       <p><q>Have you, miss? Well, for sure!</q></p>
-       <p>A short time after she pursued, <q>I seed you go out with the master, but I didn't know
-         you were gone to church to be wed</q>; and she basted away. John, when I turned to him, was
-        grinning from ear to ear. <q>I telled Mary how it would be,</q> he said: <q>I knew what Mr
-         Edward</q> (John was an old servant, and had known his master when he was the cadet of the
-        house, therefore he often gave him his Christian name) — <q>I knew what Mr Edward would do;
-         and I was certain he would not wait long either: and he's done right, for aught I know. I
-         wish you joy, miss!</q> and he politely pulled his forelock.</p>
-       <p><q>Thank you, John. Mr Rochester told me to give you and Mary this.</q></p>
-       <p>I put into his hand a five-pound note. Without waiting to hear more, I left the kitchen.
-        In passing the door of that sanctum some time after, I caught the words —</p>
-       <p><q>She'll happen do better for him nor ony o' t' grand ladies.</q> And again, <q>If she
-         ben't one o' th' handsomest, she's noan faàl, and varry good-natured; and i' his een she's
-         fair beautiful, onybody may see that.</q></p>
-       <p>I wrote to Moor House and to Cambridge immediately, to say what I had done: fully
-        explaining also why I had thus acted. Diana and <pb n="475"/> Mary approved the step
-        unreservedly. Diana announced that she would just give me time to get over the honeymoon,
-        and then she would come and see me.</p>
-       <p><q>She had better not wait till then, Jane,</q> said Mr Rochester, when I read her letter
-        to him; <q>if she does, she will be too late, for our honeymoon will shine our life long:
-         its beams will only fade over your grave or mine.</q></p>
-       <p>How St John received the news I don't know: he never answered the letter in which I
-        communicated it: yet six months after he wrote to me, without, however, mentioning Mr
-        Rochester's name or alluding to my marriage. His letter was then calm, and though very
-        serious, kind. He has maintained a regular, though not very frequent correspondence ever
-        since: he hopes I am happy, and trusts I am not of those who live without God in the world,
-        and only mind earthly things.</p>
-      </div></egXML></p>
     <p>This particular encoding represents a set of choices or priorities. As a trivial example,
-     note that in the second example, end-of-line hyphenation has been silently removed. Conceivably
-     Brontë (or her printer) intended the word <q>honeymoon</q> to appear as <q>honey-moon</q> on
-     its second appearance, though this seems unlikely: our decision to focus on Brontë's text,
-     rather than on the printing of it in this particular edition, makes it impossible to be
-     certain. This is an instance of the fundamental <emph>selectivity</emph> of any encoding. An
-     encoding makes explicit only those textual features of importance to the encoder. It is not
-     difficult to think of ways in which the encoding of even this short passage might readily be
-     extended. For example: <list type="simple">
-      <item>a regularized form of the passages in dialect could be provided; </item>
-      <item>footnotes glossing or commenting on any passage could be added;</item>
-      <item>pointers linking parts of this text to others could be added;</item>
-      <item>proper names of various kinds could be distinguished from the surrounding text;</item>
-      <item>detailed bibliographic information about the text's provenance and context could be
-       prefixed to it;</item>
-      <item>a linguistic analysis of the passage into sentences, clauses, words, etc., could be
-       provided, each unit being associated with appropriate category codes;</item>
-      <item>the text could be segmented into narrative or discourse units;</item>
-      <item>systematic analysis or interpretation of the text could be included in the encoding,
-       with potentially complex alignment or linkage between the text and the analysis, or between
-       the text and one or more translations of it;</item>
-      <item>passages in the text could be linked to images or sound held on other media.</item>
-     </list></p>
+    note that in the second example, end-of-line hyphenation has been silently removed. Conceivably
+    Brontë (or her printer) intended the word <q>honeymoon</q> to appear as <q>honey-moon</q> on
+    its second appearance, though this seems unlikely: our decision to focus on Brontë's text,
+    rather than on the printing of it in this particular edition, makes it impossible to be
+    certain. This is an instance of the fundamental <emph>selectivity</emph> of any encoding. An
+    encoding makes explicit only those textual features of importance to the encoder. It is not
+    difficult to think of ways in which the encoding of even this short passage might readily be
+    extended. For example: <list type="simple">
+    <item>a regularized form of the passages in dialect could be provided; </item>
+    <item>footnotes glossing or commenting on any passage could be added;</item>
+    <item>pointers linking parts of this text to others could be added;</item>
+    <item>proper names of various kinds could be distinguished from the surrounding text;</item>
+    <item>detailed bibliographic information about the text's provenance and context could be
+    prefixed to it;</item>
+    <item>a linguistic analysis of the passage into sentences, clauses, words, etc., could be
+    provided, each unit being associated with appropriate category codes;</item>
+    <item>the text could be segmented into narrative or discourse units;</item>
+    <item>systematic analysis or interpretation of the text could be included in the encoding,
+    with potentially complex alignment or linkage between the text and the analysis, or between
+    the text and one or more translations of it;</item>
+    <item>passages in the text could be linked to images or sound held on other media.</item>
+  </list>
+    </p>
     <p>TEI-recommended ways of carrying out most of these are described in the remainder of this
-     document. The TEI scheme as a whole also provides for an enormous range of other possibilities,
-     of which we cite only a few: <list type="simple">
-      <item>detailed analysis of the components of names;</item>
-      <item>detailed meta-information providing thesaurus-style information about the text's origins
-       or topics;</item>
-      <item>information about the printing history or manuscript variations exhibited by a
-       particular series of versions of the text.</item>
-     </list> For recommendations on these and many other possibilities, the full Guidelines should
-     be consulted.</p>
-   </div>
-   <div xml:id="U5-struc">
+    document. The TEI scheme as a whole also provides for an enormous range of other possibilities,
+    of which we cite only a few: <list type="simple">
+    <item>detailed analysis of the components of names;</item>
+    <item>detailed meta-information providing thesaurus-style information about the text's origins
+    or topics;</item>
+    <item>information about the printing history or manuscript variations exhibited by a
+    particular series of versions of the text.</item>
+    </list> For recommendations on these and many other possibilities, the full Guidelines should
+    be consulted.</p>
+  </div>
+  <div xml:id="U5-struc">
     <head>The Structure of a TEI Text</head>
     <p>All TEI-conformant texts contain (a) a <term>TEI header</term> (marked up as a
-      <gi>teiHeader</gi> element) and (b) the transcription of the text proper (marked up as a
-      <gi>text</gi> element). These two elements are combined together to form a single <gi>TEI</gi>
-     element, which must be declared within the TEI namespace<note place="foot">A
-       <term>namespace</term> is an XML concept. Its function is to identify the vocabulary from
-      which a group of element names are drawn, using a standard identifier resembling a web
-      address. The namespace for all TEI elements is
-     <code>http://www.tei-c.org/ns/1.0</code></note>. </p>
+    <gi>teiHeader</gi> element) and (b) the transcription of the text proper (marked up as a
+    <gi>text</gi> element). These two elements are combined together to form a single <gi>TEI</gi>
+    element, which must be declared within the TEI namespace<note place="foot">A
+    <term>namespace</term> is an XML concept. Its function is to identify the vocabulary from
+    which a group of element names are drawn, using a standard identifier resembling a web
+    address. The namespace for all TEI elements is
+    <code>http://www.tei-c.org/ns/1.0</code>
+    </note>. </p>
     <p>The TEI header provides information analogous to that provided by the title page of a printed
-     text. It has up to four parts: a bibliographic description of the machine-readable text, a
-     description of the way it has been encoded, a non-bibliographic description of the text (a
-      <term>text profile</term>), and a revision history. The header is described in more detail in
-     section <ptr target="#U5-header"/>.</p>
+    text. It has up to four parts: a bibliographic description of the machine-readable text, a
+    description of the way it has been encoded, a non-bibliographic description of the text (a
+    <term>text profile</term>), and a revision history. The header is described in more detail in
+    section <ptr target="#U5-header"/>.</p>
     <p>A TEI text may be <term>unitary</term> (a single work) or <term>composite</term> (a
-     collection of single works, such as an anthology). In either case, the text may have an
-     optional <term>front</term> or <term>back</term>. In between is the <term>body</term> of the
-     text, which, in the case of a composite text, may consist of <term>group</term>s, each
-     containing more groups or texts.</p>
-    <p>A unitary text will be encoded using an overall structure like this: <egXML
-      xmlns="http://www.tei-c.org/ns/Examples"><TEI>
-       <teiHeader><!-- [ TEI Header information ]  --></teiHeader>
-       <text>
-        <front><!-- [ front matter ... ] -->
-        </front>
-        <body>
-         <!-- [ body of text ... ]  -->
-        </body>
-        <back><!--  [ back matter ...  ] -->
-        </back>
-       </text>
-      </TEI></egXML></p>
+    collection of single works, such as an anthology). In either case, the text may have an
+    optional <term>front</term> or <term>back</term>. In between is the <term>body</term> of the
+    text, which, in the case of a composite text, may consist of <term>group</term>s, each
+    containing more groups or texts.</p>
+    <p>A unitary text will be encoded using an overall structure like this: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+    <TEI>
+      <teiHeader><!-- [ TEI Header information ]  --></teiHeader>
+      <text>
+	<front><!-- [ front matter ... ] -->
+	</front>
+	<body>
+	  <!-- [ body of text ... ]  -->
+	</body>
+	<back><!--  [ back matter ...  ] -->
+	</back>
+      </text>
+    </TEI>
+  </egXML>
+    </p>
     <p>A composite text also has an optional front and back. In between occur one or more groups of
-     texts, each with its own optional front and back matter. A composite text will thus be encoded
-     using an overall structure like this: <egXML xmlns="http://www.tei-c.org/ns/Examples"><TEI>
-       <teiHeader>
-        <!--[ header information for the composite ]-->
-       </teiHeader>
-       <text>
-        <front>
-         <!--[ front matter for the composite  ]-->
-        </front>
-        <group>
-         <text>
-          <front>
-           <!--[ front matter of first text ]-->
-          </front>
-          <body>
-           <!--[ body of first text  ]-->
-          </body>
-          <back>
-           <!--[ back matter of first text ]-->
-          </back>
-         </text>
-         <text>
-          <front>
-           <!--[ front matter of second text]-->
-          </front>
-          <body>
-           <!--[ body of second text  ]-->
-          </body>
-          <back>
-           <!--[ back matter of second text ]-->
-          </back>
-         </text>
-         <!--[ more texts or groups of texts here ]-->
-        </group>
-        <back>
-         <!--[ back matter for the composite  ]-->
-        </back>
-       </text>
-      </TEI></egXML></p>
+    texts, each with its own optional front and back matter. A composite text will thus be encoded
+    using an overall structure like this: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+    <TEI>
+      <teiHeader>
+	<!--[ header information for the composite ]-->
+      </teiHeader>
+      <text>
+	<front>
+	  <!--[ front matter for the composite  ]-->
+	</front>
+	<group>
+	  <text>
+	    <front>
+	      <!--[ front matter of first text ]-->
+	    </front>
+	    <body>
+	      <!--[ body of first text  ]-->
+	    </body>
+	    <back>
+	      <!--[ back matter of first text ]-->
+	    </back>
+	  </text>
+	  <text>
+	    <front>
+	      <!--[ front matter of second text]-->
+	    </front>
+	    <body>
+	      <!--[ body of second text  ]-->
+	    </body>
+	    <back>
+	      <!--[ back matter of second text ]-->
+	    </back>
+	  </text>
+	  <!--[ more texts or groups of texts here ]-->
+	</group>
+	<back>
+	  <!--[ back matter for the composite  ]-->
+	</back>
+      </text>
+    </TEI>
+  </egXML>
+    </p>
     <p>It is also possible to define a composite of complete TEI texts, each with its own header.
-     Such a collection is known as a <term>TEI corpus</term>, and may itself have a header: <egXML
-      xmlns="http://www.tei-c.org/ns/Examples"><teiCorpus><teiHeader>
-        <!--[header information for the corpus]--></teiHeader><TEI>
-        <teiHeader><!--[header information for first text]--></teiHeader>
-        <text>
-         <!--[first text in corpus]-->
-        </text>
-       </TEI><TEI>
-        <teiHeader><!--[header information for second text]--></teiHeader>
-        <text>
-         <!--[second text in corpus]-->
-        </text>
-       </TEI></teiCorpus></egXML> It is also possible to create a composite of corpora -- that is,
-     one <gi>teiCorpus</gi> element may contain many nested <gi>teiCorpus</gi> elements rather than
-     many nested <gi>TEI</gi> elements, to any depth considered necessary.</p>
+    Such a collection is known as a <term>TEI corpus</term>, and may itself have a header: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+    <teiCorpus>
+      <teiHeader>
+      <!--[header information for the corpus]--></teiHeader>
+      <TEI>
+	<teiHeader><!--[header information for first text]--></teiHeader>
+	<text>
+	  <!--[first text in corpus]-->
+	</text>
+      </TEI>
+      <TEI>
+	<teiHeader><!--[header information for second text]--></teiHeader>
+	<text>
+	  <!--[second text in corpus]-->
+	</text>
+      </TEI>
+    </teiCorpus>
+    </egXML> It is also possible to create a composite of corpora -- that is,
+    one <gi>teiCorpus</gi> element may contain many nested <gi>teiCorpus</gi> elements rather than
+    many nested <gi>TEI</gi> elements, to any depth considered necessary.</p>
     <p>In the remainder of this document, we discuss chiefly simple text structures. The discussion
-     in each case consists of a short list of relevant TEI <term>elements</term> with a brief
-     definition of each, followed by definitions for any <term>attributes</term> specific to that
-     element, and a reference to any <term>classes</term> of which the element is a member. These
-     references are linked to full specifications for each object, as given in the TEI
-      <title>Guidelines</title>. In most cases, short examples are also given.</p>
+    in each case consists of a short list of relevant TEI <term>elements</term> with a brief
+    definition of each, followed by definitions for any <term>attributes</term> specific to that
+    element, and a reference to any <term>classes</term> of which the element is a member. These
+    references are linked to full specifications for each object, as given in the TEI
+    <title>Guidelines</title>. In most cases, short examples are also given.</p>
     <p>For example, here are the elements discussed so far: <specList>
-      <specDesc key="TEI"/>
-      <specDesc key="teiHeader"/>
-      <specDesc key="text"/>
-      <specDesc key="teiCorpus"/>
-     </specList></p>
-   </div>
-   <div xml:id="U5-body">
+    <specDesc key="TEI"/>
+    <specDesc key="teiHeader"/>
+    <specDesc key="text"/>
+    <specDesc key="teiCorpus"/>
+  </specList>
+    </p>
+  </div>
+  <div xml:id="U5-body">
     <head>Encoding the Body</head>
     <p>As indicated above, a simple TEI document at the textual level consists of the following
-     elements: <specList>
-      <specDesc key="front"/>
-      <specDesc key="group"/>
-      <specDesc key="body"/>
-      <specDesc key="back"/>
-     </specList> Elements specific to front and back matter are described below in section <ptr
-      target="#U5-fronbac"/>. In this section we discuss the elements making up the body of a text. </p>
+    elements: <specList>
+    <specDesc key="front"/>
+    <specDesc key="group"/>
+    <specDesc key="body"/>
+    <specDesc key="back"/>
+    </specList> Elements specific to front and back matter are described below in section <ptr target="#U5-fronbac"/>. In this section we discuss the elements making up the body of a text. </p>
     <div xml:id="divs">
-     <head>Text Division Elements</head>
-     <p>The body of a prose text may be just a series of paragraphs, or these paragraphs may be
+      <head>Text Division Elements</head>
+      <p>The body of a prose text may be just a series of paragraphs, or these paragraphs may be
       grouped together into chapters, sections, subsections, etc. Each paragraph is tagged using the
-       <gi>p</gi> tag. The <gi>div</gi> element is used to represent any such grouping of
+      <gi>p</gi> tag. The <gi>div</gi> element is used to represent any such grouping of
       paragraphs. <specList>
-       <specDesc key="p"/>
-       <specDesc key="div"/>
-      </specList>
-     </p>
-     <p>The <att>type</att> attribute on the <gi>div</gi> element may be used to supply a
+      <specDesc key="p"/>
+      <specDesc key="div"/>
+    </specList>
+      </p>
+      <p>The <att>type</att> attribute on the <gi>div</gi> element may be used to supply a
       conventional name for this category of text division, or otherwise distinguish them. Typical
       values might be <q>book</q>, <q>chapter</q>, <q>section</q>, <q>part</q>, <q>poem</q>,
-       <q>song</q>, etc. For a given project, it will usually be advisable to define and adhere to a
+      <q>song</q>, etc. For a given project, it will usually be advisable to define and adhere to a
       specific list of such values. </p>
-     <p>A <gi>div</gi> element may itself contain further, nested, <gi>div</gi>s, thus mimicking the
+      <p>A <gi>div</gi> element may itself contain further, nested, <gi>div</gi>s, thus mimicking the
       traditional structure of a book, which can be decomposed hierarchically into units such as
       parts, containing chapters, containing sections, and so on. TEI texts in general conform to
       this simple hierarchic model.</p>
-     <p> The <att>xml:id</att> attribute may be used to supply a unique identifier for the division,
+      <p> The <att>xml:id</att> attribute may be used to supply a unique identifier for the division,
       which may be used for cross references or other links to it, such as a commentary, as further
       discussed in section <ptr target="#U5-ptrs"/>. It is often useful to provide an
-       <att>xml:id</att> attribute for every major structural unit in a text, and to derive its
+      <att>xml:id</att> attribute for every major structural unit in a text, and to derive its
       values in some systematic way, for example by appending a section number to a short code for
       the title of the work in question, as in the examples below. It is particularly useful to
       supply such identifiers if the resource concerned is to be made available over the web, since
       they make it much easier for other web-based applications to link directly to the
       corresponding parts of your text. </p>
-     <p>The <att>n</att> attribute may be used to supply (additionally or alternatively) a short
+      <p>The <att>n</att> attribute may be used to supply (additionally or alternatively) a short
       mnemonic name or number for a division, or any other element. If a conventional form of
       reference or abbreviation for the parts of a work already exists (such as the
       book/chapter/verse pattern of Biblical citations), the <att>n</att> attribute is the place to
       record it; unlike the identifier supplied by <att>xml:id</att>, it does not need to be
       unique.</p>
-     <p>The <att>xml:lang</att> attribute may be used to specify the language of the division.
+      <p>The <att>xml:lang</att> attribute may be used to specify the language of the division.
       Languages are identified by an internationally defined code, as further discussed in section
-       <ptr target="#z636"/> below.</p>
-     <p>The <att>rend</att> attribute may be used to supply information about the rendition
-      (appearance) of a division, or any other element, as further discussed in section <ptr
-       target="#U5-hilites"/> below. As with the <att>type</att> attribute, a project will often
+      <ptr target="#z636"/> below.</p>
+      <p>The <att>rend</att> attribute may be used to supply information about the rendition
+      (appearance) of a division, or any other element, as further discussed in section <ptr target="#U5-hilites"/> below. As with the <att>type</att> attribute, a project will often
       find it useful to predefine the possible values for this attribute, but TEI Lite does not
       constrain it in anyway. </p>
-     <p> These four attributes, <att>xml:id</att>, <att>n</att>, <att>xml:lang</att>, and
-       <att>rend</att> are so widely useful that they are allowed on any element in any TEI schema:
+      <p> These four attributes, <att>xml:id</att>, <att>n</att>, <att>xml:lang</att>, and
+      <att>rend</att> are so widely useful that they are allowed on any element in any TEI schema:
       they are <term>global attributes</term>. Other global attributes defined in the TEI Lite
       scheme are discussed in section <ptr target="#xatts"/>.</p>
-     <p>The value of every <att>xml:id</att> attribute should be unique within a document. One
+      <p>The value of every <att>xml:id</att> attribute should be unique within a document. One
       simple way of ensuring that this is so is to make it reflect the hierarchic structure of the
       document. For example, Smith's <title>Wealth of Nations</title> as first published consists of
       five books, each of which is divided into chapters, while some chapters are further subdivided
-      into parts. We might define <att>xml:id</att> values for this structure as follows: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><body>
-        <div xml:id="WN1" n="I" type="book">
-         <div xml:id="WN101" n="I.1" type="chapter">
-          <!-- ... -->
-         </div>
-         <div xml:id="WN102" n="I.2" type="chapter">
-          <!-- ... -->
-         </div>
-         <!-- ... -->
-         <div xml:id="WN110" n="I.10" type="chapter">
-          <div xml:id="WN1101" n="I.10.1" type="part">
-           <!-- ... -->
-          </div>
-          <div xml:id="WN1102" n="I.10.2" type="part">
-           <!-- ... -->
-          </div>
-         </div>
-         <!-- ... -->
-        </div>
-        <div xml:id="WN2" n="II" type="book">
-         <!-- ... -->
-        </div>
-       </body></egXML></p>
-     <p>A different numbering scheme may be used for <att>xml:id</att> and <att>n</att> attributes:
+      into parts. We might define <att>xml:id</att> values for this structure as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <body>
+	<div xml:id="WN1" n="I" type="book">
+	  <div xml:id="WN101" n="I.1" type="chapter">
+	    <!-- ... -->
+	  </div>
+	  <div xml:id="WN102" n="I.2" type="chapter">
+	    <!-- ... -->
+	  </div>
+	  <!-- ... -->
+	  <div xml:id="WN110" n="I.10" type="chapter">
+	    <div xml:id="WN1101" n="I.10.1" type="part">
+	      <!-- ... -->
+	    </div>
+	    <div xml:id="WN1102" n="I.10.2" type="part">
+	      <!-- ... -->
+	    </div>
+	  </div>
+	  <!-- ... -->
+	</div>
+	<div xml:id="WN2" n="II" type="book">
+	  <!-- ... -->
+	</div>
+      </body>
+    </egXML>
+      </p>
+      <p>A different numbering scheme may be used for <att>xml:id</att> and <att>n</att> attributes:
       this is often useful where a canonical reference scheme is used which does not tally with the
       structure of the work. For example, in a novel divided into books each containing chapters,
       where the chapters are numbered sequentially through the whole work, rather than within each
-      book, one might use a scheme such as the following: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><body>
-        <div xml:id="TS01" n="1" type="volume">
-         <div xml:id="TS011" n="1" type="chapter">
-          <!-- ... -->
-         </div>
-         <div xml:id="TS012" n="2" type="chapter">
-          <!-- ... --></div>
-        </div>
-        <div xml:id="TS02" n="2" type="volume">
-         <div xml:id="TS021" n="3" type="chapter">
-          <!-- ... --></div>
-         <div xml:id="TS022" n="4" type="chapter">
-          <!-- ... --></div>
-        </div>
-       </body></egXML> Here the work has two volumes, each containing two chapters. The chapters are
+      book, one might use a scheme such as the following: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <body>
+	<div xml:id="TS01" n="1" type="volume">
+	  <div xml:id="TS011" n="1" type="chapter">
+	    <!-- ... -->
+	  </div>
+	  <div xml:id="TS012" n="2" type="chapter">
+	  <!-- ... --></div>
+	</div>
+	<div xml:id="TS02" n="2" type="volume">
+	  <div xml:id="TS021" n="3" type="chapter">
+	  <!-- ... --></div>
+	  <div xml:id="TS022" n="4" type="chapter">
+	  <!-- ... --></div>
+	</div>
+      </body>
+      </egXML> Here the work has two volumes, each containing two chapters. The chapters are
       numbered conventionally 1 to 4, but the <att>xml:id</att> values specified allow them to be
       regarded additionally as if they were numbered 1.1, 1.2, 2.1, 2.2.</p>
     </div>
     <div xml:id="h25">
-     <head>Headings and Closings</head>
-     <p>Every <gi>div</gi> may have a title or heading at its start, and (less commonly) a trailer
+      <head>Headings and Closings</head>
+      <p>Every <gi>div</gi> may have a title or heading at its start, and (less commonly) a trailer
       such as <q>End of Chapter 1</q> at its end. The following elements may be used to transcribe
       them: <specList>
-       <specDesc key="head"/>
-       <specDesc key="trailer"/>
+      <specDesc key="head"/>
+      <specDesc key="trailer"/>
       </specList> Some other elements which may be necessary at the beginning or ending of text
       divisions are discussed below in section <ptr target="#h52"/>.</p>
-     <p>Whether or not headings and trailers are included in a transcription is a matter for the
+      <p>Whether or not headings and trailers are included in a transcription is a matter for the
       individual transcriber to decide. Where a heading is completely regular (for example
-       <q>Chapter 1</q>) or may be automatically constructed from attribute values (e.g.
-       <code>&lt;div type="chapter" n="1"&gt;</code>), it may be omitted; where it contains
+      <q>Chapter 1</q>) or may be automatically constructed from attribute values (e.g.
+      <code>&lt;div type="chapter" n="1"&gt;</code>), it may be omitted; where it contains
       otherwise unrecoverable text it should always be included. For example, the start of Hardy's
-       <title>Under the Greenwood Tree</title> might be encoded as follows: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><div xml:id="UGT1" n="Winter" type="Part">
-        <div xml:id="UGT11" n="1" type="Chapter">
-         <head>Mellstock-Lane</head>
-         <p>To dwellers in a wood almost every species of tree ... </p>
-        </div>
-       </div></egXML></p>
+      <title>Under the Greenwood Tree</title> might be encoded as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <div xml:id="UGT1" n="Winter" type="Part">
+	<div xml:id="UGT11" n="1" type="Chapter">
+	  <head>Mellstock-Lane</head>
+	  <p>To dwellers in a wood almost every species of tree ... </p>
+	</div>
+      </div>
+    </egXML>
+      </p>
     </div>
     <div xml:id="vedr">
-     <head>Prose, Verse and Drama</head>
-     <p>As in the Bronte example above, the paragraphs making up a textual division are tagged with
+      <head>Prose, Verse and Drama</head>
+      <p>As in the Bronte example above, the paragraphs making up a textual division are tagged with
       the <gi>p</gi> tag. In poetic or dramatic texts different tags are needed, to represent verse
       lines and stanzas in the first case, or individual speeches and stage directions in the
       second. : <specList>
-       <specDesc key="l"/>
-       <specDesc key="lg"/>
-       <specDesc key="sp"/>
-       <specDesc key="speaker"/>
-       <specDesc key="stage"/>
-      </specList>
-     </p>
-     <p>Here, for example, is the start of a poetic text in which verse lines and stanzas are
-      tagged: <egXML xmlns="http://www.tei-c.org/ns/Examples"><lg n="I"><l>I Sing the progresse of a
-         deathlesse soule,</l><l>Whom Fate, with God made, but doth not controule,</l><l>Plac'd in
-         most shapes; all times before the law</l><l>Yoak'd us, and when, and since, in this I
-         sing.</l><l>And the great world to his aged evening;</l><l>From infant morne, through manly
-         noone I draw.</l><l>What the gold Chaldee, of silver Persian saw,</l><l>Greeke brass, or
-         Roman iron, is in this one;</l><l>A worke t'out weare Seths pillars, bricke and
-         stone,</l><l>And (holy writs excepted) made to yeeld to none,</l></lg></egXML></p>
-     <p>Note that the <gi>l</gi> element marks verse lines, not typographic lines: the original
+      <specDesc key="l"/>
+      <specDesc key="lg"/>
+      <specDesc key="sp"/>
+      <specDesc key="speaker"/>
+      <specDesc key="stage"/>
+    </specList>
+      </p>
+      <p>Here, for example, is the start of a poetic text in which verse lines and stanzas are
+      tagged: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <lg n="I">
+	<l>I Sing the progresse of a
+	deathlesse soule,</l>
+	<l>Whom Fate, with God made, but doth not controule,</l>
+	<l>Plac'd in
+	most shapes; all times before the law</l>
+	<l>Yoak'd us, and when, and since, in this I
+	sing.</l>
+	<l>And the great world to his aged evening;</l>
+	<l>From infant morne, through manly
+	noone I draw.</l>
+	<l>What the gold Chaldee, of silver Persian saw,</l>
+	<l>Greeke brass, or
+	Roman iron, is in this one;</l>
+	<l>A worke t'out weare Seths pillars, bricke and
+	stone,</l>
+	<l>And (holy writs excepted) made to yeeld to none,</l>
+      </lg>
+    </egXML>
+      </p>
+      <p>Note that the <gi>l</gi> element marks verse lines, not typographic lines: the original
       lineation of the first few lines above has not therefore been made explicit by this encoding,
       and may be lost. The <gi>lb</gi> element described in section <ptr target="#U5-pln"/> might
       additionally be used to mark typographic lines if so desired. </p>
-     <p>Here is the end of a famous dramatic text, in which speeches and stage directions are
+      <p>Here is the end of a famous dramatic text, in which speeches and stage directions are
       marked: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-       <sp><speaker>Vladimir</speaker><p>Pull on your trousers.</p></sp>
-       <sp><speaker>Estragon</speaker><p>You want me to pull off my trousers?</p></sp>
-       <sp><speaker>Vladimir</speaker><p>Pull <emph>on</emph> your trousers.</p></sp>
-       <sp><speaker>Vladimir</speaker><p><stage>(realizing his trousers are down)</stage>.
-        True</p></sp>
-       <stage>He pulls up his trousers</stage>
-       <sp><speaker>Vladimir</speaker><p>Well? Shall we go?</p></sp>
-       <sp><speaker>Estragon</speaker><p>Yes, let's go.</p></sp>
-       <stage>They do not move.</stage>
-      </egXML>
-     </p>
-     <p>Note that the <gi>stage</gi> (stage direction) element can appear either within a speech or
+      <sp>
+	<speaker>Vladimir</speaker>
+	<p>Pull on your trousers.</p>
+      </sp>
+      <sp>
+	<speaker>Estragon</speaker>
+	<p>You want me to pull off my trousers?</p>
+      </sp>
+      <sp>
+	<speaker>Vladimir</speaker>
+	<p>Pull <emph>on</emph> your trousers.</p>
+      </sp>
+      <sp>
+	<speaker>Vladimir</speaker>
+	<p>
+	  <stage>(realizing his trousers are down)</stage>.
+	True</p>
+      </sp>
+      <stage>He pulls up his trousers</stage>
+      <sp>
+	<speaker>Vladimir</speaker>
+	<p>Well? Shall we go?</p>
+      </sp>
+      <sp>
+	<speaker>Estragon</speaker>
+	<p>Yes, let's go.</p>
+      </sp>
+      <stage>They do not move.</stage>
+    </egXML>
+      </p>
+      <p>Note that the <gi>stage</gi> (stage direction) element can appear either within a speech or
       between speeches. The <gi>sp</gi> ("speech") element contains, following an optional
-       <gi>speaker</gi> element indicating who is speaking, either paragraphs (if the speech is in
+      <gi>speaker</gi> element indicating who is speaking, either paragraphs (if the speech is in
       prose) or verse lines or stanzas as in the next example. In this case, it is quite common to
       find that verse lines are split between speakers. The easiest way of encoding this is to use
-      the <att>part</att> attribute to indicate that the lines so fragmented are incomplete : <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><div type="Act" n="I">
-        <head>ACT I</head>
-        <div type="Scene" n="1">
-         <head>SCENE I</head>
-         <stage rend="italic"> Enter Barnardo and Francisco, two Sentinels, at several doors</stage>
-         <sp>
-          <speaker>Barn</speaker>
-          <l part="Y">Who's there?</l>
-         </sp>
-         <sp>
-          <speaker>Fran</speaker>
-          <l>Nay, answer me. Stand and unfold yourself.</l>
-         </sp>
-         <sp>
-          <speaker>Barn</speaker>
-          <l part="I">Long live the King!</l>
-         </sp>
-         <sp>
-          <speaker>Fran</speaker>
-          <l part="M">Barnardo?</l>
-         </sp>
-         <sp>
-          <speaker>Barn</speaker>
-          <l part="F">He.</l>
-         </sp>
-         <sp>
-          <speaker>Fran</speaker>
-          <l>You come most carefully upon your hour.</l>
-         </sp>
-         <!-- ... -->
-        </div>
-       </div></egXML></p>
-     <p>The same mechanism may be applied to stanzas which are divided between two speakers: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><div>
-        <sp>
-         <speaker>First voice</speaker>
-         <lg type="stanza" part="I">
-          <l>But why drives on that ship so fast</l>
-          <l>Withouten wave or wind?</l>
-         </lg>
-        </sp>
-        <sp>
-         <speaker>Second Voice</speaker>
-         <lg part="F">
-          <l>The air is cut away before.</l>
-          <l>And closes from behind.</l>
-         </lg>
-        </sp>
-        <!-- ... -->
-       </div></egXML>
-     </p>
-     <p>The <gi>sp</gi> element can also be used for dialogue presented in a prose work as if it
+      the <att>part</att> attribute to indicate that the lines so fragmented are incomplete : <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <div type="Act" n="I">
+	<head>ACT I</head>
+	<div type="Scene" n="1">
+	  <head>SCENE I</head>
+	  <stage rend="italic"> Enter Barnardo and Francisco, two Sentinels, at several doors</stage>
+	  <sp>
+	    <speaker>Barn</speaker>
+	    <l part="Y">Who's there?</l>
+	  </sp>
+	  <sp>
+	    <speaker>Fran</speaker>
+	    <l>Nay, answer me. Stand and unfold yourself.</l>
+	  </sp>
+	  <sp>
+	    <speaker>Barn</speaker>
+	    <l part="I">Long live the King!</l>
+	  </sp>
+	  <sp>
+	    <speaker>Fran</speaker>
+	    <l part="M">Barnardo?</l>
+	  </sp>
+	  <sp>
+	    <speaker>Barn</speaker>
+	    <l part="F">He.</l>
+	  </sp>
+	  <sp>
+	    <speaker>Fran</speaker>
+	    <l>You come most carefully upon your hour.</l>
+	  </sp>
+	  <!-- ... -->
+	</div>
+      </div>
+    </egXML>
+      </p>
+      <p>The same mechanism may be applied to stanzas which are divided between two speakers: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <div>
+	<sp>
+	  <speaker>First voice</speaker>
+	  <lg type="stanza" part="I">
+	    <l>But why drives on that ship so fast</l>
+	    <l>Withouten wave or wind?</l>
+	  </lg>
+	</sp>
+	<sp>
+	  <speaker>Second Voice</speaker>
+	  <lg part="F">
+	    <l>The air is cut away before.</l>
+	    <l>And closes from behind.</l>
+	  </lg>
+	</sp>
+	<!-- ... -->
+      </div>
+    </egXML>
+      </p>
+      <p>The <gi>sp</gi> element can also be used for dialogue presented in a prose work as if it
       were drama, as in the next example, which also demonstrates the use of the <att>who</att>
-      attribute to bear a code identifying the speaker of the piece of dialogue concerned: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><div>
-        <sp who="#OPI">
-         <speaker>The reverend Doctor Opimian</speaker>
-         <p>I do not think I have named a single unpresentable fish.</p>
-        </sp>
-        <sp who="#GRM">
-         <speaker>Mr Gryll</speaker>
-         <p>Bream, Doctor: there is not much to be said for bream.</p>
-        </sp>
-        <sp who="#OPI">
-         <speaker>The Reverend Doctor Opimian</speaker>
-         <p>On the contrary, sir, I think there is much to be said for him. In the first
-          place....</p>
-         <p>Fish, Miss Gryll -- I could discourse to you on fish by the hour: but for the present I
-          will forbear.</p>
-        </sp>
-       </div></egXML> Here the <att>who</att> attribute values (<code>#OPI</code> etc.) are links,
-      pointing to a list of the characters in the novel, each of which has an identifier: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples">
-       <list><head>Characters in the novel</head>
-        <item xml:id="OPI"><name>Dr Opimian</name> : named for the famous Roman fine wine</item>
-        <item xml:id="GRM"><name>Mr Gryll</name> : named for the mythical Gryllus, one of Ulysses'
-         sailors transformed by Circe into a pig, who argues that he was happier in that state than
-         as a man</item>
-       </list></egXML></p>
+      attribute to bear a code identifying the speaker of the piece of dialogue concerned: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <div>
+	<sp who="#OPI">
+	  <speaker>The reverend Doctor Opimian</speaker>
+	  <p>I do not think I have named a single unpresentable fish.</p>
+	</sp>
+	<sp who="#GRM">
+	  <speaker>Mr Gryll</speaker>
+	  <p>Bream, Doctor: there is not much to be said for bream.</p>
+	</sp>
+	<sp who="#OPI">
+	  <speaker>The Reverend Doctor Opimian</speaker>
+	  <p>On the contrary, sir, I think there is much to be said for him. In the first
+	  place....</p>
+	  <p>Fish, Miss Gryll -- I could discourse to you on fish by the hour: but for the present I
+	  will forbear.</p>
+	</sp>
+      </div>
+      </egXML> Here the <att>who</att> attribute values (<code>#OPI</code> etc.) are links,
+      pointing to a list of the characters in the novel, each of which has an identifier: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <list>
+	<head>Characters in the novel</head>
+	<item xml:id="OPI">
+	<name>Dr Opimian</name> : named for the famous Roman fine wine</item>
+	<item xml:id="GRM">
+	  <name>Mr Gryll</name> : named for the mythical Gryllus, one of Ulysses'
+	  sailors transformed by Circe into a pig, who argues that he was happier in that state than
+	as a man</item>
+      </list>
+    </egXML>
+      </p>
     </div>
-   </div>
-   <div xml:id="U5-pln">
+  </div>
+  <div xml:id="U5-pln">
     <head>Page and Line Numbers</head>
     <p>Page and line breaks etc. may be marked with the following elements. <specList>
-      <specDesc key="pb"/>
-      <specDesc key="lb"/>
-      <specDesc key="milestone"/>
-     </specList> These elements mark a single point in the text, not a span of text. The global
-      <att>n</att> attribute should be used to supply the number of the page or line beginning at
-     the tag. </p>
+    <specDesc key="pb"/>
+    <specDesc key="lb"/>
+    <specDesc key="milestone"/>
+    </specList> These elements mark a single point in the text, not a span of text. The global
+    <att>n</att> attribute should be used to supply the number of the page or line beginning at
+    the tag. </p>
     <p>When working from a paginated original, it is often useful to record its pagination, if only
-     to simplify later proof-reading. It is also useful for synchronizing an encoded text with a set
-     of page images. Recording the line breaks may be useful for similar reasons.
-     <!--; treatment of end-of-line
-     hyphenation in printed source texts will require some consideration.--></p>
+    to simplify later proof-reading. It is also useful for synchronizing an encoded text with a set
+    of page images. Recording the line breaks may be useful for similar reasons.
+    <!--; treatment of end-of-line
+	hyphenation in printed source texts will require some consideration.--></p>
     <p>If features such as pagination or lineation are marked for more than one edition, specify the
-     edition in question using the <att>ed</att> attribute, and supply as many tags are necessary.
-     For example, in the following passage we indicate where the page breaks occur in two different
-     editions (<val>ED1</val> and <val>ED2</val>) <egXML xmlns="http://www.tei-c.org/ns/Examples"
-       ><p>I wrote to Moor House and to Cambridge immediately, to say what I had done: fully
-       explaining also why I had thus acted. Diana and <pb ed="ED1" n="475"/> Mary approved the step
-       unreservedly. Diana announced that she would <pb ed="ED2" n="485"/>just give me time to get
-       over the honeymoon, and then she would come and see me.</p></egXML></p>
+    edition in question using the <att>ed</att> attribute, and supply as many tags are necessary.
+    For example, in the following passage we indicate where the page breaks occur in two different
+    editions (<val>ED1</val> and <val>ED2</val>) <egXML xmlns="http://www.tei-c.org/ns/Examples">
+    <p>I wrote to Moor House and to Cambridge immediately, to say what I had done: fully
+    explaining also why I had thus acted. Diana and <pb ed="ED1" n="475"/> Mary approved the step
+    unreservedly. Diana announced that she would <pb ed="ED2" n="485"/>just give me time to get
+    over the honeymoon, and then she would come and see me.</p>
+  </egXML>
+    </p>
     <p>A special attribute <att>break</att> may be used to indicate whether or not this empty
-     element is considered as a word-breaking, irrespective of any adjacent whitespace. For example,
-     in the following encoded sample: </p>
+    element is considered as a word-breaking, irrespective of any adjacent whitespace. For example,
+    in the following encoded sample: </p>
     <p>The <gi>pb</gi> and <gi>lb</gi> elements are special cases of the general class of
-      <term>milestone</term> elements which mark reference points within a text. The generic
-      <gi>milestone</gi> element can mark any kind of reference point: for example, a column break,
-     the start of a new kind of section not otherwise tagged, or in general any significant change
-     in the text not marked by an XML element. The names used for types of unit and for editions
-     referred to by the <att>ed</att> and <att>unit</att> attributes may be chosen freely, but
-     should be documented in the header <gi>refsDecl</gi> element (see <ptr target="#refsdecl"/>).
-     The <gi>milestone</gi> element may be used to replace the others, or the others may be used as
-     a set; they should not be mixed arbitrarily.</p>
-   </div>
-   <div xml:id="U5-hilites">
+    <term>milestone</term> elements which mark reference points within a text. The generic
+    <gi>milestone</gi> element can mark any kind of reference point: for example, a column break,
+    the start of a new kind of section not otherwise tagged, or in general any significant change
+    in the text not marked by an XML element. The names used for types of unit and for editions
+    referred to by the <att>ed</att> and <att>unit</att> attributes may be chosen freely, but
+    should be documented in the header <gi>refsDecl</gi> element (see <ptr target="#refsdecl"/>).
+    The <gi>milestone</gi> element may be used to replace the others, or the others may be used as
+    a set; they should not be mixed arbitrarily.</p>
+  </div>
+  <div xml:id="U5-hilites">
     <head>Marking Highlighted Phrases</head>
     <div xml:id="faces">
-     <head>Changes of Typeface, etc.</head>
-     <p>Highlighted words or phrases are those made visibly different from the rest of the text,
+      <head>Changes of Typeface, etc.</head>
+      <p>Highlighted words or phrases are those made visibly different from the rest of the text,
       typically by a change of type font, handwriting style, ink colour etc., which is intended to
       draw the reader's attention to some associated change.</p>
-     <p>The global <att>rend</att> attribute can be attached to any element, and used wherever
+      <p>The global <att>rend</att> attribute can be attached to any element, and used wherever
       necessary to specify details of the highlighting used for it in the source. For example, a
       heading rendered in bold might be tagged <code>&lt;head rend="bold"&gt;</code>, and one in
-      italic <code>&lt;head rend="italic"&gt;</code>.</p><p>The values to be used for the
-       <att>rend</att> attribute are not specified by the TEI Guidelines, since they will depend
+      italic <code>&lt;head rend="italic"&gt;</code>.</p>
+      <p>The values to be used for the
+      <att>rend</att> attribute are not specified by the TEI Guidelines, since they will depend
       entirely on the needs of the particular project. Some typical values might include
-       <code>italic</code>, <code>bold</code> <!--, <code>sup</code>(erior)--> etc. for font variations;
-       <code>center</code>, <code>right</code> etc. for alignment; <code>large</code>,
-       <code>small</code> etc. for size; <code>smallcaps</code>, <code>allcaps</code> etc. for type
+      <code>italic</code>, <code>bold</code> 
+      <!--, <code>sup</code>(erior)--> etc. for font variations;
+      <code>center</code>, <code>right</code> etc. for alignment; <code>large</code>,
+      <code>small</code> etc. for size; <code>smallcaps</code>, <code>allcaps</code> etc. for type
       variants and so on. Several such words may be used in combination as necessary, but no formal
       syntax is proposed. The full TEI Guidelines provide more rigorous mechanisms, using other W3C
       standards such as CSS, as an alternative to the use of <att>rend</att>. </p>
-     <p>It is not always possible or desirable to interpret the reasons for such changes of
+      <p>It is not always possible or desirable to interpret the reasons for such changes of
       rendering in a text. In such cases, the element <gi>hi</gi> may be used to mark a sequence of
       highlighted text without making any claim as to its status. <specList>
-       <specDesc key="hi"/>
-      </specList></p>
-     <p>In the following example, the use of a distinct typeface for the subheading and for the
-      included name are recorded but not interpreted: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><p><hi rend="gothic">And this Indenture further
-         witnesseth</hi> that the said <hi rend="italic">Walter Shandy</hi>, merchant, in
-        consideration of the said intended marriage ...</p></egXML></p>
-     <p>Alternatively, where the cause for the highlighting can be identified with confidence, a
+      <specDesc key="hi"/>
+    </specList>
+      </p>
+      <p>In the following example, the use of a distinct typeface for the subheading and for the
+      included name are recorded but not interpreted: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <p>
+	<hi rend="gothic">And this Indenture further
+	witnesseth</hi> that the said <hi rend="italic">Walter Shandy</hi>, merchant, in
+      consideration of the said intended marriage ...</p>
+    </egXML>
+      </p>
+      <p>Alternatively, where the cause for the highlighting can be identified with confidence, a
       number of other, more specific, elements are available. <specList>
-       <specDesc key="emph"/>
-       <specDesc key="foreign"/>
-       <specDesc key="gloss"/>
-       <specDesc key="label"/>
-       <specDesc key="mentioned"/>
-       <specDesc key="term"/>
-       <specDesc key="title"/>
-      </specList></p>
-     <p>Some features (notably quotations and glosses) may be found in a text either marked by
+      <specDesc key="emph"/>
+      <specDesc key="foreign"/>
+      <specDesc key="gloss"/>
+      <specDesc key="label"/>
+      <specDesc key="mentioned"/>
+      <specDesc key="term"/>
+      <specDesc key="title"/>
+    </specList>
+      </p>
+      <p>Some features (notably quotations and glosses) may be found in a text either marked by
       highlighting, or with quotation marks. In either case, the elements <gi>q</gi> and
-       <gi>gloss</gi> (as discussed in the following section) should be used. If the highlighting is
+      <gi>gloss</gi> (as discussed in the following section) should be used. If the highlighting is
       to be recorded, use the global <att>rend</att> attribute.</p>
-     <p>As an example of the elements defined here, consider the following sentence: <q
-       rend="display">On the one hand the <hi rend="it">Nibelungenlied</hi> is associated with the
-       new rise of romance of twelfth-century France, the <hi rend="it">romans d'antiquité</hi>, the
-       romances of Chrétien de Troyes, and the German adaptations of these works by Heinrich van
-       Veldeke, Hartmann von Aue, and Wolfram von Eschenbach.</q> Interpreting the role of the
-      highlighting, the sentence might look like this: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><p>On the one hand the <title>Nibelungenlied</title>
-        is associated with the new rise of romance of twelfth-century France, the <foreign>romans
-         d'antiquité</foreign>, the romances of Chrétien de Troyes, ...</p></egXML> Describing only
-      the appearance of the original, it might look like this: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><p>On the one hand the <hi rend="italic"
-         >Nibelungenlied</hi> is associated with the new rise of romance of twelfth-century France,
-        the <hi rend="italic">romans d'antiquité</hi>, the romances of Chrétien de Troyes,
-       ...</p></egXML></p>
+      <p>As an example of the elements defined here, consider the following sentence: <q rend="display">On the one hand the <hi rend="it">Nibelungenlied</hi> is associated with the
+      new rise of romance of twelfth-century France, the <hi rend="it">romans d'antiquité</hi>, the
+      romances of Chrétien de Troyes, and the German adaptations of these works by Heinrich van
+      Veldeke, Hartmann von Aue, and Wolfram von Eschenbach.</q> Interpreting the role of the
+      highlighting, the sentence might look like this: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <p>On the one hand the <title>Nibelungenlied</title>
+      is associated with the new rise of romance of twelfth-century France, the <foreign>romans
+      d'antiquité</foreign>, the romances of Chrétien de Troyes, ...</p>
+      </egXML> Describing only
+      the appearance of the original, it might look like this: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <p>On the one hand the <hi rend="italic">Nibelungenlied</hi> is associated with the new rise of romance of twelfth-century France,
+      the <hi rend="italic">romans d'antiquité</hi>, the romances of Chrétien de Troyes,
+      ...</p>
+    </egXML>
+      </p>
     </div>
     <div xml:id="z635">
-     <head>Quotations and Related Features</head>
-     <p>Like changes of typeface, quotation marks are conventionally used to denote several
+      <head>Quotations and Related Features</head>
+      <p>Like changes of typeface, quotation marks are conventionally used to denote several
       different features within a text, of which the most frequent is quotation. When possible, we
       recommend that the underlying feature be tagged, rather than the simple fact that quotation
       marks appear in the text, using the following elements: <specList>
-       <specDesc key="q"/>
-       <!--specDesc key="quote"/-->
-       <!--specDesc key="said"/-->
-       <specDesc key="mentioned"/>
-       <specDesc key="soCalled"/>
-       <specDesc key="gloss"/>
-      </specList>
-     </p>
-     <p>Here is a simple example of a quotation: <egXML xmlns="http://www.tei-c.org/ns/Examples"
-        ><p>Few dictionary makers are likely to forget Dr. Johnson's description of the
-        lexicographer as <q>a harmless drudge.</q></p></egXML>
-     </p>
-     <p>To record how a quotation was printed (for example, <term>in-line</term> or set off as a
-       <term>display</term> or <term>block quotation</term>), the <att>rend</att> attribute should
+      <specDesc key="q"/>
+      <!--specDesc key="quote"/-->
+      <!--specDesc key="said"/-->
+      <specDesc key="mentioned"/>
+      <specDesc key="soCalled"/>
+      <specDesc key="gloss"/>
+    </specList>
+      </p>
+      <p>Here is a simple example of a quotation: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <p>Few dictionary makers are likely to forget Dr. Johnson's description of the
+      lexicographer as <q>a harmless drudge.</q>
+      </p>
+    </egXML>
+      </p>
+      <p>To record how a quotation was printed (for example, <term>in-line</term> or set off as a
+      <term>display</term> or <term>block quotation</term>), the <att>rend</att> attribute should
       be used. This may also be used to indicate the kind of quotation marks used.</p>
-     <p>Direct speech interrupted by a narrator can be represented simply by ending the quotation
-      and beginning it again after the interruption, as in the following example: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><p><q>Who-e debel you?</q> — he at last said —
-         <q>you no speak-e, damme, I kill-e.</q> And so saying, the lighted tomahawk began
-        flourishing about me in the dark.</p></egXML> If it is important to convey the idea that the
+      <p>Direct speech interrupted by a narrator can be represented simply by ending the quotation
+      and beginning it again after the interruption, as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <p>
+	<q>Who-e debel you?</q> — he at last said —
+	<q>you no speak-e, damme, I kill-e.</q> And so saying, the lighted tomahawk began
+      flourishing about me in the dark.</p>
+      </egXML> If it is important to convey the idea that the
       two <gi>q</gi> elements together make up a single speech, the linking attributes
-       <att>next</att> and <att>prev</att> may be used, as described in section <ptr target="#xatts"
-      />.</p>
-     <p>Quotations may be accompanied by a reference to the source or speaker, using the
-       <att>who</att> attribute, whether or not this is explicit in the text, as in the following
-      example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><q who="#Wilson">Spaulding, he came
-        down into the office just this day eight weeks with this very paper in his hand, and he
-         says:—<q who="#Spaulding">I wish to the Lord, Mr. Wilson, that I was a red-headed
-        man.</q></q></egXML> This example also demonstrates how quotations may be embedded within
+      <att>next</att> and <att>prev</att> may be used, as described in section <ptr target="#xatts"/>.</p>
+      <p>Quotations may be accompanied by a reference to the source or speaker, using the
+      <att>who</att> attribute, whether or not this is explicit in the text, as in the following
+      example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <q who="#Wilson">Spaulding, he came
+      down into the office just this day eight weeks with this very paper in his hand, and he
+      says:—<q who="#Spaulding">I wish to the Lord, Mr. Wilson, that I was a red-headed
+      man.</q>
+      </q>
+      </egXML> This example also demonstrates how quotations may be embedded within
       other quotations: one speaker (Wilson) quotes another speaker (Spaulding).</p>
-     <p>The creator of the electronic text must decide whether quotation marks are replaced by the
+      <p>The creator of the electronic text must decide whether quotation marks are replaced by the
       tags or whether the tags are added and the quotation marks kept. If the quotation marks are
       removed from the text, the <att>rend</att> attribute may be used to record the way in which
       they were rendered in the copy text.</p>
-     <p>The full TEI Guidelines provide additional elements to distinguish direct speech,
+      <p>The full TEI Guidelines provide additional elements to distinguish direct speech,
       quotation, and other typical uses of quotation mark although it is not always possible and may
       not be considered desirable to interpret the function of quotation marks in a text. For
       simplicity, only <gi>q</gi> (which may be used for any such case) has been included in TEI
       Lite. </p>
     </div>
     <div xml:id="z636">
-     <head>Foreign Words or Expressions</head>
-     <p>Words or phrases which are not in the main language of the texts may be tagged as such in
+      <head>Foreign Words or Expressions</head>
+      <p>Words or phrases which are not in the main language of the texts may be tagged as such in
       one of two ways. If the word or phrase is already tagged for some reason, the element
       indicated should bear a value for the global <att>xml:lang</att> attribute indicating the
       language used. Where there is no applicable element, the element <gi>foreign</gi> may be used,
-      again using the <att>xml:lang</att> attribute. For example: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><p>John has real <foreign xml:lang="fr"
-         >savoir-faire</foreign>.</p><p>Have you read <title xml:lang="de">Die
-         Dreigroschenoper</title>?</p><p><mentioned xml:lang="fr">Savoir-faire</mentioned> is French
-        for know-how.</p><p>The court issued a writ of <term xml:lang="la"
-       >mandamus</term>.</p></egXML></p>
-     <p>As these examples show, the <gi>foreign</gi> element should not be used to tag foreign words
+      again using the <att>xml:lang</att> attribute. For example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <p>John has real <foreign xml:lang="fr">savoir-faire</foreign>.</p>
+      <p>Have you read <title xml:lang="de">Die
+      Dreigroschenoper</title>?</p>
+      <p>
+	<mentioned xml:lang="fr">Savoir-faire</mentioned> is French
+      for know-how.</p>
+      <p>The court issued a writ of <term xml:lang="la">mandamus</term>.</p>
+    </egXML>
+      </p>
+      <p>As these examples show, the <gi>foreign</gi> element should not be used to tag foreign words
       if some other more specific element such as <gi>title</gi>, <gi>mentioned</gi>, or
-       <gi>term</gi> applies. The global <att>xml:lang</att> attribute may be attached to any
+      <gi>term</gi> applies. The global <att>xml:lang</att> attribute may be attached to any
       element to show that it uses some other language than that of the surrounding text.</p>
-     <p>The codes used to identify languages, supplied on the <att>xml:lang</att> attribute, must be
-      constructed in a particular way, and must conform to common Internet standards<note
-       place="foot">The relevant standard is <title>Best Current Practice 47</title> (<ptr
-        target="http://tools.ietf.org/html/bcp47"/>). The authoritative list of registered subtags
-       is maintained by IANA and is available at <ptr
-        target="http://www.iana.org/assignments/language-subtag-registry"/>. For a general overview
-       of the construction of language tags, see <ptr
-        target="http://www.w3.org/International/articles/language-tags/"/>, and for a practical
-       step-by-step guide, see <ptr
-        target="http://www.w3.org/International/questions/qa-choosing-language-tags"/>.</note>, as
+      <p>The codes used to identify languages, supplied on the <att>xml:lang</att> attribute, must be
+      constructed in a particular way, and must conform to common Internet standards<note place="foot">The relevant standard is <title>Best Current Practice 47</title> (<ptr target="http://tools.ietf.org/html/bcp47"/>). The authoritative list of registered subtags
+      is maintained by IANA and is available at <ptr target="http://www.iana.org/assignments/language-subtag-registry"/>. For a general overview
+      of the construction of language tags, see <ptr target="http://www.w3.org/International/articles/language-tags/"/>, and for a practical
+      step-by-step guide, see <ptr target="http://www.w3.org/International/questions/qa-choosing-language-tags"/>.</note>, as
       further explained in the relevant section of the TEI Guidelines. Some simple example codes for
       a few languages are given here: <table>
-       <row>
-        <cell>zh</cell>
-        <cell>Chinese</cell>
-        <cell>grc</cell>
-        <cell>Ancient Greek</cell>
-       </row>
-       <row>
-        <cell>en</cell>
-        <cell>English</cell>
-        <cell>el</cell>
-        <cell>Greek</cell>
-       </row>
-       <row>
-        <cell>enm</cell>
-        <cell>Middle English</cell>
-        <cell>ja</cell>
-        <cell>Japanese</cell>
-       </row>
-       <row>
-        <cell>fr</cell>
-        <cell>French</cell>
-        <cell>la</cell>
-        <cell>Latin</cell>
-       </row>
-       <row>
-        <cell>de</cell>
-        <cell>German</cell>
-        <cell>sa</cell>
-        <cell>Sanskrit</cell>
-       </row>
-      </table>
-     </p>
+      <row>
+	<cell>zh</cell>
+	<cell>Chinese</cell>
+	<cell>grc</cell>
+	<cell>Ancient Greek</cell>
+      </row>
+      <row>
+	<cell>en</cell>
+	<cell>English</cell>
+	<cell>el</cell>
+	<cell>Greek</cell>
+      </row>
+      <row>
+	<cell>enm</cell>
+	<cell>Middle English</cell>
+	<cell>ja</cell>
+	<cell>Japanese</cell>
+      </row>
+      <row>
+	<cell>fr</cell>
+	<cell>French</cell>
+	<cell>la</cell>
+	<cell>Latin</cell>
+      </row>
+      <row>
+	<cell>de</cell>
+	<cell>German</cell>
+	<cell>sa</cell>
+	<cell>Sanskrit</cell>
+      </row>
+    </table>
+      </p>
     </div>
-   </div>
-   <div xml:id="U5-notes">
+  </div>
+  <div xml:id="U5-notes">
     <head>Notes</head>
     <p>All notes, whether printed as footnotes, endnotes, marginalia, or elsewhere, should be marked
-     using the same element: <specList>
-      <specDesc key="note"/>
-     </specList> Where possible, the body of a note should be inserted in the text at the point at
-     which its identifier or mark first appears. This may not be possible for example with
-     marginalia, which may not be anchored to an exact location. For simplicity, it may be adequate
-     to position marginal notes before the relevant paragraph or other element. Notes may also be
-     placed in a separate division of the text (as end-notes are, in printed books) and linked to
-     the relevant portion of the text using their <att>target</att> attribute.</p>
+    using the same element: <specList>
+    <specDesc key="note"/>
+    </specList> Where possible, the body of a note should be inserted in the text at the point at
+    which its identifier or mark first appears. This may not be possible for example with
+    marginalia, which may not be anchored to an exact location. For simplicity, it may be adequate
+    to position marginal notes before the relevant paragraph or other element. Notes may also be
+    placed in a separate division of the text (as end-notes are, in printed books) and linked to
+    the relevant portion of the text using their <att>target</att> attribute.</p>
     <p>The <att>n</att> attribute may be used to supply the number or identifier of a note if this
-     is required. The <att>resp</att> attribute should be used consistently to distinguish between
-     authorial and editorial notes, if the work has both kinds.</p>
-    <p>Examples: <egXML xmlns="http://www.tei-c.org/ns/Examples"><p>Collections are ensembles of
-       distinct entities or objects of any sort. <note place="foot" n="1"> We explain below why we
-        use the uncommon term <mentioned>collection</mentioned> instead of the expected
-         <mentioned>set</mentioned>. Our usage corresponds to the <mentioned>aggregate</mentioned>
-        of many mathematical writings and to the sense of <mentioned>class</mentioned> found in
-        older logical writings. </note> The elements ...</p></egXML>
-     <egXML xmlns="http://www.tei-c.org/ns/Examples"><lg xml:id="RAM609"><note place="margin">The
-        curse is finally expiated</note><l>And now this spell was snapt: once more</l><l>I viewed
-        the ocean green,</l><l>And looked far forth, yet little saw</l><l>Of what had else been seen
-        —</l></lg></egXML></p>
-   </div>
-   <div xml:id="U5-ptrs">
+    is required. The <att>resp</att> attribute should be used consistently to distinguish between
+    authorial and editorial notes, if the work has both kinds.</p>
+    <p>Examples: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+    <p>Collections are ensembles of
+    distinct entities or objects of any sort. <note place="foot" n="1"> We explain below why we
+    use the uncommon term <mentioned>collection</mentioned> instead of the expected
+    <mentioned>set</mentioned>. Our usage corresponds to the <mentioned>aggregate</mentioned>
+    of many mathematical writings and to the sense of <mentioned>class</mentioned> found in
+    older logical writings. </note> The elements ...</p>
+  </egXML>
+  <egXML xmlns="http://www.tei-c.org/ns/Examples">
+    <lg xml:id="RAM609">
+      <note place="margin">The
+      curse is finally expiated</note>
+      <l>And now this spell was snapt: once more</l>
+      <l>I viewed
+      the ocean green,</l>
+      <l>And looked far forth, yet little saw</l>
+      <l>Of what had else been seen
+      —</l>
+    </lg>
+  </egXML>
+    </p>
+  </div>
+  <div xml:id="U5-ptrs">
     <head>Cross References and Links</head>
     <p>Explicit cross references or links from one point in a text to another in the same or another
-     document may be encoded using the elements described in this section. Implicit links (such as
-     the association between two parallel texts, or that between a text and its interpretation) may
-     be encoded using the linking attributes discussed in section <ptr target="#xatts"/>.</p>
+    document may be encoded using the elements described in this section. Implicit links (such as
+    the association between two parallel texts, or that between a text and its interpretation) may
+    be encoded using the linking attributes discussed in section <ptr target="#xatts"/>.</p>
     <div xml:id="ptrs">
-     <head>Simple Cross References</head>
-     <p>A cross reference from one point within a single document to another can be encoded using
+      <head>Simple Cross References</head>
+      <p>A cross reference from one point within a single document to another can be encoded using
       either of the following elements: <specList>
-       <specDesc key="ref"/>
-       <specDesc key="ptr"/>
-      </specList>
-     </p>
-     <p>The difference between these two elements is that <gi>ptr</gi> is an empty element, simply
+      <specDesc key="ref"/>
+      <specDesc key="ptr"/>
+    </specList>
+      </p>
+      <p>The difference between these two elements is that <gi>ptr</gi> is an empty element, simply
       marking a point from which a link is to be made, whereas <gi>ref</gi> may contain some text as
       well, typically identifying the target of the cross reference. The <gi>ptr</gi> element would
       be used for a cross reference which is to be indicated by some non-verbal means such as a
       symbol or icon, or in an electronic text by a button. It is also useful in document production
       systems, where the formatter can generate the correct verbal form of the cross reference.</p>
-     <p>The following two forms, for example, are logically equivalent : <egXML
-       xmlns="http://www.tei-c.org/ns/Examples">See especially <ref target="#SEC12">section 12 on
-        page 34</ref>.</egXML>
+      <p>The following two forms, for example, are logically equivalent : <egXML xmlns="http://www.tei-c.org/ns/Examples">See especially <ref target="#SEC12">section 12 on
+      page 34</ref>.</egXML>
       <egXML xmlns="http://www.tei-c.org/ns/Examples">See especially <ptr target="#SEC12"/>.</egXML>
       The value of the <att>target</att> attribute on either element may be the identifier of some
       other element within the current document. The passage or phrase being pointed at must bear an
       identifier, and must therefore be tagged as an element of some kind. In the following example,
-      the cross reference is to a <gi>div</gi> element: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"> ... see especially <ptr target="#SEC12"/>. ... <div
-        xml:id="SEC12">
-        <head>Concerning Identifiers</head>
-        <!-- ... -->
-       </div></egXML>
-     </p>
-     <p>Because the <att>xml:id</att> attribute is global, any element in a TEI document may be
+      the cross reference is to a <gi>div</gi> element: <egXML xmlns="http://www.tei-c.org/ns/Examples"> ... see especially <ptr target="#SEC12"/>. ... <div xml:id="SEC12">
+      <head>Concerning Identifiers</head>
+      <!-- ... -->
+    </div>
+  </egXML>
+      </p>
+      <p>Because the <att>xml:id</att> attribute is global, any element in a TEI document may be
       pointed to in this way. In the following example, a paragraph has been given an identifier so
       that it may be pointed at: <egXML xmlns="http://www.tei-c.org/ns/Examples"> ... this is
-       discussed in <ref target="#pspec">the paragraph on links</ref> ... <p xml:id="pspec">Links
-        may be made to any kind of element ...</p></egXML></p>
-     <p>Sometimes the target of a cross reference does not correspond with any particular feature of
+      discussed in <ref target="#pspec">the paragraph on links</ref> ... <p xml:id="pspec">Links
+      may be made to any kind of element ...</p>
+    </egXML>
+      </p>
+      <p>Sometimes the target of a cross reference does not correspond with any particular feature of
       a text, and so may not be tagged as an element of some kind. If the desired target is simply a
       point in the current document, the easiest way to mark it is by introducing an <gi>anchor</gi>
       element at the appropriate spot. If the target is some sequence of words not otherwise tagged,
       the <gi>seg</gi> element may be introduced to mark them. These two elements are described as
       follows: <specList>
-       <specDesc key="anchor"/>
-       <specDesc key="seg"/>
-      </specList>
-     </p>
-     <p>In the following (imaginary) example, <gi>ref</gi> elements have been used to represent
+      <specDesc key="anchor"/>
+      <specDesc key="seg"/>
+    </specList>
+      </p>
+      <p>In the following (imaginary) example, <gi>ref</gi> elements have been used to represent
       points in this text which are to be linked in some way to other parts of it; in the first case
-      to a point, and in the second, to a sequence of words: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"> Returning to <ref target="#ABCD">the point where I
-        dozed off</ref>, I noticed that <ref target="#EFGH">three words</ref> had been circled in
-       red by a previous reader</egXML></p>
-     <p>This encoding requires that elements with the specified identifiers (<code>ABCD</code> and
-       <code>EFGH</code> in this example) are to be found somewhere else in the current document.
+      to a point, and in the second, to a sequence of words:
+      <egXML xmlns="http://www.tei-c.org/ns/Examples"> Returning to <ref target="#ABCD">the point where I
+      dozed off</ref>, I noticed that <ref target="#EFGH">three words</ref> had been circled in
+      red by a previous reader</egXML></p>
+      <p>This encoding requires that elements with the specified identifiers (<code>ABCD</code> and
+      <code>EFGH</code> in this example) are to be found somewhere else in the current document.
       Assuming that no element already exists to carry these identifiers, the <gi>anchor</gi> and
-       <gi>seg</gi> elements may be used: <egXML xmlns="http://www.tei-c.org/ns/Examples"> ....
-        <anchor type="bookmark" xml:id="ABCD"/> .... ....<seg type="target" xml:id="EFGH"> ...
-       </seg> ...</egXML></p>
-     <p>The <att>type</att> attribute should be used (as above) to distinguish amongst different
+      <gi>seg</gi> elements may be used: <egXML xmlns="http://www.tei-c.org/ns/Examples"> ....
+      <anchor type="bookmark" xml:id="ABCD"/> .... ....<seg type="target" xml:id="EFGH"> ...
+      </seg> ...</egXML>
+      </p>
+      <p>The <att>type</att> attribute should be used (as above) to distinguish amongst different
       purposes for which these general purpose elements might be used in a text. Some other uses are
       discussed in section <ptr target="#xatts"/> below.</p>
     </div>
     <div xml:id="xptrs">
-     <head>Pointing to other documents</head>
-     <p>So far, we have shown how the elements <gi>ptr</gi> and <gi>ref</gi> may be used for
+      <head>Pointing to other documents</head>
+      <p>So far, we have shown how the elements <gi>ptr</gi> and <gi>ref</gi> may be used for
       cross-references or links whose targets occur within the same document as their source.
       However, the same elements may also be used to refer to elements in any other XML document or
       resource, such as a document on the web, or a database component. This is possible because the
       value of the <att>target</att> attribute may be any valid <term>universal resource
-       indicator</term> (URI)<note>A full definition of this term, defined by the W3C (the
-       consortium which manages the development and maintenance of the World Wide Web), is beyond
-       the scope of this tutorial: however, the most frequently encountered version of a URI is the
-       familiar <soCalled>URL</soCalled> used to indicate a web page, such as
-        <code>http://www.tei-c.org/index.xml</code></note>. </p>
-     <p>A URI may reference a web page or just a part of one, for example
-       <code>http://www.tei-c.org/index.xml#SEC2</code>. The sharp sign indicates that what follows
+      indicator</term> (URI)<note>A full definition of this term, defined by the W3C (the
+      consortium which manages the development and maintenance of the World Wide Web), is beyond
+      the scope of this tutorial: however, the most frequently encountered version of a URI is the
+      familiar <soCalled>URL</soCalled> used to indicate a web page, such as
+      <code>http://www.tei-c.org/index.xml</code>
+      </note>. </p>
+      <p>A URI may reference a web page or just a part of one, for example
+      <code>http://www.tei-c.org/index.xml#SEC2</code>. The sharp sign indicates that what follows
       it is the identifier of an element to be located within the XML document identified by what
       precedes it: this example will therefore locate an element which has an <att>xml:id</att>
       attribute value of <val>SEC2</val> within the document retrieved from
-       <code>http://www.tei-c.org/index.xml</code>. In the examples we have discussed so far, the
+      <code>http://www.tei-c.org/index.xml</code>. In the examples we have discussed so far, the
       part to the left of the sharp sign has been omitted: this is understood to mean that the
       referenced element is to be located within the current document.</p>
-     <p>Parts of an XML document can be specified by means of other more sophisticated mechanisms
+      <p>Parts of an XML document can be specified by means of other more sophisticated mechanisms
       using a special language called Xpath, also defined by the W3C. This is particularly useful
       where the elements to be linked to do not bear identifiers and must therefore be located by
       some other means.
       <!--A full specification of the language is well beyond
-      the scope of this document; here we provide only a flavour of its power. </p>
-     <p>In the XPath language, locations are defined as a series of <term>steps</term>, each one
-      identifying some part of the document, often in terms of the locations identified by the
-      previous step. For example, you would point to the third sentence of the second paragraph of
-      chapter two by selecting chapter two in the first step, the second paragraph in the second
-      step, and the third sentence in the last step. A step can be defined in terms of the document
-      tree itself, using such concepts as <val>parent</val>, <val>descendent</val>,
-       <val>preceding</val>, etc. or, more loosely, in terms of text patterns, word or character
-      positions. --></p>
+	  the scope of this document; here we provide only a flavour of its power. </p>
+	  <p>In the XPath language, locations are defined as a series of <term>steps</term>, each one
+	  identifying some part of the document, often in terms of the locations identified by the
+	  previous step. For example, you would point to the third sentence of the second paragraph of
+	  chapter two by selecting chapter two in the first step, the second paragraph in the second
+	  step, and the third sentence in the last step. A step can be defined in terms of the document
+	  tree itself, using such concepts as <val>parent</val>, <val>descendent</val>,
+	  <val>preceding</val>, etc. or, more loosely, in terms of text patterns, word or character
+	  positions. --></p>
     </div>
     <div xml:id="xatts">
-     <head>Special kinds of Linking</head>
-     <p>The following special purpose <term>linking</term> attributes are defined for every element
+      <head>Special kinds of Linking</head>
+      <p>The following special purpose <term>linking</term> attributes are defined for every element
       in the TEI Lite scheme: <list type="gloss">
-       <label><att>ana</att></label>
-       <item>links an element with its interpretation.</item>
-       <label><att>corresp</att></label>
-       <item>links an element with one or more other corresponding elements.</item>
-       <label><att>next</att></label>
-       <item>links an element to the next element in an aggregate.</item>
-       <label><att>prev</att></label>
-       <item>links an element to the previous element in an aggregate.</item>
-      </list></p>
-     <p>The <att>ana</att> (analysis) attribute is intended for use where a set of abstract analyses
+      <label>
+	<att>ana</att>
+      </label>
+      <item>links an element with its interpretation.</item>
+      <label>
+	<att>corresp</att>
+      </label>
+      <item>links an element with one or more other corresponding elements.</item>
+      <label>
+	<att>next</att>
+      </label>
+      <item>links an element to the next element in an aggregate.</item>
+      <label>
+	<att>prev</att>
+      </label>
+      <item>links an element to the previous element in an aggregate.</item>
+    </list>
+      </p>
+      <p>The <att>ana</att> (analysis) attribute is intended for use where a set of abstract analyses
       or interpretations have been defined somewhere within a document, as further discussed in
       section <ptr target="#U5-anal"/>. For example, a linguistic analysis of the sentence <q>John
-       loves Nancy</q> might be encoded as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples"
-        ><seg type="sentence" ana="SVO"><seg type="lex" ana="#NP1">John</seg><seg type="lex"
-         ana="#VVI">loves</seg><seg type="lex" ana="#NP1">Nancy</seg></seg></egXML> This encoding
+      loves Nancy</q> might be encoded as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <seg type="sentence" ana="SVO">
+	<seg type="lex" ana="#NP1">John</seg>
+	<seg type="lex" ana="#VVI">loves</seg>
+	<seg type="lex" ana="#NP1">Nancy</seg>
+      </seg>
+      </egXML> This encoding
       implies the existence elsewhere in the document of elements with identifiers <val>SVO</val>,
-       <val>NP1</val>, and <val>VV1</val> where the significance of these particular codes is
+      <val>NP1</val>, and <val>VV1</val> where the significance of these particular codes is
       explained. Note the use of the <gi>seg</gi> element to mark particular components of the
       analysis, distinguished by the <att>type</att> attribute.</p>
-     <p>The <att>corresp</att> (corresponding) attribute provides a simple way of representing some
+      <p>The <att>corresp</att> (corresponding) attribute provides a simple way of representing some
       form of correspondence between two elements in a text. For example, in a multilingual text, it
-      may be used to link translation equivalents, as in the following example <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><seg xml:lang="fr" xml:id="FR1" corresp="#EN1">Jean
-        aime Nancy</seg><seg xml:lang="en" xml:id="EN1" corresp="#FR1">John loves
-       Nancy</seg></egXML></p>
-     <p>The same mechanism may be used for a variety of purposes. In the following example, it has
+      may be used to link translation equivalents, as in the following example <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <seg xml:lang="fr" xml:id="FR1" corresp="#EN1">Jean
+      aime Nancy</seg>
+      <seg xml:lang="en" xml:id="EN1" corresp="#FR1">John loves
+      Nancy</seg>
+    </egXML>
+      </p>
+      <p>The same mechanism may be used for a variety of purposes. In the following example, it has
       been used to represent the correspondences between <q rend="inline" type="inline">the
-       show</q> and <q>Shirley</q>, and between <q>NBC</q> and <q>the network</q>: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><p><title xml:id="shirley">Shirley</title>, which
-        made its Friday night debut only a month ago, was not listed on <name xml:id="nbc"
-         >NBC</name>'s new schedule, although <seg xml:id="network" corresp="#nbc">the network</seg>
-        says <seg xml:id="show" corresp="#shirley">the show</seg> still is being
-       considered.</p></egXML></p>
-     <p>The <att>next</att> and <att>prev</att> attributes provide a simple way of linking together
-      the components of a discontinuous element, as in the following example: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><q xml:id="Q1a" next="#Q1b">Who-e debel you?</q> —
-       he at last said — <q xml:id="Q1b" prev="#Q1a">you no speak-e, damme, I kill-e.</q> And so
-       saying, the lighted tomahawk began flourishing about me in the dark.</egXML></p>
+      show</q> and <q>Shirley</q>, and between <q>NBC</q> and <q>the network</q>: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <p>
+	<title xml:id="shirley">Shirley</title>, which
+	made its Friday night debut only a month ago, was not listed on <name xml:id="nbc">NBC</name>'s new schedule, although <seg xml:id="network" corresp="#nbc">the network</seg>
+	says <seg xml:id="show" corresp="#shirley">the show</seg> still is being
+      considered.</p>
+    </egXML>
+      </p>
+      <p>The <att>next</att> and <att>prev</att> attributes provide a simple way of linking together
+      the components of a discontinuous element, as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <q xml:id="Q1a" next="#Q1b">Who-e debel you?</q> —
+      he at last said — <q xml:id="Q1b" prev="#Q1a">you no speak-e, damme, I kill-e.</q> And so
+      saying, the lighted tomahawk began flourishing about me in the dark.</egXML></p>
     </div>
-   </div>
-   <div xml:id="U5-edit1">
-    <head>Editorial Interventions</head>
-    <p>The process of encoding an electronic text has much in common with the process of editing a
-     manuscript or other text for printed publication. In either case a conscientious editor may
-     wish to record both the original state of the source and any editorial correction or other
-     change made in it. The elements discussed in this and the next section provide some facilities
-     for meeting these needs.</p>
-    <div>
-     <head>Correction and Normalization</head>
-     <p>The following elements may be used to mark <term>correction</term>, that is editorial
-      changes introduced where the editor believes the original to be erroneous: <specList>
-       <specDesc key="corr"/>
-       <specDesc key="sic"/>
+      </div>
+      <div xml:id="U5-edit1">
+	<head>Editorial Interventions</head>
+	<p>The process of encoding an electronic text has much in common with the process of editing a
+	manuscript or other text for printed publication. In either case a conscientious editor may
+	wish to record both the original state of the source and any editorial correction or other
+	change made in it. The elements discussed in this and the next section provide some facilities
+	for meeting these needs.</p>
+	<div>
+	  <head>Correction and Normalization</head>
+	  <p>The following elements may be used to mark <term>correction</term>, that is editorial
+	  changes introduced where the editor believes the original to be erroneous: <specList>
+	  <specDesc key="corr"/>
+	  <specDesc key="sic"/>
+	</specList>
+	  </p>
+	  <p>The following elements may be used to mark <term>normalization</term>, that is editorial
+	  changes introduced for the sake of consistency or modernization of a text: <specList>
+	  <specDesc key="orig"/>
+	  <specDesc key="reg"/>
+	</specList>
+	  </p>
+	  <p>As an example, consider this extract from the quarto printing of Shakespeare's <title>Henry
+	  V</title>. <eg> ... for his nose was as sharp as a pen and a table of green feelds</eg>
+	  </p>
+	  <p>A modern editor might wish to make a number of interventions here, specifically to modernize
+	  (or normalise) the Elizabethan spellings of <mentioned>a'</mentioned> and
+	  <mentioned>feelds</mentioned> for <mentioned>he</mentioned> and <mentioned>fields</mentioned>
+	  respectively. He or she might also want to emend <mentioned>table</mentioned> to
+	  <mentioned>babbl'd</mentioned>, following an editorial tradition that goes back to the 18th
+	  century Shakespearian scholar Lewis Theobald. The following encoding would then be
+	  appropriate: <egXML xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as
+	  a pen and <reg>he</reg>
+	  <corr resp="#Theobald">babbl'd</corr> of green <reg>fields</reg>
+	</egXML>
+	  </p>
+	  <p>A more conservative or source-oriented editor, however, might want to retain the original,
+	  but at the same time signal that some of the readings it contains are in some sense anomalous:
+	  <egXML xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as a pen and
+	  <orig>a</orig>
+	  <sic>table</sic> of green <orig>feelds</orig>
+	  </egXML>
+	  </p>
+	  <p>Finally, a modern digital editor may decide to combine both possibilities in a single
+	  composite text, using the <gi>choice</gi> element. <specList>
+	  <specDesc key="choice"/>
+	  </specList> This allows an editor to mark where alternative readings are possible: <egXML xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as a pen and
+	  <choice>
+	    <orig>a</orig>
+	    <reg>he</reg>
+	  </choice>
+	  <choice>
+	    <corr resp="#Theobald">babbl'd</corr>
+	    <sic>table</sic>
+	    </choice> of green
+	    <choice>
+	      <orig>feelds</orig>
+	      <reg>fields</reg>
+	    </choice>
+	  </egXML>
+	  </p>
+	</div>
+	<div xml:id="U5-edit2">
+	  <head>Omissions, Deletions, and Additions</head>
+	  <p>In addition to correcting or normalizing words and phrases, editors and transcribers may
+	  also supply missing material, omit material, or transcribe material deleted or crossed out in
+	  the source. In addition, some material may be particularly hard to transcribe because it is
+	  hard to make out on the page. The following elements may be used to record such phenomena: <specList>
+	  <specDesc key="add"/>
+	  <specDesc key="gap"/>
+	  <specDesc key="del"/>
+	  <specDesc key="unclear"/>
+	</specList>
+	  </p>
+	  <p>These elements may be used to record changes made by an editor, by the transcriber, or (in
+	  manuscript material) by the author or scribe. For example, if the source for an electronic
+	  text read <q>The following elements are provided for for simple editorial interventions.</q>
+	  then it might be felt desirable to correct the obvious error, but at the same time to record
+	  the deletion of the superfluous second <mentioned>for</mentioned>, thus: <egXML xmlns="http://www.tei-c.org/ns/Examples">The following elements are provided for <del resp="#LB">for</del> simple editorial interventions.</egXML> The attribute value
+	  <code>#LB</code> on the <att>resp</att> attribute is used to point to a fuller definition
+	  (typically in a <gi>respStmt</gi> element) for the agency responsible for correcting the
+	  duplication of <mentioned>for</mentioned>.</p>
+	  <p>If the source read <q>The following elements provided for simple editorial
+	  interventions.</q> (i.e. if the verb had been inadvertently dropped) then the corrected text
+	  might read: <egXML xmlns="http://www.tei-c.org/ns/Examples">The following elements <add resp="#LB">are</add> provided for simple editorial interventions.</egXML>
+	  </p>
+	  <p>These elements are also used to record
+	  authorial changes in manuscripts. A manuscript in which the author has first written <q>How it
+	  galls me, what a galling shadow</q>, then crossed out the word <mentioned>galls</mentioned>
+	  and inserted <mentioned>dogs</mentioned> might be encoded thus: <egXML xmlns="http://www.tei-c.org/ns/Examples">How it <del hand="#DHL" type="overstrike">galls</del>
+	  <add hand="#DHL" place="supralinear">dogs</add> me, what a galling shadow</egXML> Again, the
+	  code <code>#DHL</code> points to another location where more information about the hand
+	  concerned is to be found<note place="foot">The full TEI provides a range of elements for
+	  encoding metadata about manuscript production and description, which are not however included
+	  in TEI Lite</note>. </p>
+	  <p>Similarly, the <gi>unclear</gi> and <gi>gap</gi> elements may be used together to indicate
+	  the omission of illegible material; the following example also shows the use of <gi>add</gi>
+	  for a conjectural emendation: <egXML xmlns="http://www.tei-c.org/ns/Examples">One hundred
+	  &amp; twenty good regulars joined to me <unclear>
+	  <gap reason="indecipherable"/>
+	</unclear>
+	&amp; instantly, would aid me signally <add hand="#ed">in?</add> an enterprise against
+	Wilmington.</egXML>
+	  </p>
+	  <p>The <gi>del</gi> element marks material which has been transcribed as part of the electronic text
+	  despite being marked as deleted, while <gi>gap</gi> marks the location of material which is
+	  omitted from the electronic text, whether it is legible or not. A language corpus, for
+	  example, might omit long quotations in foreign languages: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <p> ... An example of a list appearing in a fief
+	  ledger of <name type="place">Koldinghus</name>
+	  <date>1611/12</date> is given below. It shows cash income from a sale of
+	  honey.</p>
+	  <gap>
+	    <desc>quotation from ledger (in Danish)</desc>
+	  </gap>
+	  <p>A description of the
+	  overall structure of the account is once again ... </p>
+	</egXML>
+	  </p>
+	  <p>Other corpora (particular those constructed before the widespread use of scanners)
+	  systematically omit figures and mathematics: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <p>At the bottom of your screen below the mode line is the <term>minibuffer</term>. This is
+	  the area where Emacs echoes the commands you enter and where you specify filenames for Emacs
+	  to find, values for search and replace, and so on. <gap reason="graphic">
+	  <desc>diagram of
+	  Emacs screen</desc>
+	</gap>
+	  </p>
+	</egXML>
+	  </p>
+	  <p>The full TEI scheme provides more precise ways of capturing
+	  different aspects of  a transcription, distinguishing for example
+	  between text added or supplied by the encoder and text indicated as
+	  supplied or deleted in the source. TEI Lite does not provide different
+	  tags for these purposes.</p>
+	</div>
+	<div>
+	  <head>Abbreviations and their Expansion</head>
+	  <p>Like names, dates, and numbers, abbreviations may be transcribed as they stand or expanded;
+	  they may be left unmarked, or encoded using the following elements: <specList>
+	  <specDesc key="abbr"/>
+	  <specDesc key="expan"/>
+	</specList>
+	  </p>
+	  <p>The <gi>abbr</gi> element is useful as a means of distinguishing semi-lexical items such as
+	  acronyms or jargon: <egXML xmlns="http://www.tei-c.org/ns/Examples">We can sum up the above
+	  discussion as follows: the identity of a <abbr>CC</abbr> is defined by that calibration of
+	  values which motivates the elements of its <abbr>GSP</abbr>;</egXML>
+	  <egXML xmlns="http://www.tei-c.org/ns/Examples">Every manufacturer of <abbr>3GL</abbr> or
+	  <abbr>4GL</abbr> languages is currently nailing on <abbr>OOP</abbr> extensions</egXML>
+	  </p>
+	  <p>The <att>type</att> attribute may be used to distinguish types of abbreviation by their
+	  function. </p>
+	  <p>The <gi>expan</gi> element is used to mark an expansion supplied by an encoder. This element
+	  is particularly useful in the transcription of manuscript materials. For example, the
+	  character p with a bar through its descender as a conventional representation for the word
+	  <val>per</val> is commonly encountered in Medieval European manuscripts. An encoder may
+	  choose to expand this as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <expan>per</expan>
+	</egXML>
+	  </p>
+	  <p>The expansion corresponding with an abbreviated form may not always contain the same letters
+	  as the abbreviation. Where it does, however, common editorial practice is to italicize or
+	  otherwise signal which letters have been supplied. The <gi>expan</gi> element should not be
+	  used for this purpose since its function is to indicate an expanded form, not a part of one.
+	  For example, consider the common abbreviation <val>wt</val> (for <val>with</val>) found in
+	  medieval texts. In a modern edition, an editor might wish to represent this as <soCalled>w<hi rend="it">i</hi>t<hi rend="it">h</hi>
+	  </soCalled>, italicising the letters not found in the
+	  source. One simple means of achieving that would be an encoding such as the follow<egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <expan>w<hi rend="it">i</hi>t<hi rend="it">h</hi>
+	  </expan>
+	</egXML>
+	The full TEI also provides elements <gi>ex</gi> and <gi>am</gi>
+	for use in this situation, but these are not included in the TEI Lite
+	  schema.</p>
+	  <p>To record both an abbreviation and its expansion, the <gi>choice</gi> element mentioned
+	  above may be used to group the abbreviated form with its proposed expansion: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <choice>
+	    <abbr>wt</abbr>
+	    <expan>with</expan>
+	  </choice>
+	</egXML>
+	  </p>
+	</div>
+      </div>
+      <div xml:id="U5-names">
+	<head>Names, Dates, and Numbers</head>
+	<p>The TEI scheme defines elements for a large number of <soCalled>data-like</soCalled> features
+	which may appear almost anywhere within almost any kind of text. These features may be of
+	particular interest in a range of disciplines; they all relate to objects external to the text
+	itself, such as the names of persons and places, numbers and dates. They also pose particular
+	problems for many natural language processing (NLP) applications because of the variety of ways
+	in which they may be presented within a text. The elements described here, by making such
+	features explicit, reduce the complexity of processing texts containing them.</p>
+	<div xml:id="nomen">
+	  <head>Names and Referring Strings</head>
+	  <p>A <term>referring string</term> is a phrase which refers to some person, place, object, etc.
+	  Two elements are provided to mark such strings: <specList>
+	  <specDesc key="rs"/>
+	  <specDesc key="name"/>
+	</specList>
+	  </p>
+	  <p> The <att>type</att> attribute is used to distinguish amongst (for example) names of
+	  persons, places and organizations, where this is possible: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <q>My dear <rs type="person">Mr. Bennet</rs>, </q>
+	  said his lady to him one day, <q>have you heard that <rs type="place">Netherfield Park</rs>
+	  is let at last?</q>
+	</egXML>
+	<egXML xmlns="http://www.tei-c.org/ns/Examples">It being one of the principles of the <rs type="organization">Circumlocution Office</rs> never, on any account whatsoever, to give a
+	straightforward answer, <rs type="person">Mr Barnacle</rs> said, <q>Possibly.</q>
+	</egXML>
+	  </p>
+	  <p>As the following example shows, the <gi>rs</gi> element may be used for any reference to a
+	  person, place, etc, not necessarily one in the form of a proper noun or noun phrase. <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <q>My dear <rs type="person">Mr. Bennet</rs>,</q>
+	  said <rs type="person">his lady</rs> to him one day...</egXML>
+	  </p>
+	  <p>The <gi>name</gi> element by contrast is provided for the special case of referencing
+	  strings which consist only of proper nouns; it may be used synonymously with the <gi>rs</gi>
+	  element, or nested within it if a referring string contains a mixture of common and proper
+	  nouns.</p>
+	  <p>Simply tagging something as a name is rarely enough to enable automatic processing of
+	  personal names into the canonical forms usually required for reference purposes. The name as
+	  it appears in the text may be inconsistently spelled, partial, or vague. Moreover, name
+	  prefixes such as <mentioned>van</mentioned> or <mentioned>de la</mentioned>, may or may not be
+	  included as part of the reference form of a name, depending on the language and country of
+	  origin of the bearer.</p>
+	  <p>The <att>key</att> attribute provides an alternative normalized identifier for the object
+	  being named, like a database record key. It may thus be useful as a means of gathering
+	  together all references to the same individual or location scattered throughout a document:
+	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <q>My dear <rs type="person" key="BENM1">Mr.
+	    Bennet</rs>, </q> said <rs type="person" key="BENM2">his lady</rs> to him one day, <q>have
+	    you heard that <rs type="place" key="NETP1">Netherfield Park</rs> is let at
+	    last?</q>
+	  </egXML>
+	  </p>
+	  <p>This use should be distinguished from the case of the <gi>reg</gi> (regularization) element,
+	  which provides a means of marking the standard form of a referencing string as demonstrated
+	  below: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <name type="person" key="WADLM1">
+	    <choice>
+	      <sic>Walter de la Mare</sic>
+	      <reg>de la Mare, Walter</reg>
+	    </choice>
+	    </name> was
+	    born at <name key="Ch1" type="place">Charlton</name>, in <name key="KT1" type="county">Kent</name>, in 1873.</egXML>
+	  </p>
+	  <p>The <gi>index</gi> element discussed in <ptr target="indexing"/> may be more appropriate if
+	  the function of the regularization is to provide a consistent index: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <p>
+	    <name type="place">Montaillou</name> is not a
+	    large parish. At the time of the events which led to <name type="person">Fournier</name>'s
+	    <index>
+	      <term>Benedict XII, Pope of Avignon (Jacques Fournier)</term>
+	    </index>
+	    investigations, the local population consisted of between 200 and 250
+	  inhabitants.</p>
+	  </egXML> Although adequate for many simple applications, these methods have
+	  two inconveniences: if the name occurs many times, then its regularised form must be repeated
+	  many times; and the burden of additional XML markup in the body of the text may be
+	  inconvenient to maintain and complex to process. For applications such as onomastics, relating
+	  to persons or places named rather than the name itself, or wherever a detailed analysis of the
+	  component parts of a name is needed, the full TEI Guidelines provide a range of other
+	  solutions.</p>
+	</div>
+	<div>
+	  <head>Dates and Times</head>
+	  <p>Tags for the more detailed encoding of times and dates include the following: <specList>
+	  <specDesc key="date"/>
+	  <specDesc key="time"/>
+	</specList>
+	  </p>
+	  <p>These elements have a number of attributes which can be used to provide normalised versions
+	  of their values. <specList>
+	  <specDesc key="att.datable" atts="period when"/>
+	  </specList> The <att>when</att>
+	  attribute specifies a normalized form for the date or time, using one of the standard formats
+	  defined by ISO 8601. Partial dates or times (e.g. <q>1990</q>, <q>September 1990</q>,
+	  <q>twelvish</q>) can be expressed by omitting a part of the value supplied, as in the
+	  following examples: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <date when="1980-02-21">21
+	  Feb 1980</date>
+	  <date when="1990">1990</date>
+	  <date when="1990-09">September 1990</date>
+	  <date when="--09">September</date>
+	  <date when="2001-09-11T12:48:00">Sept 11th, 12 minutes before 9
+	  am</date>
+	  </egXML>Note in the last example the use of a normalized representation for the
+	  date string which includes a time: this example could thus equally well be tagged using the
+	  <gi>time</gi> element. </p>
+	  <p>
+	    <egXML xmlns="http://www.tei-c.org/ns/Examples">Given on the <date when="1977-06-12">Twelfth
+	    Day of June in the Year of Our Lord One Thousand Nine Hundred and Seventy-seven of the
+	    Republic the Two Hundredth and first and of the University the Eighty-Sixth.</date>
+	    </egXML>
+	    <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	      <l>specially when it's nine below zero</l>
+	      <l>and <time when="15:00:00">three o'clock in the afternoon</time>
+	      </l>
+	    </egXML>
+	  </p>
+	</div>
+	<div>
+	  <head>Numbers </head>
+	  <p>Numbers can be written with either letters or digits (<code>twenty-one</code>,
+	  <code>xxi</code>, and <code>21</code>) and their presentation is language-dependent (e.g.
+	  English <mentioned>5th</mentioned> becomes Greek <mentioned>5.</mentioned>; English
+	  <mentioned>123,456.78</mentioned> equals French <mentioned>123.456,78</mentioned>). In
+	  natural-language processing or machine-translation applications, it is often helpful to
+	  distinguish them from other, more <soCalled>lexical</soCalled> parts of the text. In other
+	  applications, the ability to record a number's value in standard notation is important. The
+	  <gi>num</gi> element provides this possibility: <specList>
+	  <specDesc key="num"/>
+	</specList>
+	  </p>
+	  <p>For example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <num value="33">xxxiii</num>
+	  <num type="cardinal" value="21">twenty-one</num>
+	  <num type="percentage" value="10">ten percent</num>
+	  <num type="percentage" value="10">10%</num>
+	  <num type="ordinal" value="5">5th</num>
+	</egXML>
+	  </p>
+	</div>
+      </div>
+      <div xml:id="U5-lists">
+	<head>Lists</head>
+	<p>The element <gi>list</gi> is used to mark any kind of <term>list</term>. A list is a sequence
+	of text items, which may be numbered, bulleted, or arranged as a glossary list. Each item may be preceded
+	by an item label (in a glossary list, this label is the term being defined): <specList>
+	<specDesc key="list"/>
+	<specDesc key="item"/>
+	<specDesc key="label"/>
       </specList>
-     </p>
-     <p>The following elements may be used to mark <term>normalization</term>, that is editorial
-      changes introduced for the sake of consistency or modernization of a text: <specList>
-       <specDesc key="orig"/>
-       <specDesc key="reg"/>
-      </specList></p>
-     <p>As an example, consider this extract from the quarto printing of Shakespeare's <title>Henry
-       V</title>. <eg> ... for his nose was as sharp as a pen and a table of green feelds</eg>
-     </p>
-     <p>A modern editor might wish to make a number of interventions here, specifically to modernize
-      (or normalise) the Elizabethan spellings of <mentioned>a'</mentioned> and
-       <mentioned>feelds</mentioned> for <mentioned>he</mentioned> and <mentioned>fields</mentioned>
-      respectively. He or she might also want to emend <mentioned>table</mentioned> to
-       <mentioned>babbl'd</mentioned>, following an editorial tradition that goes back to the 18th
-      century Shakespearian scholar Lewis Theobald. The following encoding would then be
-      appropriate: <egXML xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as
-       a pen and <reg>he</reg>
-       <corr resp="#Theobald">babbl'd</corr> of green <reg>fields</reg></egXML></p>
-     <p>A more conservative or source-oriented editor, however, might want to retain the original,
-      but at the same time signal that some of the readings it contains are in some sense anomalous:
-       <egXML xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as a pen and
-        <orig>a</orig>
-       <sic>table</sic> of green <orig>feelds</orig></egXML></p>
-     <p>Finally, a modern digital editor may decide to combine both possibilities in a single
-      composite text, using the <gi>choice</gi> element. <specList>
-       <specDesc key="choice"/>
-      </specList> This allows an editor to mark where alternative readings are possible: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples">... for his nose was as sharp as a pen and
-         <choice><orig>a</orig><reg>he</reg></choice>
-       <choice><corr resp="#Theobald">babbl'd</corr><sic>table</sic></choice> of green
-         <choice><orig>feelds</orig><reg>fields</reg></choice>
-      </egXML></p>
-    </div>
-    <div xml:id="U5-edit2">
-     <head>Omissions, Deletions, and Additions</head>
-     <p>In addition to correcting or normalizing words and phrases, editors and transcribers may
-      also supply missing material, omit material, or transcribe material deleted or crossed out in
-      the source. In addition, some material may be particularly hard to transcribe because it is
-      hard to make out on the page. The following elements may be used to record such phenomena: <specList>
-       <specDesc key="add"/>
-       <specDesc key="gap"/>
-       <specDesc key="del"/>
-       <specDesc key="unclear"/>
-      </specList>
-     </p>
-     <p>These elements may be used to record changes made by an editor, by the transcriber, or (in
-      manuscript material) by the author or scribe. For example, if the source for an electronic
-      text read <q>The following elements are provided for for simple editorial interventions.</q>
-      then it might be felt desirable to correct the obvious error, but at the same time to record
-      the deletion of the superfluous second <mentioned>for</mentioned>, thus: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples">The following elements are provided for <del
-        resp="#LB">for</del> simple editorial interventions.</egXML> The attribute value
-       <code>#LB</code> on the <att>resp</att> attribute is used to point to a fuller definition
-      (typically in a <gi>respStmt</gi> element) for the agency responsible for correcting the
-      duplication of <mentioned>for</mentioned>.</p>
-     <p>If the source read <q>The following elements provided for simple editorial
-       interventions.</q> (i.e. if the verb had been inadvertently dropped) then the corrected text
-      might read: <egXML xmlns="http://www.tei-c.org/ns/Examples">The following elements <add
-        resp="#LB">are</add> provided for simple editorial interventions.</egXML></p>
-     <p>These elements are also used to record
-      authorial changes in manuscripts. A manuscript in which the author has first written <q>How it
-       galls me, what a galling shadow</q>, then crossed out the word <mentioned>galls</mentioned>
-      and inserted <mentioned>dogs</mentioned> might be encoded thus: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples">How it <del hand="#DHL" type="overstrike"
-        >galls</del>
-       <add hand="#DHL" place="supralinear">dogs</add> me, what a galling shadow</egXML> Again, the
-      code <code>#DHL</code> points to another location where more information about the hand
-      concerned is to be found<note place="foot">The full TEI provides a range of elements for
-       encoding metadata about manuscript production and description, which are not however included
-       in TEI Lite</note>. </p>
-     <p>Similarly, the <gi>unclear</gi> and <gi>gap</gi> elements may be used together to indicate
-      the omission of illegible material; the following example also shows the use of <gi>add</gi>
-      for a conjectural emendation: <egXML xmlns="http://www.tei-c.org/ns/Examples">One hundred
-       &amp; twenty good regulars joined to me <unclear><gap reason="indecipherable"/></unclear>
-       &amp; instantly, would aid me signally <add hand="#ed">in?</add> an enterprise against
-       Wilmington.</egXML></p>
-     <p>The <gi>del</gi> element marks material which has been transcribed as part of the electronic text
-      despite being marked as deleted, while <gi>gap</gi> marks the location of material which is
-      omitted from the electronic text, whether it is legible or not. A language corpus, for
-      example, might omit long quotations in foreign languages: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><p> ... An example of a list appearing in a fief
-        ledger of <name type="place">Koldinghus</name>
-        <date>1611/12</date> is given below. It shows cash income from a sale of
-         honey.</p><gap><desc>quotation from ledger (in Danish)</desc></gap><p>A description of the
-        overall structure of the account is once again ... </p></egXML></p>
-     <p>Other corpora (particular those constructed before the widespread use of scanners)
-      systematically omit figures and mathematics: <egXML xmlns="http://www.tei-c.org/ns/Examples"
-        ><p>At the bottom of your screen below the mode line is the <term>minibuffer</term>. This is
-        the area where Emacs echoes the commands you enter and where you specify filenames for Emacs
-        to find, values for search and replace, and so on. <gap reason="graphic"><desc>diagram of
-          Emacs screen</desc></gap>
-       </p></egXML></p>
-<p>The full TEI scheme provides more precise ways of capturing
-different aspects of  a transcription, distinguishing for example
-between text added or supplied by the encoder and text indicated as
-supplied or deleted in the source. TEI Lite does not provide different
-tags for these purposes.</p>
-    </div>
-    <div>
-     <head>Abbreviations and their Expansion</head>
-     <p>Like names, dates, and numbers, abbreviations may be transcribed as they stand or expanded;
-      they may be left unmarked, or encoded using the following elements: <specList>
-       <specDesc key="abbr"/>
-       <specDesc key="expan"/>
-      </specList>
-     </p>
-     <p>The <gi>abbr</gi> element is useful as a means of distinguishing semi-lexical items such as
-      acronyms or jargon: <egXML xmlns="http://www.tei-c.org/ns/Examples">We can sum up the above
-       discussion as follows: the identity of a <abbr>CC</abbr> is defined by that calibration of
-       values which motivates the elements of its <abbr>GSP</abbr>;</egXML>
-      <egXML xmlns="http://www.tei-c.org/ns/Examples">Every manufacturer of <abbr>3GL</abbr> or
-        <abbr>4GL</abbr> languages is currently nailing on <abbr>OOP</abbr> extensions</egXML>
-     </p>
-     <p>The <att>type</att> attribute may be used to distinguish types of abbreviation by their
-      function. </p>
-     <p>The <gi>expan</gi> element is used to mark an expansion supplied by an encoder. This element
-      is particularly useful in the transcription of manuscript materials. For example, the
-      character p with a bar through its descender as a conventional representation for the word
-       <val>per</val> is commonly encountered in Medieval European manuscripts. An encoder may
-      choose to expand this as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples"
-        ><expan>per</expan></egXML>
-     </p>
-     <p>The expansion corresponding with an abbreviated form may not always contain the same letters
-      as the abbreviation. Where it does, however, common editorial practice is to italicize or
-      otherwise signal which letters have been supplied. The <gi>expan</gi> element should not be
-      used for this purpose since its function is to indicate an expanded form, not a part of one.
-      For example, consider the common abbreviation <val>wt</val> (for <val>with</val>) found in
-      medieval texts. In a modern edition, an editor might wish to represent this as <soCalled>w<hi
-        rend="it">i</hi>t<hi rend="it">h</hi></soCalled>, italicising the letters not found in the
-      source. One simple means of achieving that would be an encoding such as the follow<egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><expan>w<hi rend="it">i</hi>t<hi rend="it"
-        >h</hi></expan></egXML>
-     The full TEI also provides elements <gi>ex</gi> and <gi>am</gi>
-     for use in this situation, but these are not included in the TEI Lite
-     schema.</p>
-     <p>To record both an abbreviation and its expansion, the <gi>choice</gi> element mentioned
-      above may be used to group the abbreviated form with its proposed expansion: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"
-       ><choice><abbr>wt</abbr><expan>with</expan></choice></egXML>
-     </p>
-    </div>
-   </div>
-   <div xml:id="U5-names">
-    <head>Names, Dates, and Numbers</head>
-    <p>The TEI scheme defines elements for a large number of <soCalled>data-like</soCalled> features
-     which may appear almost anywhere within almost any kind of text. These features may be of
-     particular interest in a range of disciplines; they all relate to objects external to the text
-     itself, such as the names of persons and places, numbers and dates. They also pose particular
-     problems for many natural language processing (NLP) applications because of the variety of ways
-     in which they may be presented within a text. The elements described here, by making such
-     features explicit, reduce the complexity of processing texts containing them.</p>
-    <div xml:id="nomen">
-     <head>Names and Referring Strings</head>
-     <p>A <term>referring string</term> is a phrase which refers to some person, place, object, etc.
-      Two elements are provided to mark such strings: <specList>
-       <specDesc key="rs"/>
-       <specDesc key="name"/>
-      </specList>
-     </p>
-     <p> The <att>type</att> attribute is used to distinguish amongst (for example) names of
-      persons, places and organizations, where this is possible: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><q>My dear <rs type="person">Mr. Bennet</rs>, </q>
-       said his lady to him one day, <q>have you heard that <rs type="place">Netherfield Park</rs>
-        is let at last?</q></egXML>
-      <egXML xmlns="http://www.tei-c.org/ns/Examples">It being one of the principles of the <rs
-        type="organization">Circumlocution Office</rs> never, on any account whatsoever, to give a
-       straightforward answer, <rs type="person">Mr Barnacle</rs> said, <q>Possibly.</q></egXML></p>
-     <p>As the following example shows, the <gi>rs</gi> element may be used for any reference to a
-      person, place, etc, not necessarily one in the form of a proper noun or noun phrase. <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><q>My dear <rs type="person">Mr. Bennet</rs>,</q>
-       said <rs type="person">his lady</rs> to him one day...</egXML></p>
-     <p>The <gi>name</gi> element by contrast is provided for the special case of referencing
-      strings which consist only of proper nouns; it may be used synonymously with the <gi>rs</gi>
-      element, or nested within it if a referring string contains a mixture of common and proper
-      nouns.</p>
-     <p>Simply tagging something as a name is rarely enough to enable automatic processing of
-      personal names into the canonical forms usually required for reference purposes. The name as
-      it appears in the text may be inconsistently spelled, partial, or vague. Moreover, name
-      prefixes such as <mentioned>van</mentioned> or <mentioned>de la</mentioned>, may or may not be
-      included as part of the reference form of a name, depending on the language and country of
-      origin of the bearer.</p>
-     <p>The <att>key</att> attribute provides an alternative normalized identifier for the object
-      being named, like a database record key. It may thus be useful as a means of gathering
-      together all references to the same individual or location scattered throughout a document:
-       <egXML xmlns="http://www.tei-c.org/ns/Examples"><q>My dear <rs type="person" key="BENM1">Mr.
-         Bennet</rs>, </q> said <rs type="person" key="BENM2">his lady</rs> to him one day, <q>have
-        you heard that <rs type="place" key="NETP1">Netherfield Park</rs> is let at
-       last?</q></egXML></p>
-     <p>This use should be distinguished from the case of the <gi>reg</gi> (regularization) element,
-      which provides a means of marking the standard form of a referencing string as demonstrated
-      below: <egXML xmlns="http://www.tei-c.org/ns/Examples"><name type="person" key="WADLM1"
-          ><choice><sic>Walter de la Mare</sic><reg>de la Mare, Walter</reg></choice></name> was
-       born at <name key="Ch1" type="place">Charlton</name>, in <name key="KT1" type="county"
-        >Kent</name>, in 1873.</egXML></p>
-     <p>The <gi>index</gi> element discussed in <ptr target="indexing"/> may be more appropriate if
-      the function of the regularization is to provide a consistent index: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><p><name type="place">Montaillou</name> is not a
-        large parish. At the time of the events which led to <name type="person">Fournier</name>'s
-          <index><term>Benedict XII, Pope of Avignon (Jacques Fournier)</term></index>
-        investigations, the local population consisted of between 200 and 250
-       inhabitants.</p></egXML> Although adequate for many simple applications, these methods have
-      two inconveniences: if the name occurs many times, then its regularised form must be repeated
-      many times; and the burden of additional XML markup in the body of the text may be
-      inconvenient to maintain and complex to process. For applications such as onomastics, relating
-      to persons or places named rather than the name itself, or wherever a detailed analysis of the
-      component parts of a name is needed, the full TEI Guidelines provide a range of other
-      solutions.</p>
-    </div>
-    <div>
-     <head>Dates and Times</head>
-     <p>Tags for the more detailed encoding of times and dates include the following: <specList>
-       <specDesc key="date"/>
-       <specDesc key="time"/>
-      </specList>
-     </p>
-     <p>These elements have a number of attributes which can be used to provide normalised versions
-      of their values. <specList><specDesc key="att.datable" atts="period when"/></specList> The <att>when</att>
-      attribute specifies a normalized form for the date or time, using one of the standard formats
-      defined by ISO 8601. Partial dates or times (e.g. <q>1990</q>, <q>September 1990</q>,
-       <q>twelvish</q>) can be expressed by omitting a part of the value supplied, as in the
-      following examples: <egXML xmlns="http://www.tei-c.org/ns/Examples"><date when="1980-02-21">21
-        Feb 1980</date><date when="1990">1990</date><date when="1990-09">September 1990</date><date
-        when="--09">September</date><date when="2001-09-11T12:48:00">Sept 11th, 12 minutes before 9
-        am</date></egXML>Note in the last example the use of a normalized representation for the
-      date string which includes a time: this example could thus equally well be tagged using the
-       <gi>time</gi> element. </p>
-     <p>
-      <egXML xmlns="http://www.tei-c.org/ns/Examples">Given on the <date when="1977-06-12">Twelfth
-        Day of June in the Year of Our Lord One Thousand Nine Hundred and Seventy-seven of the
-        Republic the Two Hundredth and first and of the University the Eighty-Sixth.</date></egXML>
-      <egXML xmlns="http://www.tei-c.org/ns/Examples">
-       <l>specially when it's nine below zero</l>
-       <l>and <time when="15:00:00">three o'clock in the afternoon</time></l>
+	</p>
+	<p>Individual list items are tagged with <gi>item</gi>. The first <gi>item</gi> may optionally
+	be preceded by a <gi>head</gi>, which gives a heading for the list. The numbering of a list may
+	be omitted, indicated using the <att>n</att> attribute on each item, or (rarely) tagged as
+	content using the <gi>label</gi> element. The following are all thus equivalent: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	<list>
+	  <head>A short list</head>
+	  <item>First item in list.</item>
+	  <item>Second item in list.</item>
+	  <item>Third item in list.</item>
+	</list>
+	<list>
+	  <head>A short list</head>
+	  <item n="1">First item in list.</item>
+	  <item n="2">Second item in list.</item>
+	  <item n="3">Third item in list.</item>
+	</list>
+	<list>
+	  <head>A short list</head>
+	  <label>1</label>
+	  <item>First item in list.</item>
+	  <label>2</label>
+	  <item>Second item in list.</item>
+	  <label>3</label>
+	  <item>Third item in list.</item>
+	</list>
+	</egXML> The styles should not be mixed in the same list.</p>
+	<p>A simple two-column table may be treated as a <term>glossary list</term>, tagged
+	<code>&lt;list type="gloss"&gt;</code>. Here, each item comprises a <term>term</term> and a
+	<term>gloss</term>, marked with <gi>label</gi> and <gi>item</gi> respectively. These
+	correspond to the elements <gi>term</gi> and <gi>gloss</gi>, which can occur anywhere in prose
+	text. <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	<list type="gloss">
+	  <head>Vocabulary</head>
+	  <label xml:lang="enm">nu</label>
+	  <item>now</item>
+	  <label xml:lang="enm">lhude</label>
+	  <item>loudly</item>
+	  <label xml:lang="enm">bloweth</label>
+	  <item>blooms</item>
+	  <label xml:lang="enm">med</label>
+	  <item>meadow</item>
+	  <label xml:lang="enm">wude</label>
+	  <item>wood</item>
+	  <label xml:lang="enm">awe</label>
+	  <item>ewe</item>
+	  <label xml:lang="enm">lhouth</label>
+	  <item>lows</item>
+	  <label xml:lang="enm">sterteth</label>
+	  <item>bounds, frisks</item>
+	  <label xml:lang="enm">verteth</label>
+	  <item xml:lang="la">pedit</item>
+	  <label xml:lang="enm">murie</label>
+	  <item>merrily</item>
+	  <label xml:lang="enm">swik</label>
+	  <item>cease</item>
+	  <label xml:lang="enm">naver</label>
+	  <item>never</item>
+	</list>
       </egXML>
-     </p>
-    </div>
-    <div>
-     <head>Numbers </head>
-     <p>Numbers can be written with either letters or digits (<code>twenty-one</code>,
-       <code>xxi</code>, and <code>21</code>) and their presentation is language-dependent (e.g.
-      English <mentioned>5th</mentioned> becomes Greek <mentioned>5.</mentioned>; English
-       <mentioned>123,456.78</mentioned> equals French <mentioned>123.456,78</mentioned>). In
-      natural-language processing or machine-translation applications, it is often helpful to
-      distinguish them from other, more <soCalled>lexical</soCalled> parts of the text. In other
-      applications, the ability to record a number's value in standard notation is important. The
-       <gi>num</gi> element provides this possibility: <specList>
-       <specDesc key="num"/>
-      </specList>
-     </p>
-     <p>For example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><num value="33"
-        >xxxiii</num><num type="cardinal" value="21">twenty-one</num><num type="percentage"
-        value="10">ten percent</num><num type="percentage" value="10">10%</num><num type="ordinal"
-        value="5">5th</num></egXML></p>
-    </div>
-   </div>
-   <div xml:id="U5-lists">
-    <head>Lists</head>
-    <p>The element <gi>list</gi> is used to mark any kind of <term>list</term>. A list is a sequence
-     of text items, which may be numbered, bulleted, or arranged as a glossary list. Each item may be preceded
-     by an item label (in a glossary list, this label is the term being defined): <specList>
-      <specDesc key="list"/>
-      <specDesc key="item"/>
-      <specDesc key="label"/>
-     </specList>
-    </p>
-    <p>Individual list items are tagged with <gi>item</gi>. The first <gi>item</gi> may optionally
-     be preceded by a <gi>head</gi>, which gives a heading for the list. The numbering of a list may
-     be omitted, indicated using the <att>n</att> attribute on each item, or (rarely) tagged as
-     content using the <gi>label</gi> element. The following are all thus equivalent: <egXML
-      xmlns="http://www.tei-c.org/ns/Examples"><list>
-       <head>A short list</head>
-       <item>First item in list.</item>
-       <item>Second item in list.</item>
-       <item>Third item in list.</item>
-      </list><list>
-       <head>A short list</head>
-       <item n="1">First item in list.</item>
-       <item n="2">Second item in list.</item>
-       <item n="3">Third item in list.</item>
-      </list><list>
-       <head>A short list</head>
-       <label>1</label>
-       <item>First item in list.</item>
-       <label>2</label>
-       <item>Second item in list.</item>
-       <label>3</label>
-       <item>Third item in list.</item>
-      </list></egXML> The styles should not be mixed in the same list.</p>
-    <p>A simple two-column table may be treated as a <term>glossary list</term>, tagged
-      <code>&lt;list type="gloss"&gt;</code>. Here, each item comprises a <term>term</term> and a
-      <term>gloss</term>, marked with <gi>label</gi> and <gi>item</gi> respectively. These
-     correspond to the elements <gi>term</gi> and <gi>gloss</gi>, which can occur anywhere in prose
-     text. <egXML xmlns="http://www.tei-c.org/ns/Examples"><list type="gloss">
-       <head>Vocabulary</head>
-       <label xml:lang="enm">nu</label>
-       <item>now</item>
-       <label xml:lang="enm">lhude</label>
-       <item>loudly</item>
-       <label xml:lang="enm">bloweth</label>
-       <item>blooms</item>
-       <label xml:lang="enm">med</label>
-       <item>meadow</item>
-       <label xml:lang="enm">wude</label>
-       <item>wood</item>
-       <label xml:lang="enm">awe</label>
-       <item>ewe</item>
-       <label xml:lang="enm">lhouth</label>
-       <item>lows</item>
-       <label xml:lang="enm">sterteth</label>
-       <item>bounds, frisks</item>
-       <label xml:lang="enm">verteth</label>
-       <item xml:lang="la">pedit</item>
-       <label xml:lang="enm">murie</label>
-       <item>merrily</item>
-       <label xml:lang="enm">swik</label>
-       <item>cease</item>
-       <label xml:lang="enm">naver</label>
-       <item>never</item>
-      </list></egXML></p>
-    <p>Where the internal structure of a list item is more complex, it may be preferable to regard
-     the list as a <term>table</term>, for which special-purpose tagging is defined below (<ptr
-      target="#U5-tables"/>). </p>
-    <p>Lists of whatever kind can, of course, nest within list items to any depth required. Here,
-     for example, a glossary list contains two items, each of which is itself a simple list: <egXML
-      xmlns="http://www.tei-c.org/ns/Examples"><list type="gloss">
-       <label>EVIL</label>
-       <item><list type="simple">
-         <item>I am cast upon a horrible desolate island, void of all hope of recovery.</item>
-         <item>I am singled out and separated as it were from all the world to be miserable.</item>
-         <item>I am divided from mankind — a solitaire; one banished from human society.</item>
-        </list></item>
-       <label>GOOD</label>
-       <item><list type="simple">
-         <item>But I am alive; and not drowned, as all my ship's company were.</item>
-         <item>But I am singled out, too, from all the ship's crew, to be spared from
-          death...</item>
-         <item>But I am not starved, and perishing on a barren place, affording no
-          sustenances....</item>
-        </list></item>
-      </list></egXML></p>
-    <p>A list need not necessarily be displayed in list format. For example, <egXML
-      xmlns="http://www.tei-c.org/ns/Examples"><p>On those remote pages it is written that animals
-       are divided into <list rend="run-on">
-        <item n="a">those that belong to the Emperor,</item>
-        <item n="b"> embalmed ones, </item>
-        <item n="c"> those that are trained, </item>
-        <item n="d"> suckling pigs, </item>
-        <item n="e"> mermaids, </item>
-        <item n="f"> fabulous ones, </item>
-        <item n="g"> stray dogs, </item>
-        <item n="h"> those that are included in this classification, </item>
-        <item n="i"> those that tremble as if they were mad, </item>
-        <item n="j"> innumerable ones, </item>
-        <item n="k"> those drawn with a very fine camel's-hair brush, </item>
-        <item n="l"> others, </item>
-        <item n="m"> those that have just broken a flower vase, </item>
-        <item n="n"> those that resemble flies from a distance.</item>
-       </list></p></egXML></p>
-    <p>Lists of bibliographic items should be tagged using the <gi>listBibl</gi> element, described
-     in the next section.</p>
-   </div>
-   <div xml:id="U5-bibls">
-    <head>Bibliographic Citations</head>
-    <p>It is often useful to distinguish bibliographic citations where they occur within texts being
-     transcribed for research, if only so that they will be properly formatted when the text is
-     printed out. The element <gi>bibl</gi> is provided for this purpose. Where the components of a
-     bibliographic reference are to be distinguished, the following elements may be used as
-     appropriate. It is generally useful to mark at least those parts (such as the titles of
-     articles, books, and journals) which will need special formatting. The other elements are
-     provided for cases where particular interest attaches to such details. <specList>
-      <specDesc key="bibl"/>
-      <specDesc key="author"/>
-      <specDesc key="biblScope"/>
-      <specDesc key="date"/>
-      <specDesc key="editor"/>
-      <specDesc key="publisher"/>
-      <specDesc key="pubPlace"/>
-      <specDesc key="title"/>
-     </specList></p>
-    <p>For example, the following editorial note might be transcribed as shown: <q rend="display">He
-      was a member of Parliament for Warwickshire in 1445, and died March 14, 1470 (according to
-      Kittredge, <title>Harvard Studies</title> 5. 88ff).</q>
-     <egXML xmlns="http://www.tei-c.org/ns/Examples">He was a member of Parliament for Warwickshire
-      in 1445, and died March 14, 1470 (according to <bibl><author>Kittredge</author>,
-        <title>Harvard Studies</title><biblScope>5. 88ff</biblScope></bibl>).</egXML></p>
-    <p>For lists of bibliographic citations, the <gi>listBibl</gi> element should be used; it may
-     contain a series of <gi>bibl</gi> elements. </p>
-   </div>
-   <div xml:id="U5-tables">
-    <head>Tables</head>
-    <p>Tables represent a challenge for any text processing system, but simple tables, at least,
-     appear in so many texts that even in the simplified TEI tag set presented here, markup for
-     tables is necessary. The following elements are provided for this purpose: <specList>
-      <specDesc key="table"/>
-      <specDesc key="row"/>
-      <specDesc key="cell"/>
-     </specList></p>
-    <p>For example, Defoe uses mortality tables like the following in the <title level="m">Journal
-      of the Plague Year</title> to show the rise and ebb of the epidemic:<egXML
-      xmlns="http://www.tei-c.org/ns/Examples"><p>It was indeed coming on amain, for the burials
-       that same week were in the next adjoining parishes thus:— <table rows="5" cols="4">
-        <row role="data">
-         <cell role="label">St. Leonard's, Shoreditch</cell>
-         <cell>64</cell>
-         <cell>84</cell>
-         <cell>119</cell>
-        </row>
-        <row role="data">
-         <cell role="label">St. Botolph's, Bishopsgate</cell>
-         <cell>65</cell>
-         <cell>105</cell>
-         <cell>116</cell>
-        </row>
-        <row role="data">
-         <cell role="label">St. Giles's, Cripplegate</cell>
-         <cell>213</cell>
-         <cell>421</cell>
-         <cell>554</cell>
-        </row>
-       </table></p><p>This shutting up of houses was at first counted a very cruel and unchristian
-       method, and the poor people so confined made bitter lamentations. ... </p></egXML></p>
-   </div>
-   <div xml:id="U5-figs">
-    <head>Figures and Graphics</head>
-    <p>Not all the components of a document are necessarily textual. The most straightforward text
-     will often contain diagrams or illustrations, to say nothing of documents in which image and
-     text are inextricably intertwined, or electronic resources in which the two are complementary. </p>
-    <p>The encoder may simply record the presence of a graphic within the text, possibly with a
-     brief description of its content, and may also provide a link to a digitized version of the
-     graphic, using the following elements: <specList>
-      <specDesc key="graphic"/>
-      <specDesc key="figure"/>
-      <specDesc key="figDesc"/>
-     </specList></p>
-    <p>Any textual information accompanying the graphic, such as a heading and/or caption, may be
-     included within the <gi>figure</gi> element itself, in a <gi>head</gi> and one or more
-      <gi>p</gi> elements, as also may any text appearing within the graphic itself. It is strongly
-     recommended that a prose description of the image be supplied, as the content of a
-      <gi>figDesc</gi> element, for the use of applications which are not able to render the
-     graphic, and to render the document accessible to vision-impaired readers. (Such text is not
-     normally considered part of the document proper.)</p>
-    <p>The simplest use for these elements is to mark the position of a graphic and provide a link
-     to it, as in this example; <egXML xmlns="http://www.tei-c.org/ns/Examples"><pb n="412"
-        /><figure><graphic url="p412fig.png"/></figure><pb n="413"/></egXML> This indicates that the
-     graphic contained by the file <ident>p412fig.png</ident> appears between pages 412 and 413. </p>
-    <p>The <gi>graphic</gi> element can appear anywhere that textual content is permitted, within
-     but not between paragraphs or headings. In the following example, the encoder has decided to
-     treat a specific printer's ornament as a heading: <egXML
-      xmlns="http://www.tei-c.org/ns/Examples"><head><graphic
-        url="http://www.iath.virginia.edu/gants/Ornaments/Heads/hp-ral02.gif"/></head></egXML>
-    </p>
-    <p>More usually, a graphic will have at the least an identifying title, which may be encoded
-     using the <gi>head</gi> element, or a number of figures may be grouped together in a particular
-     structure. It is also often convenient to include a brief description of the image. The
-      <gi>figure</gi> element provides a means of wrapping one or more such elements together as a
-     kind of graphic <soCalled>block</soCalled>: <egXML xmlns="http://www.tei-c.org/ns/Examples"
-        ><figure><graphic url="fessipic.png"/><head>Mr Fezziwig's Ball</head><figDesc>A Cruikshank
-        engraving showing Mr Fezziwig leading a group of revellers.</figDesc></figure></egXML></p>
-    <p>These cases should be carefully distinguished from the case where an encoded text is
-     complemented by a collection of digital images, maintained as a distinct resource. The
-      <att>facs</att> attribute may be used to associate any element in an encoded text with a
-     digital facsimile of it. In the simple case where only page images are available, the
-      <att>facs</att> attribute on the <gi>pb</gi> element may be used to associate each image with
-     an appropriate point in the text: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-      <text>
-       <pb facs="page1.png" n="1"/>
-       <!-- text contained on page 1 is encoded here -->
-       <pb facs="page2.png" n="2"/>
-       <!-- text contained on page 2 is encoded here -->
-      </text>
-     </egXML> This method is only appropriate in the simple case where each digital image file
-      <ident>page1.png</ident> etc. corresponds with a single transcribed and encoded page. If more
-     detailed alignment of image and transcription is required, for example because the image files
-     actually represent double page spreads, more sophisticated mechanisms are provided in the full
-     TEI Guidelines. </p>
-   </div>
-   <div xml:id="U5-anal">
-    <head>Interpretation and Analysis</head>
-    <p>It is often said that <emph>all</emph> markup is a form of interpretation or analysis. While
-     it is certainly difficult, and may be impossible, to distinguish firmly between
-      <soCalled>objective</soCalled> and <soCalled>subjective</soCalled> information in any
-     universal way, it remains true that judgments concerning the latter are typically regarded as
-     more likely to provide controversy than those concerning the former. Many scholars therefore
-     prefer to record such interpretations only if it is possible to alert the reader that they are
-     considered more open to dispute, than the rest of the markup. This section describes some of
-     the elements provided by the TEI scheme to meet this need. </p>
-    <div>
-     <head>Orthographic Sentences</head>
-     <p>Interpretation typically ranges across the whole of a text, with no particular respect to
-      other structural units. A useful preliminary to intensive interpretation is therefore to
-      segment the text into discrete and identifiable units, each of which can then bear a label for
-      use as a sort of <soCalled>canonical reference</soCalled>. To facilitate such uses, these
-      units may not cross each other, nor nest within each other. They may conveniently be
-      represented using the following element: <specList>
-       <specDesc key="s"/>
-      </specList></p>
-     <p>As the name suggests, the <gi>s</gi> element is most commonly used (in linguistic
-      applications at least) for marking <term>orthographic sentences</term>, that is, units defined
-      by orthographic features such as punctuation. For example, the passage from <title>Jane
-       Eyre</title> discussed earlier might be divided into s-units as follows:<egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><pb n="474"/><div type="chapter" n="38">
-        <p><s n="001">Reader, I married him.</s><s n="002">A quiet wedding we had:</s><s n="003">he
-          and I, the parson and clerk, were alone present.</s><s n="004">When we got back from
-          church, I went into the kitchen of the manor-house, where Mary was cooking the dinner, and
-          John cleaning the knives, and I said —</s></p>
-        <p><q><s n="005">Mary, I have been married to Mr Rochester this morning.</s></q> ... </p>
-       </div></egXML> Note that <gi>s</gi> elements cannot nest: the beginning of one <gi>s</gi>
-      element implies that the previous one has finished. When s-units are tagged as shown above, it
-      is advisable to tag the entire text end-to-end, so that every word in the text being analysed
-      will be contained by exactly one <gi>s</gi> element, whose identifier can then be used to
-      specify a unique reference for it. If the identifiers used are unique within the document,
-      then the <att>xml:id</att> attribute might be used in preference to the <att>n</att> used in
-      the above example.</p>
-    </div><div><head>Words and punctuation</head><p>Tokenization, that is, the identification of
-      lexical or non-lexical tokens within a text, is a very common requirement for all kinds of
-      textual analysis, and not an entirely trivial one. The decision as to whether, for example,
-       <q>can't</q> in English or <q>du</q> in French should be treated as one word or two is not
-      simple. Consequently it is often useful to make explicit the preferred tokenization in a
-      marked up text. The following elements are available for this purpose: <specList><specDesc
-        key="w"/><specDesc key="pc"/></specList></p>
-     <p>For example, the output from a part of speech tagger might be recorded in TEI Lite as
-      follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-       <s n="1">
-        <w ana="#NP0">Marley</w>
-        <w ana="#VBD">was</w>
-        <w ana="#AJ0">dead</w><pc>:</pc>
-        <w ana="#TO0">to</w>
-        <w ana="#VBB">begin</w>
-        <w ana="#PRP">with</w><pc>. </pc>
-       </s></egXML>
-     </p><p>In this example, each word has been decorated with an automatically generated part of
-      speech code, using the <att>ana</att> attribute discussed in section <ptr target="#xatts"/>
-      above. The <gi>w</gi> also provides for each word to be associated with a root form or lemma,
-      either explicitly using the <att>lemma</att> attribute, or by reference, using the
-       <att>lemmaRef</att> attribute, as in this example: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples">...<w ana="#VBD" lemma="be"
-        lemmaRef="http://www.myLexicon.com/be">was</w> ... </egXML>
-     </p></div>
-    <div>
-     <head>General-Purpose Interpretation Elements</head>
-     <p>The <gi>w</gi> element is a specialisation of the <gi>seg</gi> element which has already
-      been introduced for use in identifying otherwise unmarked targets of cross references and
-      hypertext links (see section <ptr target="#U5-ptrs"/>); it identifies some phrase-level
-      portion of text to which the encoder may assign a user-specified <att>type</att>, as well as a
-      unique identifier; it may thus be used to tag textual features for which there is no other
-      provision in the published TEI Guidelines.</p>
-     <p>For example, the Guidelines provide no <soCalled>apostrophe</soCalled> element to mark parts
-      of a literary text in which the narrator addresses the reader (or hearer) directly. One
-      approach might be to regard these as instances of the <gi>q</gi> element, distinguished from
-      others by an appropriate value for the <att>who</att> attribute. A possibly simpler, and
-      certainly more general, solution would however be to use the <gi>seg</gi> element as follows:
-       <egXML xmlns="http://www.tei-c.org/ns/Examples"><div type="chapter" n="38">
-        <p><seg type="apostrophe">Reader, I married him.</seg> A quiet wedding we had: ...</p>
-       </div></egXML> The <att>type</att> attribute on the <gi>seg</gi> element can take any value,
-      and so can be used to record phrase-level phenomena of any kind; it is good practice to record
-      the values used and their significance in the header.</p>
-     <p>A <gi>seg</gi> element of one type (unlike the <gi>s</gi> element which it superficially
-      resembles) can be nested within a <gi>seg</gi> element of the same or another type. This
-      enables quite complex structures to be represented; some examples were given in section <ptr
-       target="#xatts"/> above. However, because it must respect the requirement that elements be
-      properly nested and may not cut across each other, it cannot cope with the common requirement
-      to associate an interpretation with arbitrary segments of a text which may completely ignore
-      the document hierarchy. It also requires that the interpretation itself be represented by a
-      single coded value in the <att>type</att> attribute.</p>
-     <p>Neither restriction applies to the <gi>interp</gi> element, which provides powerful features
-      for the encoding of quite complex interpretive information in a relatively straightforward
-      manner. <specList>
-       <specDesc key="interp"/>
-       <specDesc key="interpGrp"/>
-      </specList> These elements allow the encoder to specify both the class of an interpretation,
-      and the particular instance of that class which the interpretation involves. Thus, whereas
-      with <gi>seg</gi> one can say simply that something is an apostrophe, with <gi>interp</gi> one
-      can say that it is an instance (apostrophe) of a larger class (rhetorical figures).</p>
-     <p>Moreover, <gi>interp</gi> is a <soCalled>stand off</soCalled>
-     element: it does not surround the segments of text which it
-     describes, but instead is  linked to the passage in question
-      either by means of the <att>ana</att> attribute discussed in section <ptr
-       target="#xatts"/> above, or by means of its own <att>inst</att> attribute. This means that
-      any kind of analysis can be represented, independently of the
-      document hierarchy, as well as
-       facilitating the grouping of analyses of a particular type together. A special purpose
-       <gi>interpGrp</gi> element is provided for the latter purpose.</p>
-     <p>For example, suppose that you wish to mark such diverse aspects of a text as themes or
-      subject matter, rhetorical figures, and the locations of individual scenes of the narrative.
-      Different portions of our sample passage from <title>Jane Eyre</title> for example, might be
-      associated with the rhetorical figures of apostrophe, hyperbole, and metaphor; with
-      subject-matter references to churches, servants, cooking, postal service, and honeymoons; and
-      with scenes located in the church, in the kitchen, and in an unspecified location (drawing
-      room?).</p>
-     <p>These interpretations could be placed anywhere within the <gi>text</gi> element; it is
-      however good practice to put them all in the same place (e.g. a separate section of the front
-      or back matter), as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples"
-         ><back><div type="Interpretations">
-         <p><interp xml:id="fig-apos-1" resp="#LB-MSM" type="figureOfSpeech"
-           >apostrophe</interp><interp xml:id="fig-hyp-1" resp="#LB-MSM" type="figureOfSpeech"
-           >hyperbole</interp><interp xml:id="set-church-1" resp="#LB-MSM" type="setting"
-           >church</interp><interp xml:id="ref-church-1" resp="#LB-MSM" type="reference"
-           >church</interp><interp xml:id="ref-serv-1" resp="#LB-MSM" type="reference"
-           >servants</interp></p>
-        </div></back></egXML></p>
-     <p>The evident redundancy of this encoding can be considerably reduced by using the
-       <gi>interpGrp</gi> element to group together all those <gi>interp</gi> elements which share
-      common attribute values, as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples"
-         ><back><div type="Interpretations">
-         <p><interpGrp type="figureOfSpeech" resp="#LB-MSM"><interp xml:id="fig-apos"
-            >apostrophe</interp><interp xml:id="fig-hyp">hyperbole</interp><interp xml:id="fig-meta"
-            >metaphor</interp></interpGrp><interpGrp type="scene-setting" resp="#LB-MSM"><interp
-            xml:id="set-church">church</interp><interp xml:id="set-kitch">kitchen</interp><interp
-            xml:id="set-unspec">unspecified</interp></interpGrp><interpGrp type="reference"
-           resp="#LB-MSM"><interp xml:id="ref-church">church</interp><interp xml:id="ref-serv"
-            >servants</interp><interp xml:id="ref-cook">cooking</interp></interpGrp></p>
-        </div></back></egXML></p>
-     <p>Once these interpretation elements have been defined, they can be linked with the parts of
-      the text to which they apply in either or both of two ways. The <att>ana</att> attribute can
-      be used on whichever element is appropriate: <egXML xmlns="http://www.tei-c.org/ns/Examples"
-        ><div type="chapter" n="38">
-        <p xml:id="P38.1" ana="#set-church #set-kitch"><s xml:id="P38.1.1" ana="#fig-apos">Reader, I
-          married him.</s></p>
-       </div></egXML> Note in this example that since the paragraph has two settings (in the church
-      and in the kitchen), the identifiers of both have been supplied.</p>
-     <p>Alternatively, the <gi>interp</gi> elements can point to all the parts of the text to which
-      they apply, using their <att>inst</att> attribute: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><interp xml:id="fig-apos-2" type="figureOfSpeech"
-        resp="#LB-MSM" inst="#P38.1.1">apostrophe</interp><interp xml:id="set-church-2"
-        type="scene-setting" inst="#P38.1" resp="#LB-MSM">church</interp><interp
-        xml:id="set-kitchen-2" type="scene-setting" inst="#P38.1" resp="#LB-MSM"
-       >kitchen</interp></egXML></p>
-     <p>The <gi>interp</gi> element is not limited to any particular type of analysis. The literary
-      analysis shown above is but one possibility; one could equally well use <gi>interp</gi> to
-      capture a linguistic part-of-speech analysis. For example, the example sentence given in
-      section <ptr target="#xatts"/> assumes a linguistic analysis which might be represented as
-      follows: <egXML xmlns="http://www.tei-c.org/ns/Examples"><interp xml:id="NP1" type="pos">noun
-        phrase, singular</interp><interp xml:id="VV1" type="pos">inflected verb, present-tense
-        singular</interp> ... </egXML></p>
-    </div>
-   </div>
-   <div xml:id="U5-techdoc">
-    <head>Technical Documentation</head>
-    <p>Although the focus of this document is on the use of the TEI scheme for the encoding of
-     existing <soCalled>pre-electronic</soCalled> documents, the same scheme may also be used for
-     the encoding of new documents. In the preparation of new documents (such as this one), XML has
-     much to recommend it: the document's structure can be clearly represented, and the same
-     electronic text can be re-used for many purposes — to provide both online hypertext or
-     browsable versions and well-formatted typeset versions from a common source for example. </p>
-    <p>To facilitate this, the TEI Lite schema includes some elements for marking features of
-     technical documents in general, and of XML-related documents in particular.</p>
-    <div>
-     <head>Additional Elements for Technical Documents</head>
-     <p>The following elements may be used to mark particular features of technical documents: <specList>
-       <specDesc key="eg"/>
-       <specDesc key="code"/>
-       <specDesc key="ident"/>
-       <specDesc key="gi"/>
-       <specDesc key="att"/>
-       <specDesc key="formula"/>
-       <specDesc key="val"/>
-      </specList></p>
-     <p>The following example shows how these elements might be used to encode a passage from a
-      tutorial introducing the Fortran programming language: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><p>It is traditional to introduce a language with a
-        program like the following: <eg xml:space="preserve"> CHAR*12 GRTG
-GRTG = 'HELLO WORLD' 
-PRINT *, GRTG 
-END
-        </eg></p><p>This simple example first declares a variable <ident>GRTG</ident>, in the line
-         <code>CHAR*12 GRTG</code>, which identifies <ident>GRTG</ident> as consisting of 12 bytes
-        of type <ident>CHAR</ident>. To this variable, the value <val>HELLO WORLD</val> is then
-        assigned.</p></egXML></p>
-     <p>A formatting application, given a text like that above, can be instructed to format examples
-      appropriately (e.g. to preserve line breaks, or to use a distinctive font). Similarly, the use
-      of tags such as <gi>ident</gi> greatly facilitates the construction of a useful index.</p>
-     <p>The <gi>formula</gi> element should be used to enclose a mathematical or chemical formula
-      presented within the text as a distinct item. Since formulae generally include a large variety
-      of special typographic features not otherwise present in ordinary text, it will usually be
-      necessary to present the body of the formula in a specialized notation. The notation used
-      should be specified by the <att>notation</att> attribute, as in the following example: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><formula notation="tex"> \begin{math}E =
-        mc^{2}\end{math} </formula></egXML></p>
-     <p>A particular problem arises when XML encoding is the subject of discussion within a
-      technical document, itself encoded in XML. In such a document, it is clearly essential to
-      distinguish clearly the markup occurring within examples from that marking up the document
-      itself, and end-tags are highly likely to occur. One simple solution is to use the predefined
-      entity reference <code>&amp;lt;</code> to represent each &lt; character which marks the start
-      of an XML tag within the examples. A more general solution is to mark off the whole body of
-      each example as containing data which is not to be scanned for XML mark-up by the parser. This
-      is achieved by enclosing it within a special XML construct called a <term><code>CDATA</code>
-       marked section</term>, as in the following example: <eg xml:space="preserve">&lt;p&gt;A list should be encoded as
-       follows: &lt;eg&gt;&lt;![ CDATA [ &lt;list&gt; &lt;item&gt;First item in the
-       list&lt;/item&gt; &lt;item&gt;Second item&lt;/item&gt; &lt;/list&gt; ]]&gt; &lt;/eg&gt; The
-       &lt;gi&gt;list&lt;/gi&gt; element consists of a series of &lt;gi&gt;item&lt;/gi&gt;
-       elements.</eg></p>
-     <p>The <gi>list</gi> element used within the example above will not be regarded as forming part
-      of the document proper, because it is embedded within a marked section (beginning with the
-      special markup declaration <val>&lt;![CDATA[ </val>, and ending with <val>]]&gt;</val>).</p>
-     <p>Note also the use of the <gi>gi</gi> element to tag references to element names (or
-       <term>generic identifiers</term>) within the body of the text.</p>
-    </div>
-    <div>
-     <head>Generated Divisions</head>
-     <p>Most modern document production systems have the ability to generate automatically whole
-      sections such as a table of contents or an index. The TEI Lite scheme provides an element to
-      mark the location at which such a generated section should be placed. <specList>
-       <specDesc key="divGen"/>
-      </specList></p>
-     <p>The <gi>divGen</gi> element can be placed anywhere that a division element would be legal,
-      as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><front>
-        <titlePage>
-         <!-- ... -->
-        </titlePage>
-        <divGen type="toc"/>
-        <div>
-         <head>Preface</head>
-         <!-- ... -->
-        </div>
-       </front><body>
-        <!-- ... -->
-       </body><back><div>
-         <head>Appendix</head>
-         <!-- ... -->
-        </div><divGen type="index" n="Index"/></back></egXML></p>
-     <p>This example also demonstrates the use of the <att>type</att> attribute to distinguish the
-      different kinds of division to be generated: in the first case a table of contents (a
-       <mentioned>toc</mentioned>) and in the second an index.</p>
-     <p>When an existing index or table of contents is to be encoded (rather than one being
-      generated) for some reason, the <gi>list</gi> element discussed in section <ptr
-       target="#U5-lists"/> should be used. </p>
-    </div>
-    <div xml:id="indexing">
-     <head>Index Generation</head>
-     <p>While production of a table of contents from a properly tagged document is generally
-      unproblematic for an automatic processor, the production of a good quality index will often
-      require more careful tagging. It may not be enough simply to produce a list of all parts
-      tagged in some particular way, although extracting (for example) all occurrences of elements
-      such as <gi>term</gi> or <gi>name</gi> will often be a good departure point for an index. </p>
-     <p>The TEI schema provides a special purpose <gi>index</gi> tag which may be used to mark both
-      the parts of the document which should be indexed, and how the indexing should be done. <specList>
-       <specDesc key="index"/>
-      </specList></p>
-     <p>For example, the second paragraph of this section might include the following:<egXML
-       xmlns="http://www.tei-c.org/ns/Examples">... TEI lite also provides a special purpose
-        <gi>index</gi> tag <index><term>indexing</term></index>
-       <index><term>index (tag)</term><index><term>use in index generation</term></index></index>
-       which may be used ...</egXML></p>
-     <p>The <gi>index</gi> element can also be used to provide a form of interpretive or analytic
-      information. For example, in a study of Ovid, it might be desired to record all the poet's
-      references to different figures, for comparative stylistic study. In the following lines of
-      the <title>Metamorphoses</title>, such a study would record the poet's references to Jupiter
-      (as <mentioned>deus</mentioned>, <mentioned>se</mentioned>, and as the subject of
-       <mentioned>confiteor</mentioned> [in inflectional form number 227]), to
-      Jupiter-in-the-guise-of-a-bull (as <mentioned>imago tauri fallacis</mentioned> and the subject
-      of <mentioned>teneo</mentioned>), and so on.<note place="foot">The analysis is taken, with
-       permission, from Willard McCarty and Burton Wright, <title>An Analytical Onomasticon to the
-        Metamorphoses of Ovid</title> (Princeton: Princeton University Press, forthcoming). Some
-       simplifications have been undertaken.</note>
-      <egXML xmlns="http://www.tei-c.org/ns/Examples"><l n="3.001">iamque deus posita fallacis
-        imagine tauri</l><l n="3.002">se confessus erat Dictaeaque rura tenebat</l></egXML> This
-      need might be met using the <gi>note</gi> element discussed in section in <ptr
-       target="#U5-notes"/>, or with the <gi>interp</gi> element discussed in section <ptr
-       target="#U5-anal"/>. Here we demonstrate how it might also be satisfied by using the
-       <gi>index</gi> element.</p>
-     <p>We assume that the object is to generate more than one index: one for names of deities
-      (called <att>dn</att>), another for onomastic references (called <att>on</att>), a third for
-      pronominal references (called <att>pr</att>) and so forth. One way of achieving this might be
-      as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples"><l n="3.001">iamque deus posita
-        fallacis imagine tauri <index indexName="dn"
-          ><term>Iuppiter</term><index><term>deus</term></index></index>
-        <index indexName="on"><term>Iuppiter (taurus)</term><index><term>imago tauri
-          fallacis</term></index></index></l><l n="3.002">se confessus erat Dictaeaque rura tenebat
-         <index indexName="pr"><term>Iuppiter</term><index><term>se</term></index></index>
-        <index indexName="v"><term>Iuppiter</term><index><term>confiteor
-         (v227)</term></index></index></l></egXML> For each <gi>index</gi> element above, an entry
-      will be generated in the appropriate index, using as headword the content of the <gi>term</gi>
-      element it contains; the <gi>term</gi> elements nested within the secondary <gi>index</gi>
-      element in each case provide a secondary keyword. The actual reference will be taken from the
-      context in which the <gi>index</gi> element appears, i.e. in this case the identifier of the
-       <gi>l</gi> element containing it. </p>
-    </div>
-    <div>
-     <head>Addresses</head>
-     <p>The <gi>address</gi> element is used to mark a postal address of any kind. It contains one
-      or more <gi>addrLine</gi> elements, one for each line of the address. <specList>
-       <specDesc key="address"/>
-       <specDesc key="addrLine"/>
-      </specList>
-     </p>
-     <p>Here is a simple example: <egXML xmlns="http://www.tei-c.org/ns/Examples"
-       ><address><addrLine>Computer Center (M/C 135)</addrLine><addrLine>1940 W. Taylor, Room 124</addrLine><addrLine>Chicago, IL 60612-7352</addrLine><addrLine>U.S.A.</addrLine></address></egXML></p>
-     <p>The individual parts of an address may be further distinguished by using the <gi>name</gi>
-      element discussed above (section <ptr target="#nomen"/>). <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"
-       ><address><addrLine>Computer Center (M/C 135)</addrLine><addrLine>1940 W. Taylor, Room 124</addrLine><addrLine><name type="city">Chicago</name>, IL 60612-7352</addrLine><addrLine><name type="country">USA</name></addrLine></address></egXML></p>
-    </div>
-   </div>
-   <div xml:id="U5-chars">
-    <head>Character Sets, Diacritics, etc.</head>
-    <p>With the advent of XML and its adoption of Unicode as the required character set for all
-     documents, most problems previously associated with the representation of the divers languages
-     and writing systems of the world are greatly reduced. For those working with standard forms of
-     the European languages in particular, almost no special action is needed: any XML editor should
-     enable you to input accented letters or other <soCalled>non-ASCII</soCalled> characters
-     directly, and they should be stored in the resulting file in a way which is transferable
-     directly between different systems. </p>
-    <p>There are two important exceptions: the characters &amp; and &lt; may not be entered directly
-     in an XML document, since they have a special significance as initiating markup. They must
-     always be represented as <term>entity references</term>, like this: <code>&amp;amp;</code> or
-      <code>&amp;lt;</code>. Other characters may also be represented by means of entity reference
-     where necessary, for example to retain compatibility with a pre-Unicode processing system. </p>
-   </div>
-   <div xml:id="U5-fronbac">
-    <head>Front and Back Matter</head>
-    <div>
-     <head>Front Matter</head>
-     <p>For many purposes, particularly in older texts, the preliminary material such as title
-      pages, prefatory epistles, etc., may provide very useful additional linguistic or social
-      information. P5 provides a set of recommendations for distinguishing the textual elements most
-      commonly encountered in front matter, which are summarized here.</p>
-     <div xml:id="h51">
-      <head>Title Page</head>
-      <p>The start of a title page should be marked with the element <gi>titlePage</gi>. All text
-       contained on the page should be transcribed and tagged with the appropriate element from the
-       following list: <specList>
-        <specDesc key="titlePage"/>
-        <specDesc key="docTitle"/>
-        <specDesc key="titlePart"/>
-        <specDesc key="byline"/>
-        <specDesc key="docAuthor"/>
-        <specDesc key="docDate"/>
-        <specDesc key="docEdition"/>
-        <specDesc key="docImprint"/>
-        <specDesc key="epigraph"/>
-       </specList></p>
-      <p>Typeface distinctions should be marked with the <att>rend</att> attribute when necessary,
-       as described above. Very detailed description of the letter spacing and sizing used in
-       ornamental titles is not as yet provided for by the Guidelines. Changes of language should be
-       marked by appropriate use of the <att>xml:lang</att> attribute or the <gi>foreign</gi>
-       element, as necessary. Names of people, places, or organizations, may be tagged using the
-        <gi>name</gi> element wherever they appear if no other more specific element is
-       available.</p>
-      <p>Two example title pages follow: <egXML xmlns="http://www.tei-c.org/ns/Examples"><titlePage
-         rend="Roman">
-         <docTitle>
-          <titlePart type="main"> PARADISE REGAIN'D. A POEM In IV <hi>BOOKS</hi>. </titlePart>
-          <titlePart> To which is added <title>SAMSON AGONISTES</title>. </titlePart>
-         </docTitle>
-         <byline>The Author <docAuthor>JOHN MILTON</docAuthor></byline>
-         <docImprint><name>LONDON</name>, Printed by <name>J.M.</name> for <name>John Starkey</name>
-          at the <name>Mitre</name> in <name>Fleetstreet</name>, near
-          <name>Temple-Bar.</name></docImprint>
-         <docDate>MDCLXXI</docDate>
-        </titlePage></egXML><egXML xmlns="http://www.tei-c.org/ns/Examples"><titlePage>
-         <docTitle>
-          <titlePart type="main"> Lives of the Queens of England, from the Norman
-           Conquest;</titlePart>
-          <titlePart type="sub">with anecdotes of their courts. </titlePart>
-         </docTitle>
-         <titlePart>Now first published from Official Records and other authentic documents private
-          as well as public.</titlePart>
-         <docEdition>New edition, with corrections and additions</docEdition>
-         <byline>By <docAuthor>Agnes Strickland</docAuthor></byline>
-         <epigraph>
-          <q>The treasures of antiquity laid up in old historic rolls, I opened.</q>
-          <bibl>BEAUMONT</bibl>
-         </epigraph>
-         <docImprint>Philadelphia: Blanchard and Lea</docImprint>
-         <docDate>1860.</docDate>
-        </titlePage></egXML></p>
-      <p>As elsewhere, the <att>ref</att> attribute may be used to link a name with a canonical
-       definition of the entity being named. For example: <egXML
-        xmlns="http://www.tei-c.org/ns/Examples">
-        <byline>By <docAuthor><name ref="http://en.wikipedia.org/wiki/Agnes_Strickland">Agnes
-           Strickland</name></docAuthor></byline>
-       </egXML></p>
-     </div>
-     <div xml:id="h52">
-      <head>Prefatory Matter</head>
-      <p>Major blocks of text within the front matter should be marked using
-        <gi>div</gi> elements; the following suggested values for the <att>type</att> attribute may
-       be used to distinguish various common types of prefatory matter: <list type="gloss">
-        <label>preface</label>
-        <item>A foreword or preface addressed to the reader in which the author or publisher
-         explains the content, purpose, or origin of the text</item>
-        <label>dedication</label>
-        <item>A formal offering or dedication of a text to one or more persons or institutions by
-         the author.</item>
-        <label>abstract</label>
-        <item>A summary of the content of a text as continuous prose</item>
-        <label>ack</label>
-        <item>A formal declaration of acknowledgment by the author in which persons and institutions
-         are thanked for their part in the creation of a text</item>
-        <label>contents</label>
-        <item>A table of contents, specifying the structure of a work and listing its constituents.
-         The <gi>list</gi> element should be used to mark its structure.</item>
-        <label>frontispiece</label>
-        <item>A pictorial frontispiece, possibly including some text.</item>
-       </list></p>
-      <p>Where other kinds of prefatory matter are encountered, the encoder is at liberty to invent
-       other values for the <att>type</att> attribute.</p>
-      <p>Like any text division, those in front matter may contain low level structural or
-       non-structural elements as described elsewhere. They will generally begin with a heading or
-       title of some kind which should be tagged using the <gi>head</gi> element. Epistles will
-       contain the following additional elements: <specList>
-        <specDesc key="salute"/>
-        <specDesc key="signed"/>
-        <specDesc key="byline"/>
-        <specDesc key="dateline"/>
-        <specDesc key="argument"/>
-        <specDesc key="cit"/>
-	<specDesc key="imprimatur"/>
-        <specDesc key="opener"/>
-        <specDesc key="closer"/>
-       </specList></p>
-      <p> Epistles which appear elsewhere in a text will, of course, contain these same
-       elements.</p>
-      <p>As an example, the dedication at the start of Milton's <title>Comus</title> should be
-       marked up as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-        <div type="dedication">
-         <head>To the Right Honourable <name>JOHN Lord Viscount BRACLY</name>, Son and Heir apparent
-          to the Earl of Bridgewater, &amp;c.</head>
-         <salute>MY LORD,</salute>
-         <p>THis <hi>Poem</hi>, which receiv'd its first occasion of Birth from your Self, and
-          others of your Noble Family .... and as in this representation your attendant
-           <name>Thyrsis</name>, so now in all reall expression</p>
-         <closer>
-          <salute>Your faithfull, and most humble servant</salute>
-          <signed>
-           <name>H. LAWES.</name>
-          </signed>
-         </closer>
-        </div></egXML></p>
-     </div>
-    </div>
-    <div>
-     <head>Back Matter</head>
-     <div>
-      <head>Structural Divisions of Back Matter</head>
-      <p>Because of variations in publishing practice, back matter can contain virtually any of the
-       elements listed above for front matter, and the same elements should be used where this is
-       so. Additionally, back matter may contain the following types of matter within the
-        <gi>back</gi> element. Like the structural divisions of the body, these should be marked as
-        <gi>div</gi> elements, and distinguished by the following suggested values of the
-        <att>type</att> attribute: <list type="gloss">
-        <label>appendix</label>
-        <item>An ancillary self-contained section of a work, often providing additional but in some
-         sense extra-canonical text.</item>
-        <label>glossary</label>
-        <item>A list of terms associated with definition texts (‘glosses’): this should be encoded
-         as a <tag>&lt;list type="gloss"></tag> element</item>
-        <label>notes</label>
-        <item>A section in which textual or other kinds of notes are gathered together.</item>
-        <label>bibliogr</label>
-        <item>A list of bibliographic citations: this should be encoded as a <gi>listBibl</gi>
-        </item>
-        <label>index</label>
-        <item>Any form of pre-existing index to the work (An index may also be generated for a
-         document by using the <gi>index</gi> element described above).</item>
-        <label>colophon</label>
-        <item>A statement appearing at the end of a book describing the conditions of its physical
-         production.</item>
-       </list></p>
-     </div>
-    </div>
-   </div>
-   <div xml:id="U5-header">
-    <head>The Electronic Title Page</head>
-    <p>Every TEI text has a header which provides information analogous to that provided by the
-     title page of printed text. The header is introduced by the element <gi>teiHeader</gi> and has
-     four major parts: <specList>
-      <specDesc key="fileDesc"/>
-      <specDesc key="encodingDesc"/>
-      <specDesc key="profileDesc"/>
-      <specDesc key="revisionDesc"/>
-     </specList></p>
-    <p> A corpus or collection of texts with many shared characteristics may have one header for
-     the corpus and individual headers for each component of the corpus. In this case the
-      <att>type</att> attribute indicates the type of header. <code>&lt;teiHeader
-      type="corpus"&gt;</code> introduces the header for corpus-level information.</p>
-    <p>Some of the header elements contain running prose which consists of one or more <gi>p</gi>s.
-     Others are grouped: <list>
-      <item>Elements whose names end in <mentioned>Stmt</mentioned> (for statement) usually enclose a
-       group of elements recording some structured information.</item>
-      <item>Elements whose names end in <mentioned>Decl</mentioned> (for declaration) enclose
-       information about specific encoding practices.</item>
-      <item>Elements whose names end in <mentioned>Desc</mentioned> (for description) contain a
-       prose description.</item>
-     </list></p>
-    <div>
-     <head>The File Description</head>
-     <p>The <gi>fileDesc</gi> element is mandatory. It contains a full bibliographic description of
-      the file with the following elements: <specList>
-       <specDesc key="titleStmt"/>
-       <specDesc key="editionStmt"/>
-       <specDesc key="extent"/>
-       <specDesc key="publicationStmt"/>
-       <specDesc key="seriesStmt"/>
-       <specDesc key="notesStmt"/>
-       <specDesc key="sourceDesc"/>
-      </specList></p>
-     <p> A minimal header has the following structure: <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><teiHeader>
-        <fileDesc>
-         <titleStmt>
-          <!-- bibliographic description of the digital resource -->
-         </titleStmt>
-         <publicationStmt>
-          <!-- information about how the resource is distributed -->
-         </publicationStmt>
-         <sourceDesc>
-          <!-- information about the sources from which the digital resource is derived -->
-         </sourceDesc>
-        </fileDesc>
-       </teiHeader></egXML></p>
-     <div>
-      <head>The Title Statement</head>
-      <p>The following elements can be used in the <gi>titleStmt</gi>: <specList>
-        <specDesc key="title"/>
-        <specDesc key="author"/>
-        <specDesc key="sponsor"/>
-        <specDesc key="funder"/>
-        <specDesc key="principal"/>
-        <specDesc key="respStmt"/>
-       </specList></p>
-      <p> The title of a digital resource derived from a non-digital one will obviously be similar.
-       However, it is important to distinguish the title of the computer file from that of the
-       source text, for example: <eg>[title of source]: a machine readable transcription [title of
-        source]: electronic edition A machine readable version of: [title of source]</eg> The
-        <gi>respStmt</gi> element contains the following subcomponents: <specList>
-        <specDesc key="resp"/>
-        <specDesc key="name"/>
-       </specList> Example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><titleStmt>
-         <title>Two stories by Edgar Allen Poe: a machine readable transcription</title>
-         <author>Poe, Edgar Allen (1809-1849)</author>
-         <respStmt>
-          <resp>compiled by</resp>
-          <name>James D. Benson</name>
-         </respStmt>
-        </titleStmt></egXML></p>
-     </div>
-     <div>
-      <head>The Edition Statement</head>
-      <p>The <gi>editionStmt</gi> groups information relating to one edition of the digital resource
-       (where <mentioned>edition</mentioned> is used as elsewhere in bibliography), and may include
-       the following elements: <specList>
-        <specDesc key="edition"/>
-        <specDesc key="respStmt"/>
-       </specList></p>
-      <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><editionStmt><edition n="U2">Third
-          draft, substantially revised <date>1987</date>
-         </edition></editionStmt></egXML></p>
-      <p>Determining exactly what constitutes a new edition of an electronic text is left to the
-       encoder.</p>
-     </div>
-     <div>
-      <head>The Extent Statement</head>
-      <p>The <gi>extent</gi> statement describes the approximate size of the digital resource.</p>
-      <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><extent>4532
-        bytes</extent></egXML></p>
-     </div>
-     <div>
-      <head>The Publication Statement</head>
-      <p>The <gi>publicationStmt</gi> is mandatory. It may contain a simple prose description or
-       groups of the elements described below: <specList>
-        <specDesc key="publisher"/>
-        <specDesc key="distributor"/>
-        <specDesc key="authority"/>
-       </specList></p>
-      <p>At least one of these three elements must be present, unless the entire publication
-       statement is in prose. The following elements may occur within them: <specList>
-        <specDesc key="pubPlace"/>
-        <specDesc key="address"/>
-        <specDesc key="idno"/>
-        <specDesc key="availability"/>
-        <specDesc key="licence"/>
-        <specDesc key="date"/>
-       </specList></p>
-      <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><publicationStmt>
-         <publisher>University of Victoria Humanities Computing and Media Centre</publisher>
-         <pubPlace>Victoria, BC</pubPlace>
-         <date>2011</date>
-         <availability status="restricted">
-          <licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a
-           Creative Commons Attribution-ShareAlike 3.0 Unported License </licence>
-         </availability>
-        </publicationStmt></egXML></p>
-     </div>
-     <div>
-      <head>Series and Notes Statements</head>
-      <p>The <gi>seriesStmt</gi> element groups information about the series, if any, to which a
-       publication belongs. It may contain <gi>title</gi>, <gi>idno</gi>, or <gi>respStmt</gi>
-       elements.</p>
-      <p>The <gi>notesStmt</gi>, if used, contains one or more <gi>note</gi> elements which contain
-       a note or annotation. Some information found in the notes area in conventional bibliography
-       has been assigned specific elements in the TEI scheme.</p>
-     </div>
-     <div>
-      <head>The Source Description</head>
-      <p>The <gi>sourceDesc</gi> is a mandatory element which records details of the source or
-       sources from which the computer file is derived. It may contain simple prose or a
-       bibliographic citation, using one or more of the following elements: <specList>
-        <specDesc key="bibl"/>
-        <specDesc key="listBibl"/>
-       </specList></p>
-      <p>Examples: <egXML xmlns="http://www.tei-c.org/ns/Examples"><sourceDesc>
-         <bibl>The first folio of Shakespeare, prepared by Charlton Hinman (The Norton Facsimile,
-          1968)</bibl>
-        </sourceDesc></egXML>
-       <egXML xmlns="http://www.tei-c.org/ns/Examples"><sourceDesc>
-         <bibl><author>CNN Network News</author><title>News headlines</title><date>12 Jun
-           1989</date></bibl>
-        </sourceDesc></egXML></p>
-     </div>
-    </div>
-    <div>
-     <head>The Encoding Description</head>
-     <p>The <gi>encodingDesc</gi> element specifies the methods and editorial principles which
-      governed the transcription of the text. Its use is highly recommended. It may be prose
-      description or may contain elements from the following list: <specList>
-       <specDesc key="projectDesc"/>
-       <specDesc key="samplingDecl"/>
-       <specDesc key="editorialDecl"/>
-       <specDesc key="refsDecl"/>
-       <specDesc key="classDecl"/>
-      </specList></p>
-     <div>
-      <head>Project and Sampling Descriptions</head>
-      <p>Examples of <gi>projectDesc</gi> and <gi>samplingDesc</gi>: <egXML
-        xmlns="http://www.tei-c.org/ns/Examples"><encodingDesc><projectDesc><p>Texts collected for
-           use in the Claremont Shakespeare Clinic, June 1990.
-        </p></projectDesc></encodingDesc></egXML>
-       <egXML xmlns="http://www.tei-c.org/ns/Examples"><encodingDesc><samplingDecl><p>Samples of
-           2000 words taken from the beginning of the text</p>
-         </samplingDecl></encodingDesc></egXML></p>
-     </div>
-     <div>
-      <head>Editorial Declarations</head>
-      <p>The <gi>editorialDecl</gi> contains a prose description of the practices used when encoding
-       the text. Typically this description should cover such topics as the following, each of which
-       may conveniently be given as a separate paragraph. <list type="gloss">
-        <label>correction </label>
-        <item>how and under what circumstances corrections have been made in the text.</item>
-        <label>normalization</label>
-        <item>the extent to which the original source has been regularized or normalized.</item>
-        <label>quotation</label>
-        <item>what has been done with quotation marks in the original -- have they been retained or
-         replaced by entity references, are opening and closing quotes distinguished, etc. </item>
-        <label>hyphenation</label>
-        <item>what has been done with hyphens (especially end-of-line hyphens) in the original --
-         have they been retained, replaced by entity references, etc.</item>
-        <label>segmentation</label>
-        <item>how has the text has been segmented, for example into sentences, tone-units, graphemic
-         strata, etc.</item>
-        <label>interpretation</label>
-        <item>what analytic or interpretive information has been added to the text. </item>
-       </list></p>
-      <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><editorialDecl><p>The part of
-          speech analysis applied throughout section 4 was added by hand and has not been
-          checked.</p><p>Errors in transcription controlled by using the WordPerfect spelling
-          checker.</p><p>All words converted to Modern American spelling using Webster's 9th
-          Collegiate dictionary.</p></editorialDecl></egXML></p>
-     </div>
-     <div xml:id="refsdecl">
-      <head>Reference and Classification Declarations</head>
-      <p>The <gi>refsDecl</gi> element is used to document the way in which any standard referencing
-       scheme built into the encoding works. In its simplest form, it consists of prose
-       description.</p>
-      <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><refsDecl><p>The <att>n</att>
-          attribute on each <gi>div</gi> contains the canonical reference for each division in the
-          form XX.yyy where XX is the book number in roman numeral and yyy is the section number in
-          arabic.</p><p>Milestone tags refer to the edition of 1830 as E30 and that of 1850 as E50.
-         </p></refsDecl></egXML></p>
-      <p>The <gi>classDecl</gi> element groups together definitions or sources for any descriptive
-       classification schemes used by other parts of the header. At least one such scheme must be
-       provided, encoded using the following elements: <specList>
-        <specDesc key="taxonomy"/>
-        <specDesc key="bibl"/>
-        <specDesc key="category"/>
-        <specDesc key="catDesc"/>
-       </specList></p>
-      <p> In the simplest case, the taxonomy may be defined by a bibliographic reference, as in the
-       following example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><classDecl><taxonomy
-          xml:id="LC-SH"><bibl>Library of Congress Subject Headings
-        </bibl></taxonomy></classDecl></egXML></p>
-      <p>Alternatively, or in addition, the encoder may define a special purpose classification
-       scheme, as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples"
-         ><taxonomy xml:id="B"><bibl>Brown Corpus</bibl><category xml:id="B.A"><catDesc>Press
-           Reportage</catDesc><category xml:id="B.A1"><catDesc>Daily</catDesc></category><category
-           xml:id="B.A2"><catDesc>Sunday</catDesc></category><category xml:id="B.A3"
-            ><catDesc>National</catDesc></category><category xml:id="B.A4"
-            ><catDesc>Provincial</catDesc></category><category xml:id="B.A5"
-            ><catDesc>Political</catDesc></category><category xml:id="B.A6"
-            ><catDesc>Sports</catDesc></category></category><category xml:id="B.D"
-           ><catDesc>Religion</catDesc><category xml:id="B.D1"
-           ><catDesc>Books</catDesc></category><category xml:id="B.D2"><catDesc>Periodicals and
-            tracts</catDesc></category></category>
-        </taxonomy></egXML></p>
-      <p>Linkage between a particular text and a category within such a taxonomy is made by means of
-       the <gi>catRef</gi> element within the <gi>textClass</gi> element, as described in the next
-       section below.</p>
-     </div>
-    </div>
-    <div>
-     <head>The Profile Description</head>
-     <p>The <gi>profileDesc</gi> element enables information characterizing various descriptive
-      aspects of a text to be recorded within a single framework. It has three optional components: <specList>
-       <specDesc key="creation"/>
-       <specDesc key="langUsage"/>
-       <specDesc key="textClass"/>
-      </specList></p>
-     <p>The <gi>creation</gi> element is useful for documenting where a work was created, even
-      though it may not have been published or recorded there.</p>
-     <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><creation><date when="1992-08"
-         >August 1992</date><name type="place">Taos, New Mexico</name></creation></egXML></p>
-     <p>The <gi>langUsage</gi> element is useful where a text contains many different languages. It
-      may contain <gi>language</gi> elements to document each particular language used: <specList>
-       <specDesc key="language"/>
-      </specList> For example, a text containing predominantly text in French as spoken in Quebec,
-      but also smaller amounts of British and Canadian English might be documented as follows:
-       <egXML xmlns="http://www.tei-c.org/ns/Examples"><langUsage>
-        <language ident="fr-CA" usage="60">Québecois</language>
-        <language ident="en-CA" usage="20">Canadian business English</language>
-        <language ident="en-GB" usage="20">British English</language>
-       </langUsage>
+	</p>
+	<p>Where the internal structure of a list item is more complex, it may be preferable to regard
+	the list as a <term>table</term>, for which special-purpose tagging is defined below (<ptr target="#U5-tables"/>). </p>
+	<p>Lists of whatever kind can, of course, nest within list items to any depth required. Here,
+	for example, a glossary list contains two items, each of which is itself a simple list: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	<list type="gloss">
+	  <label>EVIL</label>
+	  <item>
+	    <list type="simple">
+	      <item>I am cast upon a horrible desolate island, void of all hope of recovery.</item>
+	      <item>I am singled out and separated as it were from all the world to be miserable.</item>
+	      <item>I am divided from mankind — a solitaire; one banished from human society.</item>
+	    </list>
+	  </item>
+	  <label>GOOD</label>
+	  <item>
+	    <list type="simple">
+	      <item>But I am alive; and not drowned, as all my ship's company were.</item>
+	      <item>But I am singled out, too, from all the ship's crew, to be spared from
+	      death...</item>
+	      <item>But I am not starved, and perishing on a barren place, affording no
+	      sustenances....</item>
+	    </list>
+	  </item>
+	</list>
       </egXML>
-     </p>
-     <p>The <gi>textClass</gi> element classifies a text. This may be done with reference to a
-      classification system locally defined by means of the <gi>classDecl</gi> element, or by
-      reference to some externally defined established scheme such as the Universal Decimal
-      Classification. Texts may also be classified using lists of keywords, which may themselves be
-      drawn from locally or externally defined control lists. The following elements are used to
-      supply such classifications: <specList>
-       <specDesc key="classCode"/>
-       <specDesc key="catRef"/>
-       <specDesc key="keywords"/>
+	</p>
+	<p>A list need not necessarily be displayed in list format. For example, <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	<p>On those remote pages it is written that animals
+	are divided into <list rend="run-on">
+	<item n="a">those that belong to the Emperor,</item>
+	<item n="b"> embalmed ones, </item>
+	<item n="c"> those that are trained, </item>
+	<item n="d"> suckling pigs, </item>
+	<item n="e"> mermaids, </item>
+	<item n="f"> fabulous ones, </item>
+	<item n="g"> stray dogs, </item>
+	<item n="h"> those that are included in this classification, </item>
+	<item n="i"> those that tremble as if they were mad, </item>
+	<item n="j"> innumerable ones, </item>
+	<item n="k"> those drawn with a very fine camel's-hair brush, </item>
+	<item n="l"> others, </item>
+	<item n="m"> those that have just broken a flower vase, </item>
+	<item n="n"> those that resemble flies from a distance.</item>
+      </list>
+	</p>
+      </egXML>
+	</p>
+	<p>Lists of bibliographic items should be tagged using the <gi>listBibl</gi> element, described
+	in the next section.</p>
+      </div>
+      <div xml:id="U5-bibls">
+	<head>Bibliographic Citations</head>
+	<p>It is often useful to distinguish bibliographic citations where they occur within texts being
+	transcribed for research, if only so that they will be properly formatted when the text is
+	printed out. The element <gi>bibl</gi> is provided for this purpose. Where the components of a
+	bibliographic reference are to be distinguished, the following elements may be used as
+	appropriate. It is generally useful to mark at least those parts (such as the titles of
+	articles, books, and journals) which will need special formatting. The other elements are
+	provided for cases where particular interest attaches to such details. <specList>
+	<specDesc key="bibl"/>
+	<specDesc key="author"/>
+	<specDesc key="biblScope"/>
+	<specDesc key="date"/>
+	<specDesc key="editor"/>
+	<specDesc key="publisher"/>
+	<specDesc key="pubPlace"/>
+	<specDesc key="title"/>
       </specList>
-     </p>
-     <p>The simplest way of classifying a text is by means of the <gi>classCode</gi> element. For
-      example, a text with classification 410 in the Universal Decimal Classification might be
-      documented as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
-       <classCode scheme="http://www.udc.org">410</classCode>
+	</p>
+	<p>For example, the following editorial note might be transcribed as shown: <q rend="display">He
+	was a member of Parliament for Warwickshire in 1445, and died March 14, 1470 (according to
+	Kittredge, <title>Harvard Studies</title> 5. 88ff).</q>
+	<egXML xmlns="http://www.tei-c.org/ns/Examples">He was a member of Parliament for Warwickshire
+	in 1445, and died March 14, 1470 (according to <bibl>
+	<author>Kittredge</author>,
+	<title>Harvard Studies</title>
+	<biblScope>5. 88ff</biblScope>
+	</bibl>).</egXML>
+	</p>
+	<p>For lists of bibliographic citations, the <gi>listBibl</gi> element should be used; it may
+	contain a series of <gi>bibl</gi> elements. </p>
+      </div>
+      <div xml:id="U5-tables">
+	<head>Tables</head>
+	<p>Tables represent a challenge for any text processing system, but simple tables, at least,
+	appear in so many texts that even in the simplified TEI tag set presented here, markup for
+	tables is necessary. The following elements are provided for this purpose: <specList>
+	<specDesc key="table"/>
+	<specDesc key="row"/>
+	<specDesc key="cell"/>
+      </specList>
+	</p>
+	<p>For example, Defoe uses mortality tables like the following in the <title level="m">Journal
+	of the Plague Year</title> to show the rise and ebb of the epidemic:<egXML xmlns="http://www.tei-c.org/ns/Examples">
+	<p>It was indeed coming on amain, for the burials
+	that same week were in the next adjoining parishes thus:— <table rows="5" cols="4">
+	<row role="data">
+	  <cell role="label">St. Leonard's, Shoreditch</cell>
+	  <cell>64</cell>
+	  <cell>84</cell>
+	  <cell>119</cell>
+	</row>
+	<row role="data">
+	  <cell role="label">St. Botolph's, Bishopsgate</cell>
+	  <cell>65</cell>
+	  <cell>105</cell>
+	  <cell>116</cell>
+	</row>
+	<row role="data">
+	  <cell role="label">St. Giles's, Cripplegate</cell>
+	  <cell>213</cell>
+	  <cell>421</cell>
+	  <cell>554</cell>
+	</row>
+      </table>
+	</p>
+	<p>This shutting up of houses was at first counted a very cruel and unchristian
+	method, and the poor people so confined made bitter lamentations. ... </p>
       </egXML>
-     </p>
-     <p>When a classification scheme has been locally defined using the <gi>taxonomy</gi> element
-      discussed in the preceding subsection, the <gi>catRef</gi> element should be used to reference
-      it. To continue the earlier example, a work classified in the Brown Corpus as <code>Press
-       reportage - Sunday</code> and also as <code>Religion</code> might be documented as follows:
-       <egXML xmlns="http://www.tei-c.org/ns/Examples">
-       <catRef target="#B.A3 #B.D"/>
+	</p>
+      </div>
+      <div xml:id="U5-figs">
+	<head>Figures and Graphics</head>
+	<p>Not all the components of a document are necessarily textual. The most straightforward text
+	will often contain diagrams or illustrations, to say nothing of documents in which image and
+	text are inextricably intertwined, or electronic resources in which the two are complementary. </p>
+	<p>The encoder may simply record the presence of a graphic within the text, possibly with a
+	brief description of its content, and may also provide a link to a digitized version of the
+	graphic, using the following elements: <specList>
+	<specDesc key="graphic"/>
+	<specDesc key="figure"/>
+	<specDesc key="figDesc"/>
+      </specList>
+	</p>
+	<p>Any textual information accompanying the graphic, such as a heading and/or caption, may be
+	included within the <gi>figure</gi> element itself, in a <gi>head</gi> and one or more
+	<gi>p</gi> elements, as also may any text appearing within the graphic itself. It is strongly
+	recommended that a prose description of the image be supplied, as the content of a
+	<gi>figDesc</gi> element, for the use of applications which are not able to render the
+	graphic, and to render the document accessible to vision-impaired readers. (Such text is not
+	normally considered part of the document proper.)</p>
+	<p>The simplest use for these elements is to mark the position of a graphic and provide a link
+	to it, as in this example; <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	<pb n="412"/>
+	<figure>
+	  <graphic url="p412fig.png"/>
+	</figure>
+	<pb n="413"/>
+	</egXML> This indicates that the
+	graphic contained by the file <ident>p412fig.png</ident> appears between pages 412 and 413. </p>
+	<p>The <gi>graphic</gi> element can appear anywhere that textual content is permitted, within
+	but not between paragraphs or headings. In the following example, the encoder has decided to
+	treat a specific printer's ornament as a heading: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	<head>
+	  <graphic url="http://www.iath.virginia.edu/gants/Ornaments/Heads/hp-ral02.gif"/>
+	</head>
       </egXML>
-     </p>
-     <p>The element <gi>keywords</gi> contains a list of keywords or phrases identifying the topic
-      or nature of a text. As usual, the attribute <att>scheme</att> identifies the source from
-      which these terms are taken. For example, if the LC Subject Headings are used, following
-      declaration of that classification system in a <gi>taxonomy</gi> element as above : <egXML
-       xmlns="http://www.tei-c.org/ns/Examples"><textClass><keywords scheme="#LCSH"><list>
-          <item>English literature -- History and criticism -- Data processing.</item>
-          <item>English literature -- History and criticism -- Theory etc.</item>
-          <item>English language -- Style -- Data processing.</item>
-         </list></keywords></textClass></egXML></p><p>Multiple classifications may be supplied using
-      any of the mechanisms described in this section.</p>
-    </div>
-    <div>
-     <head>The Revision Description</head>
-     <p>The <gi>revisionDesc</gi> element provides a change log in which each change made to a text
-      may be recorded. The log may be recorded as a sequence of <gi>change</gi> elements each of
-      which contains a brief description of the change. The attributes <att>when</att> and
-       <att>who</att> may be used to identify when the change was carried out and the agency
-      responsible for it. </p>
-     <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples"><revisionDesc>
-        <change when="1991-03-06" who="#EMB">File format updated</change>
-        <change when="1990-05-25" who="#EMB">Stuart's corrections entered</change>
-       </revisionDesc></egXML></p>
-     <p>In a production environment it will usually be found preferable to use some kind of
-      automated system to track and record changes. Many such <term>version control systems</term>,
-      as they are known, can also be configured to update the TEI Header of a file automatically.
-     </p>
-    </div>
-   </div>
-  </body>
-  <back>
-   <div>
-    <head>List of Elements Described</head>
-    <p>The TEI Lite schema is a pure subset of TEI P5. In the following list of elements and classes
-     used, some information, notably the examples, derives from the canonical definition for the
-     element in TEI P5 and may therefore refer to elements or attributes not provided by TEI Lite.
-     Note however that only the elements listed here are available within the TEI Lite schema. These
-     specifications also refer to many attributes which although available in TEI Lite are not
-     discussed in this tutorial for lack of space. </p>
-    <schemaSpec ident="tei_lite" start="TEI teiCorpus">
-     <moduleRef key="tei"/>
-     <moduleRef key="core"
-      include="abbr add addrLine address author bibl biblScope choice cit corr date del desc divGen editor emph expan foreign gap gloss graphic head hi index item l label lb lg list listBibl  mentioned milestone name note num orig p pb ptr pubPlace publisher q ref reg relatedItem resp respStmt rs sic soCalled sp speaker stage teiCorpus term time title unclear"/>
-     <moduleRef key="header"
-      include="authority availability catDesc catRef category change classCode classDecl creation distributor edition editionStmt editorialDecl encodingDesc extent fileDesc funder idno keywords langUsage language licence notesStmt principal profileDesc projectDesc publicationStmt refsDecl revisionDesc samplingDecl seriesStmt sourceDesc sponsor taxonomy teiHeader textClass titleStmt"/>
-     <moduleRef key="textstructure"
-      include="TEI argument back body byline closer dateline div
-	       docAuthor docDate docEdition docImprint docTitle
-	       epigraph front group imprimatur opener postscript salute signed text titlePage titlePart trailer"/>
-     <moduleRef key="figures" include="cell figure figDesc formula row table"/>
-     <moduleRef key="linking" include="anchor seg"/>
-     <moduleRef key="analysis" include="interp interpGrp pc s w"/>
-     <moduleRef key="tagdocs" include="att code eg gi ident val"/>
-     <!-- this version is compiled against P5 2.1 and no other, so we suppress @version  -->
-     <elementSpec ident="TEI" mode="change">
-      <attList><attDef ident="version" mode="delete"/></attList>
-     </elementSpec>
-     <classRef key="att.global.facs"/>
-     <classSpec ident="att.global" type="atts" mode="change" module="tei">
-      <attList>
-       <attDef ident="xml:base" mode="delete"/>
-      </attList>
-     </classSpec>
-    <classSpec ident="att.global.rendition" type="atts" mode="change" module="tei">
-              <!-- not much use having @rendition or @style without tagsDecl -->
-            <attList>
-              <attDef ident="style" mode="delete"/>
-              <attDef ident="rendition" mode="delete"/>
-            </attList>
-          </classSpec>
+	</p>
+	<p>More usually, a graphic will have at the least an identifying title, which may be encoded
+	using the <gi>head</gi> element, or a number of figures may be grouped together in a particular
+	structure. It is also often convenient to include a brief description of the image. The
+	<gi>figure</gi> element provides a means of wrapping one or more such elements together as a
+	kind of graphic <soCalled>block</soCalled>: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	<figure>
+	  <graphic url="fessipic.png"/>
+	  <head>Mr Fezziwig's Ball</head>
+	  <figDesc>A Cruikshank
+	  engraving showing Mr Fezziwig leading a group of revellers.</figDesc>
+	</figure>
+      </egXML>
+	</p>
+	<p>These cases should be carefully distinguished from the case where an encoded text is
+	complemented by a collection of digital images, maintained as a distinct resource. The
+	<att>facs</att> attribute may be used to associate any element in an encoded text with a
+	digital facsimile of it. In the simple case where only page images are available, the
+	<att>facs</att> attribute on the <gi>pb</gi> element may be used to associate each image with
+	an appropriate point in the text: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	<text>
+	  <pb facs="page1.png" n="1"/>
+	  <!-- text contained on page 1 is encoded here -->
+	  <pb facs="page2.png" n="2"/>
+	  <!-- text contained on page 2 is encoded here -->
+	</text>
+	</egXML> This method is only appropriate in the simple case where each digital image file
+	<ident>page1.png</ident> etc. corresponds with a single transcribed and encoded page. If more
+	detailed alignment of image and transcription is required, for example because the image files
+	actually represent double page spreads, more sophisticated mechanisms are provided in the full
+	TEI Guidelines. </p>
+      </div>
+      <div xml:id="U5-anal">
+	<head>Interpretation and Analysis</head>
+	<p>It is often said that <emph>all</emph> markup is a form of interpretation or analysis. While
+	it is certainly difficult, and may be impossible, to distinguish firmly between
+	<soCalled>objective</soCalled> and <soCalled>subjective</soCalled> information in any
+	universal way, it remains true that judgments concerning the latter are typically regarded as
+	more likely to provide controversy than those concerning the former. Many scholars therefore
+	prefer to record such interpretations only if it is possible to alert the reader that they are
+	considered more open to dispute, than the rest of the markup. This section describes some of
+	the elements provided by the TEI scheme to meet this need. </p>
+	<div>
+	  <head>Orthographic Sentences</head>
+	  <p>Interpretation typically ranges across the whole of a text, with no particular respect to
+	  other structural units. A useful preliminary to intensive interpretation is therefore to
+	  segment the text into discrete and identifiable units, each of which can then bear a label for
+	  use as a sort of <soCalled>canonical reference</soCalled>. To facilitate such uses, these
+	  units may not cross each other, nor nest within each other. They may conveniently be
+	  represented using the following element: <specList>
+	  <specDesc key="s"/>
+	</specList>
+	  </p>
+	  <p>As the name suggests, the <gi>s</gi> element is most commonly used (in linguistic
+	  applications at least) for marking <term>orthographic sentences</term>, that is, units defined
+	  by orthographic features such as punctuation. For example, the passage from <title>Jane
+	  Eyre</title> discussed earlier might be divided into s-units as follows:<egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <pb n="474"/>
+	  <div type="chapter" n="38">
+	    <p>
+	      <s n="001">Reader, I married him.</s>
+	      <s n="002">A quiet wedding we had:</s>
+	      <s n="003">he
+	      and I, the parson and clerk, were alone present.</s>
+	      <s n="004">When we got back from
+	      church, I went into the kitchen of the manor-house, where Mary was cooking the dinner, and
+	      John cleaning the knives, and I said —</s>
+	    </p>
+	    <p>
+	      <q>
+		<s n="005">Mary, I have been married to Mr Rochester this morning.</s>
+	    </q> ... </p>
+	  </div>
+	  </egXML> Note that <gi>s</gi> elements cannot nest: the beginning of one <gi>s</gi>
+	  element implies that the previous one has finished. When s-units are tagged as shown above, it
+	  is advisable to tag the entire text end-to-end, so that every word in the text being analysed
+	  will be contained by exactly one <gi>s</gi> element, whose identifier can then be used to
+	  specify a unique reference for it. If the identifiers used are unique within the document,
+	  then the <att>xml:id</att> attribute might be used in preference to the <att>n</att> used in
+	  the above example.</p>
+	</div>
+	<div>
+	  <head>Words and punctuation</head>
+	  <p>Tokenization, that is, the identification of
+	  lexical or non-lexical tokens within a text, is a very common requirement for all kinds of
+	  textual analysis, and not an entirely trivial one. The decision as to whether, for example,
+	  <q>can't</q> in English or <q>du</q> in French should be treated as one word or two is not
+	  simple. Consequently it is often useful to make explicit the preferred tokenization in a
+	  marked up text. The following elements are available for this purpose: <specList>
+	  <specDesc key="w"/>
+	  <specDesc key="pc"/>
+	</specList>
+	  </p>
+	  <p>For example, the output from a part of speech tagger might be recorded in TEI Lite as
+	  follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <s n="1">
+	    <w ana="#NP0">Marley</w>
+	    <w ana="#VBD">was</w>
+	    <w ana="#AJ0">dead</w>
+	    <pc>:</pc>
+	    <w ana="#TO0">to</w>
+	    <w ana="#VBB">begin</w>
+	    <w ana="#PRP">with</w>
+	    <pc>. </pc>
+	  </s>
+	</egXML>
+	  </p>
+	  <p>In this example, each word has been decorated with an automatically generated part of
+	  speech code, using the <att>ana</att> attribute discussed in section <ptr target="#xatts"/>
+	  above. The <gi>w</gi> also provides for each word to be associated with a root form or lemma,
+	  either explicitly using the <att>lemma</att> attribute, or by reference, using the
+	  <att>lemmaRef</att> attribute, as in this example: <egXML xmlns="http://www.tei-c.org/ns/Examples">...<w ana="#VBD" lemma="be" lemmaRef="http://www.myLexicon.com/be">was</w> ... </egXML>
+	  </p>
+	</div>
+	<div>
+	  <head>General-Purpose Interpretation Elements</head>
+	  <p>The <gi>w</gi> element is a specialisation of the <gi>seg</gi> element which has already
+	  been introduced for use in identifying otherwise unmarked targets of cross references and
+	  hypertext links (see section <ptr target="#U5-ptrs"/>); it identifies some phrase-level
+	  portion of text to which the encoder may assign a user-specified <att>type</att>, as well as a
+	  unique identifier; it may thus be used to tag textual features for which there is no other
+	  provision in the published TEI Guidelines.</p>
+	  <p>For example, the Guidelines provide no <soCalled>apostrophe</soCalled> element to mark parts
+	  of a literary text in which the narrator addresses the reader (or hearer) directly. One
+	  approach might be to regard these as instances of the <gi>q</gi> element, distinguished from
+	  others by an appropriate value for the <att>who</att> attribute. A possibly simpler, and
+	  certainly more general, solution would however be to use the <gi>seg</gi> element as follows:
+	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <div type="chapter" n="38">
+	      <p>
+	      <seg type="apostrophe">Reader, I married him.</seg> A quiet wedding we had: ...</p>
+	    </div>
+	    </egXML> The <att>type</att> attribute on the <gi>seg</gi> element can take any value,
+	    and so can be used to record phrase-level phenomena of any kind; it is good practice to record
+	  the values used and their significance in the header.</p>
+	  <p>A <gi>seg</gi> element of one type (unlike the <gi>s</gi> element which it superficially
+	  resembles) can be nested within a <gi>seg</gi> element of the same or another type. This
+	  enables quite complex structures to be represented; some examples were given in section <ptr target="#xatts"/> above. However, because it must respect the requirement that elements be
+	  properly nested and may not cut across each other, it cannot cope with the common requirement
+	  to associate an interpretation with arbitrary segments of a text which may completely ignore
+	  the document hierarchy. It also requires that the interpretation itself be represented by a
+	  single coded value in the <att>type</att> attribute.</p>
+	  <p>Neither restriction applies to the <gi>interp</gi> element, which provides powerful features
+	  for the encoding of quite complex interpretive information in a relatively straightforward
+	  manner. <specList>
+	  <specDesc key="interp"/>
+	  <specDesc key="interpGrp"/>
+	  </specList> These elements allow the encoder to specify both the class of an interpretation,
+	  and the particular instance of that class which the interpretation involves. Thus, whereas
+	  with <gi>seg</gi> one can say simply that something is an apostrophe, with <gi>interp</gi> one
+	  can say that it is an instance (apostrophe) of a larger class (rhetorical figures).</p>
+	  <p>Moreover, <gi>interp</gi> is a <soCalled>stand off</soCalled>
+	  element: it does not surround the segments of text which it
+	  describes, but instead is  linked to the passage in question
+	  either by means of the <att>ana</att> attribute discussed in section <ptr target="#xatts"/> above, or by means of its own <att>inst</att> attribute. This means that
+	  any kind of analysis can be represented, independently of the
+	  document hierarchy, as well as
+	  facilitating the grouping of analyses of a particular type together. A special purpose
+	  <gi>interpGrp</gi> element is provided for the latter purpose.</p>
+	  <p>For example, suppose that you wish to mark such diverse aspects of a text as themes or
+	  subject matter, rhetorical figures, and the locations of individual scenes of the narrative.
+	  Different portions of our sample passage from <title>Jane Eyre</title> for example, might be
+	  associated with the rhetorical figures of apostrophe, hyperbole, and metaphor; with
+	  subject-matter references to churches, servants, cooking, postal service, and honeymoons; and
+	  with scenes located in the church, in the kitchen, and in an unspecified location (drawing
+	  room?).</p>
+	  <p>These interpretations could be placed anywhere within the <gi>text</gi> element; it is
+	  however good practice to put them all in the same place (e.g. a separate section of the front
+	  or back matter), as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <back>
+	    <div type="Interpretations">
+	      <p>
+		<interp xml:id="fig-apos-1" resp="#LB-MSM" type="figureOfSpeech">apostrophe</interp>
+		<interp xml:id="fig-hyp-1" resp="#LB-MSM" type="figureOfSpeech">hyperbole</interp>
+		<interp xml:id="set-church-1" resp="#LB-MSM" type="setting">church</interp>
+		<interp xml:id="ref-church-1" resp="#LB-MSM" type="reference">church</interp>
+		<interp xml:id="ref-serv-1" resp="#LB-MSM" type="reference">servants</interp>
+	      </p>
+	    </div>
+	  </back>
+	</egXML>
+	  </p>
+	  <p>The evident redundancy of this encoding can be considerably reduced by using the
+	  <gi>interpGrp</gi> element to group together all those <gi>interp</gi> elements which share
+	  common attribute values, as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <back>
+	    <div type="Interpretations">
+	      <p>
+		<interpGrp type="figureOfSpeech" resp="#LB-MSM">
+		  <interp xml:id="fig-apos">apostrophe</interp>
+		  <interp xml:id="fig-hyp">hyperbole</interp>
+		  <interp xml:id="fig-meta">metaphor</interp>
+		</interpGrp>
+		<interpGrp type="scene-setting" resp="#LB-MSM">
+		  <interp xml:id="set-church">church</interp>
+		  <interp xml:id="set-kitch">kitchen</interp>
+		  <interp xml:id="set-unspec">unspecified</interp>
+		</interpGrp>
+		<interpGrp type="reference" resp="#LB-MSM">
+		  <interp xml:id="ref-church">church</interp>
+		  <interp xml:id="ref-serv">servants</interp>
+		  <interp xml:id="ref-cook">cooking</interp>
+		</interpGrp>
+	      </p>
+	    </div>
+	  </back>
+	</egXML>
+	  </p>
+	  <p>Once these interpretation elements have been defined, they can be linked with the parts of
+	  the text to which they apply in either or both of two ways. The <att>ana</att> attribute can
+	  be used on whichever element is appropriate: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <div type="chapter" n="38">
+	    <p xml:id="P38.1" ana="#set-church #set-kitch">
+	      <s xml:id="P38.1.1" ana="#fig-apos">Reader, I
+	      married him.</s>
+	    </p>
+	  </div>
+	  </egXML> Note in this example that since the paragraph has two settings (in the church
+	  and in the kitchen), the identifiers of both have been supplied.</p>
+	  <p>Alternatively, the <gi>interp</gi> elements can point to all the parts of the text to which
+	  they apply, using their <att>inst</att> attribute: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <interp xml:id="fig-apos-2"
+		  type="figureOfSpeech"
+		  resp="#LB-MSM"
+		  inst="#P38.1.1">apostrophe</interp>
+	  <interp xml:id="set-church-2"
+		  type="scene-setting"
+		  inst="#P38.1"
+		  resp="#LB-MSM">church</interp>
+	  <interp xml:id="set-kitchen-2"
+		  type="scene-setting"
+		  inst="#P38.1"
+		  resp="#LB-MSM">kitchen</interp>
+	</egXML>
+	  </p>
+	  <p>The <gi>interp</gi> element is not limited to any particular type of analysis. The literary
+	  analysis shown above is but one possibility; one could equally well use <gi>interp</gi> to
+	  capture a linguistic part-of-speech analysis. For example, the example sentence given in
+	  section <ptr target="#xatts"/> assumes a linguistic analysis which might be represented as
+	  follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <interp xml:id="NP1" type="pos">noun
+	  phrase, singular</interp>
+	  <interp xml:id="VV1" type="pos">inflected verb, present-tense
+	  singular</interp> ... </egXML>
+	  </p>
+	</div>
+      </div>
+      <div xml:id="U5-techdoc">
+	<head>Technical Documentation</head>
+	<p>Although the focus of this document is on the use of the TEI scheme for the encoding of
+	existing <soCalled>pre-electronic</soCalled> documents, the same scheme may also be used for
+	the encoding of new documents. In the preparation of new documents (such as this one), XML has
+	much to recommend it: the document's structure can be clearly represented, and the same
+	electronic text can be re-used for many purposes — to provide both online hypertext or
+	browsable versions and well-formatted typeset versions from a common source for example. </p>
+	<p>To facilitate this, the TEI Lite schema includes some elements for marking features of
+	technical documents in general, and of XML-related documents in particular.</p>
+	<div>
+	  <head>Additional Elements for Technical Documents</head>
+	  <p>The following elements may be used to mark particular features of technical documents: <specList>
+	  <specDesc key="eg"/>
+	  <specDesc key="code"/>
+	  <specDesc key="ident"/>
+	  <specDesc key="gi"/>
+	  <specDesc key="att"/>
+	  <specDesc key="formula"/>
+	  <specDesc key="val"/>
+	</specList>
+	  </p>
+	  <p>The following example shows how these elements might be used to encode a passage from a
+	  tutorial introducing the Fortran programming language: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <p>It is traditional to introduce a language with a
+	  program like the following: <eg xml:space="preserve"> CHAR*12 GRTG
+	  GRTG = 'HELLO WORLD' 
+	  PRINT *, GRTG 
+	  END
+	</eg>
+	  </p>
+	  <p>This simple example first declares a variable <ident>GRTG</ident>, in the line
+	  <code>CHAR*12 GRTG</code>, which identifies <ident>GRTG</ident> as consisting of 12 bytes
+	  of type <ident>CHAR</ident>. To this variable, the value <val>HELLO WORLD</val> is then
+	  assigned.</p>
+	</egXML>
+	  </p>
+	  <p>A formatting application, given a text like that above, can be instructed to format examples
+	  appropriately (e.g. to preserve line breaks, or to use a distinctive font). Similarly, the use
+	  of tags such as <gi>ident</gi> greatly facilitates the construction of a useful index.</p>
+	  <p>The <gi>formula</gi> element should be used to enclose a mathematical or chemical formula
+	  presented within the text as a distinct item. Since formulae generally include a large variety
+	  of special typographic features not otherwise present in ordinary text, it will usually be
+	  necessary to present the body of the formula in a specialized notation. The notation used
+	  should be specified by the <att>notation</att> attribute, as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <formula notation="tex"> \begin{math}E =
+	  mc^{2}\end{math} </formula>
+	</egXML>
+	  </p>
+	  <p>A particular problem arises when XML encoding is the subject of discussion within a
+	  technical document, itself encoded in XML. In such a document, it is clearly essential to
+	  distinguish clearly the markup occurring within examples from that marking up the document
+	  itself, and end-tags are highly likely to occur. One simple solution is to use the predefined
+	  entity reference <code>&amp;lt;</code> to represent each &lt; character which marks the start
+	  of an XML tag within the examples. A more general solution is to mark off the whole body of
+	  each example as containing data which is not to be scanned for XML mark-up by the parser. This
+	  is achieved by enclosing it within a special XML construct called a <term>
+	  <code>CDATA</code>
+	  marked section</term>, as in the following example: <eg xml:space="preserve">&lt;p&gt;A list should be encoded as
+	  follows: &lt;eg&gt;&lt;![ CDATA [ &lt;list&gt; &lt;item&gt;First item in the
+	  list&lt;/item&gt; &lt;item&gt;Second item&lt;/item&gt; &lt;/list&gt; ]]&gt; &lt;/eg&gt; The
+	  &lt;gi&gt;list&lt;/gi&gt; element consists of a series of &lt;gi&gt;item&lt;/gi&gt;
+	  elements.</eg>
+	  </p>
+	  <p>The <gi>list</gi> element used within the example above will not be regarded as forming part
+	  of the document proper, because it is embedded within a marked section (beginning with the
+	  special markup declaration <val>&lt;![CDATA[ </val>, and ending with <val>]]&gt;</val>).</p>
+	  <p>Note also the use of the <gi>gi</gi> element to tag references to element names (or
+	  <term>generic identifiers</term>) within the body of the text.</p>
+	</div>
+	<div>
+	  <head>Generated Divisions</head>
+	  <p>Most modern document production systems have the ability to generate automatically whole
+	  sections such as a table of contents or an index. The TEI Lite scheme provides an element to
+	  mark the location at which such a generated section should be placed. <specList>
+	  <specDesc key="divGen"/>
+	</specList>
+	  </p>
+	  <p>The <gi>divGen</gi> element can be placed anywhere that a division element would be legal,
+	  as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <front>
+	    <titlePage>
+	      <!-- ... -->
+	    </titlePage>
+	    <divGen type="toc"/>
+	    <div>
+	      <head>Preface</head>
+	      <!-- ... -->
+	    </div>
+	  </front>
+	  <body>
+	    <!-- ... -->
+	  </body>
+	  <back>
+	    <div>
+	      <head>Appendix</head>
+	      <!-- ... -->
+	    </div>
+	    <divGen type="index" n="Index"/>
+	  </back>
+	</egXML>
+	  </p>
+	  <p>This example also demonstrates the use of the <att>type</att> attribute to distinguish the
+	  different kinds of division to be generated: in the first case a table of contents (a
+	  <mentioned>toc</mentioned>) and in the second an index.</p>
+	  <p>When an existing index or table of contents is to be encoded (rather than one being
+	  generated) for some reason, the <gi>list</gi> element discussed in section <ptr target="#U5-lists"/> should be used. </p>
+	</div>
+	<div xml:id="indexing">
+	  <head>Index Generation</head>
+	  <p>While production of a table of contents from a properly tagged document is generally
+	  unproblematic for an automatic processor, the production of a good quality index will often
+	  require more careful tagging. It may not be enough simply to produce a list of all parts
+	  tagged in some particular way, although extracting (for example) all occurrences of elements
+	  such as <gi>term</gi> or <gi>name</gi> will often be a good departure point for an index. </p>
+	  <p>The TEI schema provides a special purpose <gi>index</gi> tag which may be used to mark both
+	  the parts of the document which should be indexed, and how the indexing should be done. <specList>
+	  <specDesc key="index"/>
+	</specList>
+	  </p>
+	  <p>For example, the second paragraph of this section might include the following:<egXML xmlns="http://www.tei-c.org/ns/Examples">... TEI lite also provides a special purpose
+	  <gi>index</gi> tag <index>
+	  <term>indexing</term>
+	</index>
+	<index>
+	  <term>index (tag)</term>
+	  <index>
+	    <term>use in index generation</term>
+	  </index>
+	</index>
+	which may be used ...</egXML>
+	  </p>
+	  <p>The <gi>index</gi> element can also be used to provide a form of interpretive or analytic
+	  information. For example, in a study of Ovid, it might be desired to record all the poet's
+	  references to different figures, for comparative stylistic study. In the following lines of
+	  the <title>Metamorphoses</title>, such a study would record the poet's references to Jupiter
+	  (as <mentioned>deus</mentioned>, <mentioned>se</mentioned>, and as the subject of
+	  <mentioned>confiteor</mentioned> [in inflectional form number 227]), to
+	  Jupiter-in-the-guise-of-a-bull (as <mentioned>imago tauri fallacis</mentioned> and the subject
+	  of <mentioned>teneo</mentioned>), and so on.<note place="foot">The analysis is taken, with
+	  permission, from Willard McCarty and Burton Wright, <title>An Analytical Onomasticon to the
+	  Metamorphoses of Ovid</title> (Princeton: Princeton University Press, forthcoming). Some
+	  simplifications have been undertaken.</note>
+	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <l n="3.001">iamque deus posita fallacis
+	    imagine tauri</l>
+	    <l n="3.002">se confessus erat Dictaeaque rura tenebat</l>
+	    </egXML> This
+	    need might be met using the <gi>note</gi> element discussed in section in <ptr target="#U5-notes"/>, or with the <gi>interp</gi> element discussed in section <ptr target="#U5-anal"/>. Here we demonstrate how it might also be satisfied by using the
+	  <gi>index</gi> element.</p>
+	  <p>We assume that the object is to generate more than one index: one for names of deities
+	  (called <att>dn</att>), another for onomastic references (called <att>on</att>), a third for
+	  pronominal references (called <att>pr</att>) and so forth. One way of achieving this might be
+	  as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <l n="3.001">iamque deus posita
+	  fallacis imagine tauri <index indexName="dn">
+	  <term>Iuppiter</term>
+	  <index>
+	    <term>deus</term>
+	  </index>
+	</index>
+	<index indexName="on">
+	  <term>Iuppiter (taurus)</term>
+	  <index>
+	    <term>imago tauri
+	    fallacis</term>
+	  </index>
+	</index>
+	  </l>
+	  <l n="3.002">se confessus erat Dictaeaque rura tenebat
+	  <index indexName="pr">
+	    <term>Iuppiter</term>
+	    <index>
+	      <term>se</term>
+	    </index>
+	  </index>
+	  <index indexName="v">
+	    <term>Iuppiter</term>
+	    <index>
+	      <term>confiteor
+	      (v227)</term>
+	    </index>
+	  </index>
+	  </l>
+	  </egXML> For each <gi>index</gi> element above, an entry
+	  will be generated in the appropriate index, using as headword the content of the <gi>term</gi>
+	  element it contains; the <gi>term</gi> elements nested within the secondary <gi>index</gi>
+	  element in each case provide a secondary keyword. The actual reference will be taken from the
+	  context in which the <gi>index</gi> element appears, i.e. in this case the identifier of the
+	  <gi>l</gi> element containing it. </p>
+	</div>
+	<div>
+	  <head>Addresses</head>
+	  <p>The <gi>address</gi> element is used to mark a postal address of any kind. It contains one
+	  or more <gi>addrLine</gi> elements, one for each line of the address. <specList>
+	  <specDesc key="address"/>
+	  <specDesc key="addrLine"/>
+	</specList>
+	  </p>
+	  <p>Here is a simple example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <address>
+	    <addrLine>Computer Center (M/C 135)</addrLine>
+	    <addrLine>1940 W. Taylor, Room 124</addrLine>
+	    <addrLine>Chicago, IL 60612-7352</addrLine>
+	    <addrLine>U.S.A.</addrLine>
+	  </address>
+	</egXML>
+	  </p>
+	  <p>The individual parts of an address may be further distinguished by using the <gi>name</gi>
+	  element discussed above (section <ptr target="#nomen"/>). <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <address>
+	    <addrLine>Computer Center (M/C 135)</addrLine>
+	    <addrLine>1940 W. Taylor, Room 124</addrLine>
+	    <addrLine>
+	    <name type="city">Chicago</name>, IL 60612-7352</addrLine>
+	    <addrLine>
+	      <name type="country">USA</name>
+	    </addrLine>
+	  </address>
+	</egXML>
+	  </p>
+	</div>
+      </div>
+      <div xml:id="U5-chars">
+	<head>Character Sets, Diacritics, etc.</head>
+	<p>With the advent of XML and its adoption of Unicode as the required character set for all
+	documents, most problems previously associated with the representation of the divers languages
+	and writing systems of the world are greatly reduced. For those working with standard forms of
+	the European languages in particular, almost no special action is needed: any XML editor should
+	enable you to input accented letters or other <soCalled>non-ASCII</soCalled> characters
+	directly, and they should be stored in the resulting file in a way which is transferable
+	directly between different systems. </p>
+	<p>There are two important exceptions: the characters &amp; and &lt; may not be entered directly
+	in an XML document, since they have a special significance as initiating markup. They must
+	always be represented as <term>entity references</term>, like this: <code>&amp;amp;</code> or
+	<code>&amp;lt;</code>. Other characters may also be represented by means of entity reference
+	where necessary, for example to retain compatibility with a pre-Unicode processing system. </p>
+      </div>
+      <div xml:id="U5-fronbac">
+	<head>Front and Back Matter</head>
+	<div>
+	  <head>Front Matter</head>
+	  <p>For many purposes, particularly in older texts, the preliminary material such as title
+	  pages, prefatory epistles, etc., may provide very useful additional linguistic or social
+	  information. P5 provides a set of recommendations for distinguishing the textual elements most
+	  commonly encountered in front matter, which are summarized here.</p>
+	  <div xml:id="h51">
+	    <head>Title Page</head>
+	    <p>The start of a title page should be marked with the element <gi>titlePage</gi>. All text
+	    contained on the page should be transcribed and tagged with the appropriate element from the
+	    following list: <specList>
+	    <specDesc key="titlePage"/>
+	    <specDesc key="docTitle"/>
+	    <specDesc key="titlePart"/>
+	    <specDesc key="byline"/>
+	    <specDesc key="docAuthor"/>
+	    <specDesc key="docDate"/>
+	    <specDesc key="docEdition"/>
+	    <specDesc key="docImprint"/>
+	    <specDesc key="epigraph"/>
+	  </specList>
+	    </p>
+	    <p>Typeface distinctions should be marked with the <att>rend</att> attribute when necessary,
+	    as described above. Very detailed description of the letter spacing and sizing used in
+	    ornamental titles is not as yet provided for by the Guidelines. Changes of language should be
+	    marked by appropriate use of the <att>xml:lang</att> attribute or the <gi>foreign</gi>
+	    element, as necessary. Names of people, places, or organizations, may be tagged using the
+	    <gi>name</gi> element wherever they appear if no other more specific element is
+	    available.</p>
+	    <p>Two example title pages follow: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <titlePage rend="Roman">
+	      <docTitle>
+		<titlePart type="main"> PARADISE REGAIN'D. A POEM In IV <hi>BOOKS</hi>. </titlePart>
+		<titlePart> To which is added <title>SAMSON AGONISTES</title>. </titlePart>
+	      </docTitle>
+	      <byline>The Author <docAuthor>JOHN MILTON</docAuthor>
+	      </byline>
+	      <docImprint>
+		<name>LONDON</name>, Printed by <name>J.M.</name> for <name>John Starkey</name>
+		at the <name>Mitre</name> in <name>Fleetstreet</name>, near
+		<name>Temple-Bar.</name>
+	      </docImprint>
+	      <docDate>MDCLXXI</docDate>
+	    </titlePage>
+	  </egXML>
+	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <titlePage>
+	      <docTitle>
+		<titlePart type="main"> Lives of the Queens of England, from the Norman
+		Conquest;</titlePart>
+		<titlePart type="sub">with anecdotes of their courts. </titlePart>
+	      </docTitle>
+	      <titlePart>Now first published from Official Records and other authentic documents private
+	      as well as public.</titlePart>
+	      <docEdition>New edition, with corrections and additions</docEdition>
+	      <byline>By <docAuthor>Agnes Strickland</docAuthor>
+	      </byline>
+	      <epigraph>
+		<q>The treasures of antiquity laid up in old historic rolls, I opened.</q>
+		<bibl>BEAUMONT</bibl>
+	      </epigraph>
+	      <docImprint>Philadelphia: Blanchard and Lea</docImprint>
+	      <docDate>1860.</docDate>
+	    </titlePage>
+	  </egXML>
+	    </p>
+	    <p>As elsewhere, the <att>ref</att> attribute may be used to link a name with a canonical
+	    definition of the entity being named. For example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <byline>By <docAuthor>
+	    <name ref="http://en.wikipedia.org/wiki/Agnes_Strickland">Agnes
+	    Strickland</name>
+	  </docAuthor>
+	    </byline>
+	  </egXML>
+	    </p>
+	  </div>
+	  <div xml:id="h52">
+	    <head>Prefatory Matter</head>
+	    <p>Major blocks of text within the front matter should be marked using
+	    <gi>div</gi> elements; the following suggested values for the <att>type</att> attribute may
+	    be used to distinguish various common types of prefatory matter: <list type="gloss">
+	    <label>preface</label>
+	    <item>A foreword or preface addressed to the reader in which the author or publisher
+	    explains the content, purpose, or origin of the text</item>
+	    <label>dedication</label>
+	    <item>A formal offering or dedication of a text to one or more persons or institutions by
+	    the author.</item>
+	    <label>abstract</label>
+	    <item>A summary of the content of a text as continuous prose</item>
+	    <label>ack</label>
+	    <item>A formal declaration of acknowledgment by the author in which persons and institutions
+	    are thanked for their part in the creation of a text</item>
+	    <label>contents</label>
+	    <item>A table of contents, specifying the structure of a work and listing its constituents.
+	    The <gi>list</gi> element should be used to mark its structure.</item>
+	    <label>frontispiece</label>
+	    <item>A pictorial frontispiece, possibly including some text.</item>
+	  </list>
+	    </p>
+	    <p>Where other kinds of prefatory matter are encountered, the encoder is at liberty to invent
+	    other values for the <att>type</att> attribute.</p>
+	    <p>Like any text division, those in front matter may contain low level structural or
+	    non-structural elements as described elsewhere. They will generally begin with a heading or
+	    title of some kind which should be tagged using the <gi>head</gi> element. Epistles will
+	    contain the following additional elements: <specList>
+	    <specDesc key="salute"/>
+	    <specDesc key="signed"/>
+	    <specDesc key="byline"/>
+	    <specDesc key="dateline"/>
+	    <specDesc key="argument"/>
+	    <specDesc key="cit"/>
+	    <specDesc key="imprimatur"/>
+	    <specDesc key="opener"/>
+	    <specDesc key="closer"/>
+	  </specList>
+	    </p>
+	    <p> Epistles which appear elsewhere in a text will, of course, contain these same
+	    elements.</p>
+	    <p>As an example, the dedication at the start of Milton's <title>Comus</title> should be
+	    marked up as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <div type="dedication">
+	      <head>To the Right Honourable <name>JOHN Lord Viscount BRACLY</name>, Son and Heir apparent
+	      to the Earl of Bridgewater, &amp;c.</head>
+	      <salute>MY LORD,</salute>
+	      <p>THis <hi>Poem</hi>, which receiv'd its first occasion of Birth from your Self, and
+	      others of your Noble Family .... and as in this representation your attendant
+	      <name>Thyrsis</name>, so now in all reall expression</p>
+	      <closer>
+		<salute>Your faithfull, and most humble servant</salute>
+		<signed>
+		  <name>H. LAWES.</name>
+		</signed>
+	      </closer>
+	    </div>
+	  </egXML>
+	    </p>
+	  </div>
+	</div>
+	<div>
+	  <head>Back Matter</head>
+	  <div>
+	    <head>Structural Divisions of Back Matter</head>
+	    <p>Because of variations in publishing practice, back matter can contain virtually any of the
+	    elements listed above for front matter, and the same elements should be used where this is
+	    so. Additionally, back matter may contain the following types of matter within the
+	    <gi>back</gi> element. Like the structural divisions of the body, these should be marked as
+	    <gi>div</gi> elements, and distinguished by the following suggested values of the
+	    <att>type</att> attribute: <list type="gloss">
+	    <label>appendix</label>
+	    <item>An ancillary self-contained section of a work, often providing additional but in some
+	    sense extra-canonical text.</item>
+	    <label>glossary</label>
+	    <item>A list of terms associated with definition texts (‘glosses’): this should be encoded
+	    as a <tag>&lt;list type="gloss"&gt;</tag> element</item>
+	    <label>notes</label>
+	    <item>A section in which textual or other kinds of notes are gathered together.</item>
+	    <label>bibliogr</label>
+	    <item>A list of bibliographic citations: this should be encoded as a <gi>listBibl</gi>
+	    </item>
+	    <label>index</label>
+	    <item>Any form of pre-existing index to the work (An index may also be generated for a
+	    document by using the <gi>index</gi> element described above).</item>
+	    <label>colophon</label>
+	    <item>A statement appearing at the end of a book describing the conditions of its physical
+	    production.</item>
+	  </list>
+	    </p>
+	  </div>
+	</div>
+      </div>
+      <div xml:id="U5-header">
+	<head>The Electronic Title Page</head>
+	<p>Every TEI text has a header which provides information analogous to that provided by the
+	title page of printed text. The header is introduced by the element <gi>teiHeader</gi> and has
+	four major parts: <specList>
+	<specDesc key="fileDesc"/>
+	<specDesc key="encodingDesc"/>
+	<specDesc key="profileDesc"/>
+	<specDesc key="revisionDesc"/>
+      </specList>
+	</p>
+	<p> A corpus or collection of texts with many shared characteristics may have one header for
+	the corpus and individual headers for each component of the corpus. In this case the
+	<att>type</att> attribute indicates the type of header. <code>&lt;teiHeader
+	type="corpus"&gt;</code> introduces the header for corpus-level information.</p>
+	<p>Some of the header elements contain running prose which consists of one or more <gi>p</gi>s.
+	Others are grouped: <list>
+	<item>Elements whose names end in <mentioned>Stmt</mentioned> (for statement) usually enclose a
+	group of elements recording some structured information.</item>
+	<item>Elements whose names end in <mentioned>Decl</mentioned> (for declaration) enclose
+	information about specific encoding practices.</item>
+	<item>Elements whose names end in <mentioned>Desc</mentioned> (for description) contain a
+	prose description.</item>
+      </list>
+	</p>
+	<div>
+	  <head>The File Description</head>
+	  <p>The <gi>fileDesc</gi> element is mandatory. It contains a full bibliographic description of
+	  the file with the following elements: <specList>
+	  <specDesc key="titleStmt"/>
+	  <specDesc key="editionStmt"/>
+	  <specDesc key="extent"/>
+	  <specDesc key="publicationStmt"/>
+	  <specDesc key="seriesStmt"/>
+	  <specDesc key="notesStmt"/>
+	  <specDesc key="sourceDesc"/>
+	</specList>
+	  </p>
+	  <p> A minimal header has the following structure: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <teiHeader>
+	    <fileDesc>
+	      <titleStmt>
+		<!-- bibliographic description of the digital resource -->
+	      </titleStmt>
+	      <publicationStmt>
+		<!-- information about how the resource is distributed -->
+	      </publicationStmt>
+	      <sourceDesc>
+		<!-- information about the sources from which the digital resource is derived -->
+	      </sourceDesc>
+	    </fileDesc>
+	  </teiHeader>
+	</egXML>
+	  </p>
+	  <div>
+	    <head>The Title Statement</head>
+	    <p>The following elements can be used in the <gi>titleStmt</gi>: <specList>
+	    <specDesc key="title"/>
+	    <specDesc key="author"/>
+	    <specDesc key="sponsor"/>
+	    <specDesc key="funder"/>
+	    <specDesc key="principal"/>
+	    <specDesc key="respStmt"/>
+	  </specList>
+	    </p>
+	    <p> The title of a digital resource derived from a non-digital one will obviously be similar.
+	    However, it is important to distinguish the title of the computer file from that of the
+	    source text, for example: <eg>[title of source]: a machine readable transcription [title of
+	    source]: electronic edition A machine readable version of: [title of source]</eg> The
+	    <gi>respStmt</gi> element contains the following subcomponents: <specList>
+	    <specDesc key="resp"/>
+	    <specDesc key="name"/>
+	    </specList> Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <titleStmt>
+	      <title>Two stories by Edgar Allen Poe: a machine readable transcription</title>
+	      <author>Poe, Edgar Allen (1809-1849)</author>
+	      <respStmt>
+		<resp>compiled by</resp>
+		<name>James D. Benson</name>
+	      </respStmt>
+	    </titleStmt>
+	  </egXML>
+	    </p>
+	  </div>
+	  <div>
+	    <head>The Edition Statement</head>
+	    <p>The <gi>editionStmt</gi> groups information relating to one edition of the digital resource
+	    (where <mentioned>edition</mentioned> is used as elsewhere in bibliography), and may include
+	    the following elements: <specList>
+	    <specDesc key="edition"/>
+	    <specDesc key="respStmt"/>
+	  </specList>
+	    </p>
+	    <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <editionStmt>
+	      <edition n="U2">Third
+	      draft, substantially revised <date>1987</date>
+	      </edition>
+	    </editionStmt>
+	  </egXML>
+	    </p>
+	    <p>Determining exactly what constitutes a new edition of an electronic text is left to the
+	    encoder.</p>
+	  </div>
+	  <div>
+	    <head>The Extent Statement</head>
+	    <p>The <gi>extent</gi> statement describes the approximate size of the digital resource.</p>
+	    <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <extent>4532
+	    bytes</extent>
+	  </egXML>
+	    </p>
+	  </div>
+	  <div>
+	    <head>The Publication Statement</head>
+	    <p>The <gi>publicationStmt</gi> is mandatory. It may contain a simple prose description or
+	    groups of the elements described below: <specList>
+	    <specDesc key="publisher"/>
+	    <specDesc key="distributor"/>
+	    <specDesc key="authority"/>
+	  </specList>
+	    </p>
+	    <p>At least one of these three elements must be present, unless the entire publication
+	    statement is in prose. The following elements may occur within them: <specList>
+	    <specDesc key="pubPlace"/>
+	    <specDesc key="address"/>
+	    <specDesc key="idno"/>
+	    <specDesc key="availability"/>
+	    <specDesc key="licence"/>
+	    <specDesc key="date"/>
+	  </specList>
+	    </p>
+	    <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <publicationStmt>
+	      <publisher>University of Victoria Humanities Computing and Media Centre</publisher>
+	      <pubPlace>Victoria, BC</pubPlace>
+	      <date>2011</date>
+	      <availability status="restricted">
+		<licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a
+		Creative Commons Attribution-ShareAlike 3.0 Unported License </licence>
+	      </availability>
+	    </publicationStmt>
+	  </egXML>
+	    </p>
+	  </div>
+	  <div>
+	    <head>Series and Notes Statements</head>
+	    <p>The <gi>seriesStmt</gi> element groups information about the series, if any, to which a
+	    publication belongs. It may contain <gi>title</gi>, <gi>idno</gi>, or <gi>respStmt</gi>
+	    elements.</p>
+	    <p>The <gi>notesStmt</gi>, if used, contains one or more <gi>note</gi> elements which contain
+	    a note or annotation. Some information found in the notes area in conventional bibliography
+	    has been assigned specific elements in the TEI scheme.</p>
+	  </div>
+	  <div>
+	    <head>The Source Description</head>
+	    <p>The <gi>sourceDesc</gi> is a mandatory element which records details of the source or
+	    sources from which the computer file is derived. It may contain simple prose or a
+	    bibliographic citation, using one or more of the following elements: <specList>
+	    <specDesc key="bibl"/>
+	    <specDesc key="listBibl"/>
+	  </specList>
+	    </p>
+	    <p>Examples: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <sourceDesc>
+	      <bibl>The first folio of Shakespeare, prepared by Charlton Hinman (The Norton Facsimile,
+	      1968)</bibl>
+	    </sourceDesc>
+	  </egXML>
+	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <sourceDesc>
+	      <bibl>
+		<author>CNN Network News</author>
+		<title>News headlines</title>
+		<date>12 Jun
+		1989</date>
+	      </bibl>
+	    </sourceDesc>
+	  </egXML>
+	    </p>
+	  </div>
+	</div>
+	<div>
+	  <head>The Encoding Description</head>
+	  <p>The <gi>encodingDesc</gi> element specifies the methods and editorial principles which
+	  governed the transcription of the text. Its use is highly recommended. It may be prose
+	  description or may contain elements from the following list: <specList>
+	  <specDesc key="projectDesc"/>
+	  <specDesc key="samplingDecl"/>
+	  <specDesc key="editorialDecl"/>
+	  <specDesc key="refsDecl"/>
+	  <specDesc key="classDecl"/>
+	</specList>
+	  </p>
+	  <div>
+	    <head>Project and Sampling Descriptions</head>
+	    <p>Examples of <gi>projectDesc</gi> and <gi>samplingDesc</gi>: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <encodingDesc>
+	      <projectDesc>
+		<p>Texts collected for
+		use in the Claremont Shakespeare Clinic, June 1990.
+		</p>
+	      </projectDesc>
+	    </encodingDesc>
+	  </egXML>
+	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <encodingDesc>
+	      <samplingDecl>
+		<p>Samples of
+		2000 words taken from the beginning of the text</p>
+	      </samplingDecl>
+	    </encodingDesc>
+	  </egXML>
+	    </p>
+	  </div>
+	  <div>
+	    <head>Editorial Declarations</head>
+	    <p>The <gi>editorialDecl</gi> contains a prose description of the practices used when encoding
+	    the text. Typically this description should cover such topics as the following, each of which
+	    may conveniently be given as a separate paragraph. <list type="gloss">
+	    <label>correction </label>
+	    <item>how and under what circumstances corrections have been made in the text.</item>
+	    <label>normalization</label>
+	    <item>the extent to which the original source has been regularized or normalized.</item>
+	    <label>quotation</label>
+	    <item>what has been done with quotation marks in the original -- have they been retained or
+	    replaced by entity references, are opening and closing quotes distinguished, etc. </item>
+	    <label>hyphenation</label>
+	    <item>what has been done with hyphens (especially end-of-line hyphens) in the original --
+	    have they been retained, replaced by entity references, etc.</item>
+	    <label>segmentation</label>
+	    <item>how has the text has been segmented, for example into sentences, tone-units, graphemic
+	    strata, etc.</item>
+	    <label>interpretation</label>
+	    <item>what analytic or interpretive information has been added to the text. </item>
+	  </list>
+	    </p>
+	    <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <editorialDecl>
+	      <p>The part of
+	      speech analysis applied throughout section 4 was added by hand and has not been
+	      checked.</p>
+	      <p>Errors in transcription controlled by using the WordPerfect spelling
+	      checker.</p>
+	      <p>All words converted to Modern American spelling using Webster's 9th
+	      Collegiate dictionary.</p>
+	    </editorialDecl>
+	  </egXML>
+	    </p>
+	  </div>
+	  <div xml:id="refsdecl">
+	    <head>Reference and Classification Declarations</head>
+	    <p>The <gi>refsDecl</gi> element is used to document the way in which any standard referencing
+	    scheme built into the encoding works. In its simplest form, it consists of prose
+	    description.</p>
+	    <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <refsDecl>
+	      <p>The <att>n</att>
+	      attribute on each <gi>div</gi> contains the canonical reference for each division in the
+	      form XX.yyy where XX is the book number in roman numeral and yyy is the section number in
+	      arabic.</p>
+	      <p>Milestone tags refer to the edition of 1830 as E30 and that of 1850 as E50.
+	      </p>
+	    </refsDecl>
+	  </egXML>
+	    </p>
+	    <p>The <gi>classDecl</gi> element groups together definitions or sources for any descriptive
+	    classification schemes used by other parts of the header. At least one such scheme must be
+	    provided, encoded using the following elements: <specList>
+	    <specDesc key="taxonomy"/>
+	    <specDesc key="bibl"/>
+	    <specDesc key="category"/>
+	    <specDesc key="catDesc"/>
+	  </specList>
+	    </p>
+	    <p> In the simplest case, the taxonomy may be defined by a bibliographic reference, as in the
+	    following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <classDecl>
+	      <taxonomy xml:id="LC-SH">
+		<bibl>Library of Congress Subject Headings
+		</bibl>
+	      </taxonomy>
+	    </classDecl>
+	  </egXML>
+	    </p>
+	    <p>Alternatively, or in addition, the encoder may define a special purpose classification
+	    scheme, as in the following example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <taxonomy xml:id="B">
+	      <bibl>Brown Corpus</bibl>
+	      <category xml:id="B.A">
+		<catDesc>Press
+		Reportage</catDesc>
+		<category xml:id="B.A1">
+		  <catDesc>Daily</catDesc>
+		</category>
+		<category xml:id="B.A2">
+		  <catDesc>Sunday</catDesc>
+		</category>
+		<category xml:id="B.A3">
+		  <catDesc>National</catDesc>
+		</category>
+		<category xml:id="B.A4">
+		  <catDesc>Provincial</catDesc>
+		</category>
+		<category xml:id="B.A5">
+		  <catDesc>Political</catDesc>
+		</category>
+		<category xml:id="B.A6">
+		  <catDesc>Sports</catDesc>
+		</category>
+	      </category>
+	      <category xml:id="B.D">
+		<catDesc>Religion</catDesc>
+		<category xml:id="B.D1">
+		  <catDesc>Books</catDesc>
+		</category>
+		<category xml:id="B.D2">
+		  <catDesc>Periodicals and
+		  tracts</catDesc>
+		</category>
+	      </category>
+	    </taxonomy>
+	  </egXML>
+	    </p>
+	    <p>Linkage between a particular text and a category within such a taxonomy is made by means of
+	    the <gi>catRef</gi> element within the <gi>textClass</gi> element, as described in the next
+	    section below.</p>
+	  </div>
+	</div>
+	<div>
+	  <head>The Profile Description</head>
+	  <p>The <gi>profileDesc</gi> element enables information characterizing various descriptive
+	  aspects of a text to be recorded within a single framework. It has three optional components: <specList>
+	  <specDesc key="creation"/>
+	  <specDesc key="langUsage"/>
+	  <specDesc key="textClass"/>
+	</specList>
+	  </p>
+	  <p>The <gi>creation</gi> element is useful for documenting where a work was created, even
+	  though it may not have been published or recorded there.</p>
+	  <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <creation>
+	    <date when="1992-08">August 1992</date>
+	    <name type="place">Taos, New Mexico</name>
+	  </creation>
+	</egXML>
+	  </p>
+	  <p>The <gi>langUsage</gi> element is useful where a text contains many different languages. It
+	  may contain <gi>language</gi> elements to document each particular language used: <specList>
+	  <specDesc key="language"/>
+	  </specList> For example, a text containing predominantly text in French as spoken in Quebec,
+	  but also smaller amounts of British and Canadian English might be documented as follows:
+	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <langUsage>
+	      <language ident="fr-CA" usage="60">Québecois</language>
+	      <language ident="en-CA" usage="20">Canadian business English</language>
+	      <language ident="en-GB" usage="20">British English</language>
+	    </langUsage>
+	  </egXML>
+	  </p>
+	  <p>The <gi>textClass</gi> element classifies a text. This may be done with reference to a
+	  classification system locally defined by means of the <gi>classDecl</gi> element, or by
+	  reference to some externally defined established scheme such as the Universal Decimal
+	  Classification. Texts may also be classified using lists of keywords, which may themselves be
+	  drawn from locally or externally defined control lists. The following elements are used to
+	  supply such classifications: <specList>
+	  <specDesc key="classCode"/>
+	  <specDesc key="catRef"/>
+	  <specDesc key="keywords"/>
+	</specList>
+	  </p>
+	  <p>The simplest way of classifying a text is by means of the <gi>classCode</gi> element. For
+	  example, a text with classification 410 in the Universal Decimal Classification might be
+	  documented as follows: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <classCode scheme="http://www.udc.org">410</classCode>
+	</egXML>
+	  </p>
+	  <p>When a classification scheme has been locally defined using the <gi>taxonomy</gi> element
+	  discussed in the preceding subsection, the <gi>catRef</gi> element should be used to reference
+	  it. To continue the earlier example, a work classified in the Brown Corpus as <code>Press
+	  reportage - Sunday</code> and also as <code>Religion</code> might be documented as follows:
+	  <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <catRef target="#B.A3 #B.D"/>
+	  </egXML>
+	  </p>
+	  <p>The element <gi>keywords</gi> contains a list of keywords or phrases identifying the topic
+	  or nature of a text. As usual, the attribute <att>scheme</att> identifies the source from
+	  which these terms are taken. For example, if the LC Subject Headings are used, following
+	  declaration of that classification system in a <gi>taxonomy</gi> element as above : <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <textClass>
+	    <keywords scheme="#LCSH">
+	      <list>
+		<item>English literature -- History and criticism -- Data processing.</item>
+		<item>English literature -- History and criticism -- Theory etc.</item>
+		<item>English language -- Style -- Data processing.</item>
+	      </list>
+	    </keywords>
+	  </textClass>
+	</egXML>
+	  </p>
+	  <p>Multiple classifications may be supplied using
+	  any of the mechanisms described in this section.</p>
+	</div>
+	<div>
+	  <head>The Revision Description</head>
+	  <p>The <gi>revisionDesc</gi> element provides a change log in which each change made to a text
+	  may be recorded. The log may be recorded as a sequence of <gi>change</gi> elements each of
+	  which contains a brief description of the change. The attributes <att>when</att> and
+	  <att>who</att> may be used to identify when the change was carried out and the agency
+	  responsible for it. </p>
+	  <p>Example: <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	  <revisionDesc>
+	    <change when="1991-03-06" who="#EMB">File format updated</change>
+	    <change when="1990-05-25" who="#EMB">Stuart's corrections entered</change>
+	  </revisionDesc>
+	</egXML>
+	  </p>
+	  <p>In a production environment it will usually be found preferable to use some kind of
+	  automated system to track and record changes. Many such <term>version control systems</term>,
+	  as they are known, can also be configured to update the TEI Header of a file automatically.
+	  </p>
+	</div>
+      </div>
+    </body>
+    <back>
+      <div>
+	<head>List of Elements Described</head>
+	<p>The TEI Lite schema is a pure subset of TEI P5. In the following list of elements and classes
+	used, some information, notably the examples, derives from the canonical definition for the
+	element in TEI P5 and may therefore refer to elements or attributes not provided by TEI Lite.
+	Note however that only the elements listed here are available within the TEI Lite schema. These
+	specifications also refer to many attributes which although available in TEI Lite are not
+	discussed in this tutorial for lack of space. </p>
+	<schemaSpec ident="tei_lite" start="TEI teiCorpus">
+	  <moduleRef key="tei"/>
+	  <moduleRef key="core"
+		     include="abbr add addrLine address author bibl biblScope choice cit corr date del desc divGen editor emph expan foreign gap gloss graphic head hi index item l label lb lg list listBibl  mentioned milestone name note num orig p pb ptr pubPlace publisher q ref reg relatedItem resp respStmt rs sic soCalled sp speaker stage teiCorpus term time title unclear"/>
+	  <moduleRef key="header"
+		     include="authority availability catDesc catRef category change classCode classDecl creation distributor edition editionStmt editorialDecl encodingDesc extent fileDesc funder idno keywords langUsage language licence notesStmt principal profileDesc projectDesc publicationStmt refsDecl revisionDesc samplingDecl seriesStmt sourceDesc sponsor taxonomy teiHeader textClass titleStmt"/>
+	  <moduleRef key="textstructure"
+		     include="TEI argument back body byline closer dateline div         docAuthor docDate docEdition docImprint docTitle         epigraph front group imprimatur opener postscript salute signed text titlePage titlePart trailer"/>
+	  <moduleRef key="figures" include="cell figure figDesc formula row table"/>
+	  <moduleRef key="linking" include="anchor seg"/>
+	  <moduleRef key="analysis" include="interp interpGrp pc s w"/>
+	  <moduleRef key="tagdocs" include="att code eg gi ident val"/>
+	  <!-- this version is compiled against P5 2.1 and no other, so we suppress @version  -->
+	  <elementSpec ident="TEI" mode="change">
+	    <attList>
+	      <attDef ident="version" mode="delete"/>
+	    </attList>
+	  </elementSpec>
+	  <classRef key="att.global.facs"/>
+	  <classSpec ident="att.global" type="atts" mode="change" module="tei">
+	    <attList>
+	      <attDef ident="xml:base" mode="delete"/>
+	    </attList>
+	  </classSpec>
+	  <classSpec ident="att.global.rendition"
+		     type="atts"
+		     mode="change"
+		     module="tei">
+	    <!-- not much use having @rendition or @style without tagsDecl -->
+	    <attList>
+	      <attDef ident="style" mode="delete"/>
+	      <attDef ident="rendition" mode="delete"/>
+	    </attList>
+	  </classSpec>
 
-     <classSpec type="atts" ident="att.global.linking" module="linking" mode="change">
-      <attList>
-       <attDef ident="synch" mode="delete"/>
-       <attDef ident="sameAs" mode="delete"/>
-       <attDef ident="copyOf" mode="delete"/>
-       <attDef ident="exclude" mode="delete"/>
-       <attDef ident="select" mode="delete"/></attList>
-     </classSpec>
-     <classSpec type="atts" ident="att.datable.w3c" module="tei" mode="change">
-      <attList>
-       <attDef ident="notBefore" mode="delete"/>
-       <attDef ident="notAfter" mode="delete"/>
-       <attDef ident="from" mode="delete"/>
-       <attDef ident="to" mode="delete"/>
-      </attList>
-     </classSpec>
-     <classSpec type="atts" ident="att.datable" module="tei" mode="change">
-      <attList>
-       <attDef ident="calendar" mode="delete"/>
-      </attList>
-     </classSpec>
-     <classSpec type="atts" ident="att.internetMedia" module="tei" mode="delete"/>
-     <classSpec type="model" ident="model.msItemPart" module="tei" mode="delete"/>
-     <!-- ??? -->
-     <classSpec type="model" ident="model.msQuoteLike" module="tei" mode="delete"/>
-     <classSpec type="model" ident="model.personPart" module="tei" mode="delete"/>
-     
-     
-<!--     MH 2014-11-19: 
-     From http://sourceforge.net/p/tei/bugs/688/
-     Since we have to replace the examples in P5, which contain elements not 
-     permitted in TEI Lite, we might as well fix the confusing content model
-     at the same time.
-     -->
-     <elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="header" ident="editorialDecl" mode="change">
-      <content>
-       <oneOrMore xmlns="http://relaxng.org/ns/structure/1.0">
-        <choice>
-         <ref name="model.pLike"/>
-        </choice>
-       </oneOrMore>
-      </content>
-      
-      <exemplum xml:lang="en">
-       <egXML xmlns="http://www.tei-c.org/ns/Examples">
-        <editorialDecl>
-          <p>All words converted to Modern American spelling using
-           Websters 9th Collegiate dictionary
-          </p>
-          <p>All opening quotation marks converted to “ all closing
-           quotation marks converted to &amp;cdq;.</p>
-        </editorialDecl>
-       </egXML>
-      </exemplum>
-      <exemplum versionDate="2008-04-06" xml:lang="fr">
-       <egXML xmlns="http://www.tei-c.org/ns/Examples">
-        <editorialDecl>
-          <p>Certains mots coupés par accident typographique en fin de ligne ont été réassemblés
-           sans commentaire.</p>
-          <p>Les "guillements français" ont été remplacée par des "guillemets droits" (sans
-           symétrie)</p>
-        </editorialDecl>
-       </egXML>
-      </exemplum>
-      <exemplum xml:lang="zh-TW">
-       <egXML xmlns="http://www.tei-c.org/ns/Examples">
-        <editorialDecl>
-          <p> 所有字皆轉換為源自Websters 9th Collegiate字典的現代美語拼法</p>
-          <p>所有的前括號都改成" 後括號都改成 "</p>
-        </editorialDecl>
-       </egXML>
-      </exemplum>
-      
-     </elementSpec>
-     <!-- changed this example per bug #1266 but I fear there are many more similar cases
-         and that the effort is probably not worth making LB 2015-10-03 -->
-     
-     <elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="core" ident="cit" mode="change">  
-      <exemplum xml:lang="en">
-       <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#DSHD-eg-30">
-        <cit>
-         <q>and the breath of the whale is frequently attended with such an insupportable smell,
-          as to bring on disorder of the brain.</q>
-         <bibl>Ulloa's South America</bibl>
-        </cit>
-       </egXML>
-      </exemplum>
-      <exemplum versionDate="2008-04-06" xml:lang="fr">
-       <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#fr-ex-Perec-vie">
-        <cit>
-         <q>Regarde de tous tes yeux, regarde</q>
-         <bibl>Jules Verne, Michel Strogof</bibl>
-        </cit>
-       </egXML>
-      </exemplum>
-     </elementSpec>
-    </schemaSpec>
-   </div>
-  </back>
- </text>
+	  <classSpec type="atts"
+		     ident="att.global.linking"
+		     module="linking"
+		     mode="change">
+	    <attList>
+	      <attDef ident="synch" mode="delete"/>
+	      <attDef ident="sameAs" mode="delete"/>
+	      <attDef ident="copyOf" mode="delete"/>
+	      <attDef ident="exclude" mode="delete"/>
+	      <attDef ident="select" mode="delete"/>
+	    </attList>
+	  </classSpec>
+	  <classSpec type="atts" ident="att.datable.w3c" module="tei" mode="change">
+	    <attList>
+	      <attDef ident="notBefore" mode="delete"/>
+	      <attDef ident="notAfter" mode="delete"/>
+	      <attDef ident="from" mode="delete"/>
+	      <attDef ident="to" mode="delete"/>
+	    </attList>
+	  </classSpec>
+	  <classSpec type="atts" ident="att.datable" module="tei" mode="change">
+	    <attList>
+	      <attDef ident="calendar" mode="delete"/>
+	    </attList>
+	  </classSpec>
+	  <classSpec type="atts"
+		     ident="att.internetMedia"
+		     module="tei"
+		     mode="delete"/>
+	  <classSpec type="model"
+		     ident="model.msItemPart"
+		     module="tei"
+		     mode="delete"/>
+	  <!-- ??? -->
+	  <classSpec type="model"
+		     ident="model.msQuoteLike"
+		     module="tei"
+		     mode="delete"/>
+	  <classSpec type="model"
+		     ident="model.personPart"
+		     module="tei"
+		     mode="delete"/>
+	  
+	  
+	  <!--     MH 2014-11-19: 
+	       From http://sourceforge.net/p/tei/bugs/688/
+	       Since we have to replace the examples in P5, which contain elements not 
+	       permitted in TEI Lite, we might as well fix the confusing content model
+	       at the same time.
+	  -->
+	  <elementSpec module="header" ident="editorialDecl" mode="change">
+	    <content>
+	      <alternate minOccurs="1" maxOccurs="unbounded">
+		<classRef key="model.pLike"/>
+	      </alternate>
+	    </content>
+	    
+	    <exemplum xml:lang="en">
+	      <egXML xmlns="http://www.tei-c.org/ns/Examples">
+		<editorialDecl>
+		  <p>All words converted to Modern American spelling using
+		  Websters 9th Collegiate dictionary</p>
+		  <p>All opening quotation marks converted to “ all closing
+		  quotation marks converted to &amp;cdq;.</p>
+		</editorialDecl>
+	      </egXML>
+	    </exemplum>
+	    <exemplum versionDate="2008-04-06" xml:lang="fr">
+	      <egXML xmlns="http://www.tei-c.org/ns/Examples">
+		<editorialDecl>
+		  <p>Certains mots coupés par accident typographique en fin de ligne ont été réassemblés
+		  sans commentaire.</p>
+		  <p>Les "guillements français" ont été remplacée par des "guillemets droits" (sans
+		  symétrie)</p>
+		</editorialDecl>
+	      </egXML>
+	    </exemplum>
+	    <exemplum xml:lang="zh-TW">
+	      <egXML xmlns="http://www.tei-c.org/ns/Examples">
+		<editorialDecl>
+		  <p> 所有字皆轉換為源自Websters 9th Collegiate字典的現代美語拼法</p>
+		  <p>所有的前括號都改成" 後括號都改成 "</p>
+		</editorialDecl>
+	      </egXML>
+	    </exemplum>
+	    
+	  </elementSpec>
+	  <!-- changed this example per bug #1266 but I fear
+	       there are many more similar cases and that the
+	       effort is probably not worth making LB 2015-10-03
+	  -->
+	  
+	  <elementSpec module="core" ident="cit" mode="change">  
+	    <exemplum xml:lang="en">
+	      <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#DSHD-eg-30">
+		<cit>
+		  <q>and the breath of the whale is frequently attended with such an insupportable smell,
+		  as to bring on disorder of the brain.</q>
+		  <bibl>Ulloa's South America</bibl>
+		</cit>
+	      </egXML>
+	    </exemplum>
+	    <exemplum versionDate="2008-04-06" xml:lang="fr">
+	      <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#fr-ex-Perec-vie">
+		<cit>
+		  <q>Regarde de tous tes yeux, regarde</q>
+		  <bibl>Jules Verne, Michel Strogof</bibl>
+		</cit>
+	      </egXML>
+	    </exemplum>
+	  </elementSpec>
+	</schemaSpec>
+      </div>
+    </back>
+  </text>
 </TEI>

--- a/P5/Exemplars/tei_math.odd
+++ b/P5/Exemplars/tei_math.odd
@@ -71,7 +71,7 @@
         <moduleRef key="figures"/>
         <elementSpec module="figures" ident="formula" mode="change">
           <content>
-            <rng:ref name="mathml.math"/>
+	    <elementRef key="mathml.math"/>
           </content>
         </elementSpec>
 

--- a/P5/Exemplars/tei_tite.odd
+++ b/P5/Exemplars/tei_tite.odd
@@ -1043,7 +1043,7 @@ some say, "No."
        <memberOf key="att.global"/>
       </classes>
       <content>
-       <rng:ref name="macro.paraContent"/>
+       <macroRef key="macro.paraContent"/>
       </content>
      </elementSpec>
      <elementSpec ident="i" mode="add" ns="http://www.tei-c.org/ns/tite/1.0">
@@ -1054,7 +1054,7 @@ some say, "No."
        <memberOf key="att.global"/>
       </classes>
       <content>
-       <rng:ref name="macro.paraContent"/>
+       <macroRef key="macro.paraContent"/>
       </content>
      </elementSpec>
      <elementSpec ident="ul" mode="add" ns="http://www.tei-c.org/ns/tite/1.0">
@@ -1065,7 +1065,7 @@ some say, "No."
        <memberOf key="att.global"/>
       </classes>
       <content>
-       <rng:ref name="macro.paraContent"/>
+       <macroRef key="macro.paraContent"/>
       </content>
      </elementSpec>
      <elementSpec ident="sub" mode="add" ns="http://www.tei-c.org/ns/tite/1.0">
@@ -1076,7 +1076,7 @@ some say, "No."
        <memberOf key="att.global"/>
       </classes>
       <content>
-       <rng:ref name="macro.paraContent"/>
+       <macroRef key="macro.paraContent"/>
       </content>
      </elementSpec>
      <elementSpec ident="sup" mode="add" ns="http://www.tei-c.org/ns/tite/1.0">
@@ -1087,7 +1087,7 @@ some say, "No."
        <memberOf key="att.global"/>
       </classes>
       <content>
-       <rng:ref name="macro.paraContent"/>
+       <macroRef key="macro.paraContent"/>
       </content>
      </elementSpec>
      <elementSpec ident="smcap" mode="add" ns="http://www.tei-c.org/ns/tite/1.0">
@@ -1098,7 +1098,7 @@ some say, "No."
        <memberOf key="att.global"/>
       </classes>
       <content>
-       <rng:ref name="macro.paraContent"/>
+       <macroRef key="macro.paraContent"/>
       </content>
      </elementSpec>
 
@@ -1112,7 +1112,7 @@ some say, "No."
        <memberOf key="att.global"/>
       </classes>
       <content>
-       <rng:empty/>
+	<empty/>
       </content>
       <attList>
        <attDef ident="ed" mode="add" ns="http://www.tei-c.org/ns/tite/1.0">
@@ -1144,7 +1144,7 @@ some say, "No."
        <memberOf key="att.global"/>
       </classes>
       <content>
-       <rng:text/>
+       <textNode/>
       </content>
      </elementSpec>
     </schemaSpec>

--- a/P5/Exemplars/tei_xinclude.odd
+++ b/P5/Exemplars/tei_xinclude.odd
@@ -1,161 +1,145 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xml:lang="en"  xmlns="http://www.tei-c.org/ns/1.0"
- xmlns:rng="http://relaxng.org/ns/structure/1.0"
- n="tei_xinclude">
-   <teiHeader>
-      <fileDesc>
-         <titleStmt>
-            <title>TEI with XInclude (experimental)</title>
-            <author>Sebastian Rahtz</author>
-         </titleStmt>
-	   <publicationStmt>
-<publisher>TEI Consortium</publisher>
-	     <availability status="free">
-     <licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a Creative
-      Commons Attribution-ShareAlike 3.0 Unported License </licence>
-     <licence target="http://www.opensource.org/licenses/BSD-2-Clause">
-      <p>Copyright 2013 TEI Consortium.</p>
-      <p>All rights reserved.</p>
+<TEI xmlns="http://www.tei-c.org/ns/1.0"
+     xmlns:rng="http://relaxng.org/ns/structure/1.0"
+     xml:lang="en"
+     n="tei_xinclude">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>TEI with XInclude (experimental)</title>
+        <author>Sebastian Rahtz</author>
+      </titleStmt>
+      <publicationStmt>
+        <publisher>TEI Consortium</publisher>
+        <availability status="free">
+          <licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a Creative
+          Commons Attribution-ShareAlike 3.0 Unported License </licence>
+          <licence target="http://www.opensource.org/licenses/BSD-2-Clause">
+            <p>Copyright 2013 TEI Consortium.</p>
+            <p>All rights reserved.</p>
 
-      <p>Redistribution and use in source and binary forms, with or without modification, are
-       permitted provided that the following conditions are met:</p>
-      <list>
-       <item>Redistributions of source code must retain the above copyright notice, this list of
-        conditions and the following disclaimer.</item>
-       <item>Redistributions in binary form must reproduce the above copyright notice, this list of
-        conditions and the following disclaimer in the documentation and/or other materials provided
-        with the distribution.</item>
-      </list>
+            <p>Redistribution and use in source and binary forms, with or without modification, are
+            permitted provided that the following conditions are met:</p>
+            <list>
+              <item>Redistributions of source code must retain the above copyright notice, this list of
+              conditions and the following disclaimer.</item>
+              <item>Redistributions in binary form must reproduce the above copyright notice, this list of
+              conditions and the following disclaimer in the documentation and/or other materials provided
+              with the distribution.</item>
+            </list>
 
 
-      <p>This software is provided by the copyright holders and contributors "as is" and any express
-       or implied warranties, including, but not limited to, the implied warranties of
-       merchantability and fitness for a particular purpose are disclaimed. In no event shall the
-       copyright holder or contributors be liable for any direct, indirect, incidental, special,
-       exemplary, or consequential damages (including, but not limited to, procurement of substitute
-       goods or services; loss of use, data, or profits; or business interruption) however caused
-       and on any theory of liability, whether in contract, strict liability, or tort (including
-       negligence or otherwise) arising in any way out of the use of this software, even if advised
-       of the possibility of such damage.</p>
-     </licence>
-     <p>TEI material can be licensed differently depending on the use you intend to make of it.
-      Hence it is made available under both the CC+BY and BSD-2 licences. The CC+BY licence is
-      generally appropriate for usages which treat TEI content as data or documentation. The BSD-2
-      licence is generally appropriate for usage of TEI content in a software environment. For
-      further information or clarification, please contact the <ref target="mailto:info@tei-c.org"
-       >TEI Consortium</ref>. </p>
-	     </availability>
-	   </publicationStmt>
-         <sourceDesc>
-            <p>authored from scratch</p>
-         </sourceDesc>
-      </fileDesc>
-   </teiHeader>
-<text>
-<body>
-  <p>This customization loads the normal four modules, and adds the
-  <gi>include</gi> element from XInclude (see <ptr
-  target="http://www.w3.org/TR/xinclude/"/> for details on this
-  scheme). This allows you to validate TEI documents
-<emph>before</emph> XInclude processing. In general, this is not
-the right way to work, since you would normally validate after
-any inclusions have been resolved. <gi>include</gi> is set up here to
-  be allowed in the <gi>teiHeader</gi> and instead of or between
-  paragraph-like objects.</p>
+            <p>This software is provided by the copyright holders and contributors "as is" and any express
+            or implied warranties, including, but not limited to, the implied warranties of
+            merchantability and fitness for a particular purpose are disclaimed. In no event shall the
+            copyright holder or contributors be liable for any direct, indirect, incidental, special,
+            exemplary, or consequential damages (including, but not limited to, procurement of substitute
+            goods or services; loss of use, data, or profits; or business interruption) however caused
+            and on any theory of liability, whether in contract, strict liability, or tort (including
+            negligence or otherwise) arising in any way out of the use of this software, even if advised
+            of the possibility of such damage.</p>
+          </licence>
+          <p>TEI material can be licensed differently depending on the use you intend to make of it.
+          Hence it is made available under both the CC+BY and BSD-2 licences. The CC+BY licence is
+          generally appropriate for usages which treat TEI content as data or documentation. The BSD-2
+          licence is generally appropriate for usage of TEI content in a software environment. For
+          further information or clarification, please contact the <ref target="mailto:info@tei-c.org">TEI Consortium</ref>. </p>
+        </availability>
+      </publicationStmt>
+      <sourceDesc>
+        <p>authored from scratch</p>
+      </sourceDesc>
+    </fileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <p>This customization loads the normal four modules, and adds the
+      <gi>include</gi> element from XInclude (see <ptr target="http://www.w3.org/TR/xinclude/"/> for details on this
+      scheme). This allows you to validate TEI documents
+      <emph>before</emph> XInclude processing. In general, this is not
+      the right way to work, since you would normally validate after
+      any inclusions have been resolved. <gi>include</gi> is set up here to
+      be allowed in the <gi>teiHeader</gi> and instead of or between
+      paragraph-like objects.</p>
 
-    <schemaSpec ident="tei_xinclude" start="TEI teiCorpus">
-      <moduleRef key="header"/>
-      <moduleRef key="core"/>
-      <moduleRef key="tei"/>
-      <moduleRef key="textstructure"/>
-      <elementSpec 
-	  xmlns:rng="http://relaxng.org/ns/structure/1.0"
-	  ident="include" 
-	  ns="http://www.w3.org/2001/XInclude" 
-	  mode="add">
-	<desc  xml:lang="en" versionDate="2014-01-12">The W3C XInclude element</desc>
-	<classes>
-	  <memberOf key="model.common"/>
-	  <memberOf key="model.teiHeaderPart"/>
-	</classes>
-	<content>
-	  <rng:optional>
-	    <rng:ref name="fallback"/>
-	  </rng:optional>
-	</content>
-	<attList>
-	  <attDef ident="href">
-	    <desc  xml:lang="en" versionDate="2014-01-12">pointer to the resource being included</desc>
-	    <datatype>
-	      <dataRef key="teidata.pointer"/>
-	    </datatype>
-	  </attDef>
-	  
-	  <attDef ident="parse"  usage="opt">
-	    <defaultVal>xml</defaultVal>
-	    <valList type="closed">
-	      <valItem ident="xml"/>
-	      <valItem ident="text"/>
-	    </valList>
-	  </attDef>
-	  
-	  <attDef ident="xpointer" usage="opt">
-	    <datatype>
-	      <rng:text/>
-	    </datatype>
-	  </attDef>
-	  
-	  <attDef ident="encoding"  usage="opt">
-	    <datatype>
-	      <rng:text/>
-	    </datatype>
-	  </attDef>
-	  
-	  <attDef ident="accept" usage="opt">
-	    <datatype>
-	      <rng:text/>
-	    </datatype>
-	  </attDef>
-	  
-	  <attDef ident="accept-charset"  usage="opt">
-	    <datatype>
-	      <rng:text/>
-	    </datatype>
-	  </attDef>
-	  
-	  <attDef ident="accept-language"  usage="opt">
-	    <datatype>
-	      <rng:text/>
-	    </datatype>
-	  </attDef>
-	</attList>
-      </elementSpec>
-      
-      <elementSpec 
-	  xmlns:rng="http://relaxng.org/ns/structure/1.0"
-	  ident="fallback" 
-	  ns="http://www.w3.org/2001/XInclude" 
-	  mode="add">
-	<desc  xml:lang="en" versionDate="2014-01-12">Wrapper for fallback elements if an XInclude fails</desc>
-	<content>
-	  <oneOrMore xmlns="http://relaxng.org/ns/structure/1.0">
-	    <choice>
-	      <text/>
-	      <ref name="macro.anyThing"/>
-	    </choice>
-	  </oneOrMore>
-	</content>
-      </elementSpec>
- <macroSpec ident="macro.anyThing" mode="add">
-      <content>
-	<?NameList?>
-      </content>
-    </macroSpec>
-      
-    </schemaSpec>
-</body>
-</text>
+      <schemaSpec ident="tei_xinclude" start="TEI teiCorpus">
+        <moduleRef key="header"/>
+        <moduleRef key="core"/>
+        <moduleRef key="tei"/>
+        <moduleRef key="textstructure"/>
+        <elementSpec ident="include" ns="http://www.w3.org/2001/XInclude" mode="add">
+          <desc xml:lang="en" versionDate="2014-01-12">The W3C XInclude element</desc>
+          <classes>
+            <memberOf key="model.common"/>
+            <memberOf key="model.teiHeaderPart"/>
+          </classes>
+          <content>
+            <elementRef key="fallback" minOccurs="0"/>
+          </content>
+          <attList>
+            <attDef ident="href">
+              <desc xml:lang="en" versionDate="2014-01-12">pointer to the resource being included</desc>
+              <datatype>
+                <dataRef key="teidata.pointer"/>
+              </datatype>
+            </attDef>
+            
+            <attDef ident="parse" usage="opt">
+              <defaultVal>xml</defaultVal>
+              <valList type="closed">
+                <valItem ident="xml"/>
+                <valItem ident="text"/>
+              </valList>
+            </attDef>
+            
+            <attDef ident="xpointer" usage="opt">
+              <datatype>
+                <dataRef key="teidata.text"/>
+              </datatype>
+            </attDef>
+            
+            <attDef ident="encoding" usage="opt">
+              <datatype>
+                <dataRef key="teidata.text"/>
+              </datatype>
+            </attDef>
+            
+            <attDef ident="accept" usage="opt">
+              <datatype>
+                <dataRef key="teidata.text"/>
+              </datatype>
+            </attDef>
+            
+            <attDef ident="accept-charset" usage="opt">
+              <datatype>
+                <dataRef key="teidata.text"/>
+              </datatype>
+            </attDef>
+            
+            <attDef ident="accept-language" usage="opt">
+              <datatype>
+                <dataRef key="teidata.text"/>
+              </datatype>
+            </attDef>
+          </attList>
+        </elementSpec>
+        
+        <elementSpec ident="fallback" ns="http://www.w3.org/2001/XInclude" mode="add">
+          <desc xml:lang="en" versionDate="2014-01-12">Wrapper for fallback elements if an XInclude fails</desc>
+          <content>
+            <alternate minOccurs="1" maxOccurs="unbounded">
+              <textNode/>
+              <macroRef key="macro.anyThing"/>
+            </alternate>
+          </content>
+        </elementSpec>
+        <macroSpec ident="macro.anyThing" mode="add">
+          <content>
+            <?NameList?>
+          </content>
+        </macroSpec>
+        
+      </schemaSpec>
+    </body>
+  </text>
 </TEI>
-
-
-


### PR DESCRIPTION
Per @raffazizzi’s request to Council of 2019-03-20T18:07-04, replace RELAX NG with Pure ODD in Exemplars wherever easy. This PR leaves only ITS and SVG as the only exemplar ODDs left containing any RELAX NG constructs.

Warning to reviewers and mergers: the process made lots of whitespace changes to the files, so the built-in GitHub diff may not be that useful. All actual code changes were on lines that had “rng:” on them (and don’t anymore :-)