### PR TITLE
Testing odd2json output in multiple langs

### DIFF
--- a/P5/antbuilder.xml
+++ b/P5/antbuilder.xml
@@ -55,13 +55,40 @@
     <delete dir="Schema"/>
     <mkdir dir="Schema"/>
     
-    <xslt processor="trax" force="yes" style="${XSL}/odds/odd2json.xsl" in="p5subset.xml" out="p5subset.js">
-      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
-      <param name="callback" expression="teijs"/>
-    </xslt>
     <xslt processor="trax" force="yes" style="${XSL}/odds/odd2json.xsl" in="p5subset.xml" out="p5subset.json">
       <factory name="net.sf.saxon.TransformerFactoryImpl"/>
-      <param name="callback" expression=""/>
+    </xslt>
+    <xslt processor="trax" force="yes" style="${XSL}/odds/odd2json.xsl" in="p5subset.xml" out="p5subset_en.json">
+      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <param name="doclang" expression="en"/>
+    </xslt>
+    <xslt processor="trax" force="yes" style="${XSL}/odds/odd2json.xsl" in="p5subset.xml" out="p5subset_de.json">
+      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <param name="doclang" expression="de"/>
+    </xslt>
+    <xslt processor="trax" force="yes" style="${XSL}/odds/odd2json.xsl" in="p5subset.xml" out="p5subset_es.json">
+      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <param name="doclang" expression="es"/>
+    </xslt>
+    <xslt processor="trax" force="yes" style="${XSL}/odds/odd2json.xsl" in="p5subset.xml" out="p5subset_fr.json">
+      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <param name="doclang" expression="fr"/>
+    </xslt>
+    <xslt processor="trax" force="yes" style="${XSL}/odds/odd2json.xsl" in="p5subset.xml" out="p5subset_it.json">
+      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <param name="doclang" expression="it"/>
+    </xslt>
+    <xslt processor="trax" force="yes" style="${XSL}/odds/odd2json.xsl" in="p5subset.xml" out="p5subset_ja.json">
+      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <param name="doclang" expression="ja"/>
+    </xslt>
+    <xslt processor="trax" force="yes" style="${XSL}/odds/odd2json.xsl" in="p5subset.xml" out="p5subset_ko.json">
+      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <param name="doclang" expression="ko"/>
+    </xslt>
+    <xslt processor="trax" force="yes" style="${XSL}/odds/odd2json.xsl" in="p5subset.xml" out="p5subset_zh-TW.json">
+      <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <param name="doclang" expression="zh-TW"/>
     </xslt>
     <xslt processor="trax" force="yes" style="${XSL}/odds/odd2xslstripspace.xsl" in="p5subset.xml" out="stripspace.xsl.model">
       <factory name="net.sf.saxon.TransformerFactoryImpl"/>


### PR DESCRIPTION
Modified p5subset.json output to generate separate files for supported languages so that they will be in the Vault. 

Tested successfully locally.