### PR TITLE
change teiCorpus content model

### DIFF
--- a/P5/Source/Specs/teiCorpus.xml
+++ b/P5/Source/Specs/teiCorpus.xml
@@ -36,25 +36,17 @@
   <content>
     <sequence>
       <elementRef key="teiHeader"/>
-      <alternate>
-        <sequence>
-          
-            <classRef key="model.resourceLike" minOccurs="1" maxOccurs="unbounded"/>
-          
-          
-            <alternate minOccurs="0" maxOccurs="unbounded">
-              <elementRef key="TEI"/>
-              <elementRef key="teiCorpus"/>
-            </alternate>
-          
-        </sequence>
-        
-          <alternate minOccurs="1" maxOccurs="unbounded">
-            <elementRef key="TEI"/>
-            <elementRef key="teiCorpus"/>
-          </alternate>
-        
-      </alternate>
+      <sequence>
+        <alternate minOccurs="0" maxOccurs="unbounded">
+          <elementRef key="facsimile"/>
+          <elementRef key="fsdDecl"/>
+          <elementRef key="sourceDoc"/>
+        </alternate>
+        <alternate minOccurs="1" maxOccurs="unbounded">
+          <elementRef key="TEI"/>
+          <elementRef key="teiCorpus"/>
+        </alternate>
+      </sequence>
     </sequence>
   </content>
   <attList>


### PR DESCRIPTION
as per Council face2face at Graz #1823.

The one thing I couldn't solve is to allow for interleaved `<TEI>` or `<teiCorpus>`. Those have to be put at the end now. 
The underlying problem of creating an ambiguous content model was already imminent with the old content model once you designed a schema without a member of `model.resourceLike`.