### PR TITLE
Datatype for values that may be value lists or URIs.

### DIFF
--- a/P5/Source/Guidelines/en/ST-Infrastructure.xml
+++ b/P5/Source/Guidelines/en/ST-Infrastructure.xml
@@ -1280,6 +1280,7 @@ entities in the XML DTD fragments.--></p>
           <specDesc key="teidata.pattern"/>
           <specDesc key="teidata.point"/>
           <specDesc key="teidata.pointer"/>
+          <specDesc key="teidata.enumeratedOrPointer"/>
           <specDesc key="teidata.version"/>
           <specDesc key="teidata.versionNumber"/>
           <specDesc key="teidata.replacement"/>
@@ -1293,6 +1294,7 @@ entities in the XML DTD fragments.--></p>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.pattern.xml"/>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.point.xml"/>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.pointer.xml"/>
+        <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.enumeratedOrPointer.xml"/>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.version.xml"/>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.versionNumber.xml"/>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.replacement.xml"/>

--- a/P5/Source/Guidelines/en/ST-Infrastructure.xml
+++ b/P5/Source/Guidelines/en/ST-Infrastructure.xml
@@ -1280,7 +1280,7 @@ entities in the XML DTD fragments.--></p>
           <specDesc key="teidata.pattern"/>
           <specDesc key="teidata.point"/>
           <specDesc key="teidata.pointer"/>
-          <specDesc key="teidata.enumeratedOrPointer"/>
+          <specDesc key="teidata.authority"/>
           <specDesc key="teidata.version"/>
           <specDesc key="teidata.versionNumber"/>
           <specDesc key="teidata.replacement"/>
@@ -1294,7 +1294,7 @@ entities in the XML DTD fragments.--></p>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.pattern.xml"/>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.point.xml"/>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.pointer.xml"/>
-        <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.enumeratedOrPointer.xml"/>
+        <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.authority.xml"/>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.version.xml"/>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.versionNumber.xml"/>
         <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/teidata.replacement.xml"/>

--- a/P5/Source/Specs/move.xml
+++ b/P5/Source/Specs/move.xml
@@ -78,7 +78,7 @@ $Id$
       <desc versionDate="2008-04-05" xml:lang="ja">舞台上の動きの方向を示す．</desc>
       <desc versionDate="2007-06-12" xml:lang="fr">indique la direction d'un mouvement sur scène.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica la direzione di un movimento in scena.</desc>
-      <datatype minOccurs="1" maxOccurs="unbounded"><dataRef key="teidata.enumeratedOrPointer"/></datatype>
+      <datatype minOccurs="1" maxOccurs="unbounded"><dataRef key="teidata.authority"/></datatype>
       <valList type="open">
         <valItem ident="L">
           <gloss versionDate="2007-07-04" xml:lang="en">left</gloss>

--- a/P5/Source/Specs/move.xml
+++ b/P5/Source/Specs/move.xml
@@ -78,7 +78,7 @@ $Id$
       <desc versionDate="2008-04-05" xml:lang="ja">舞台上の動きの方向を示す．</desc>
       <desc versionDate="2007-06-12" xml:lang="fr">indique la direction d'un mouvement sur scène.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica la direzione di un movimento in scena.</desc>
-      <datatype minOccurs="1" maxOccurs="unbounded"><dataRef key="teidata.enumerated"/></datatype>
+      <datatype minOccurs="1" maxOccurs="unbounded"><dataRef key="teidata.enumeratedOrPointer"/></datatype>
       <valList type="open">
         <valItem ident="L">
           <gloss versionDate="2007-07-04" xml:lang="en">left</gloss>
@@ -123,11 +123,11 @@ $Id$
           <desc versionDate="2007-01-21" xml:lang="it">centro della scena</desc>
         </valItem>
       </valList>
-      <remarks versionDate="2005-01-14" xml:lang="en">
+      <remarks versionDate="2020-02-12" xml:lang="en">
         <p>Full blocking information will normally require combinations of values, (for example
             <q>UL</q> for <q>upper stage left</q>) and may also require more detailed encoding of
           speed, direction etc. Full documentation of any coding system used should be provided in
-          the header.</p>
+          the header. URIs may be used as values.</p>
       </remarks>
       <remarks xml:lang="fr" versionDate="2007-06-12">
         <p>Donner une information complète de mise en place requiert normalement une combinaison de

--- a/P5/Source/Specs/teidata.authority.xml
+++ b/P5/Source/Specs/teidata.authority.xml
@@ -8,7 +8,8 @@ See the file COPYING.txt for details
 <dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei"
   ident="teidata.authority">
   <desc versionDate="2020-02-12" xml:lang="en">defines attribute values which derive from an 
-    authority list, which may be a word from an enumerated list or a URI.</desc>
+    authority list, which may be an enumerated list defined in the document's schema, a list 
+    or taxonomy elsewhere in the document, or an online taxonomy, gazetteer, or other authority.</desc>
   <content>
     <alternate>
       <dataRef key="teidata.enumerated"/>

--- a/P5/Source/Specs/teidata.authority.xml
+++ b/P5/Source/Specs/teidata.authority.xml
@@ -6,9 +6,9 @@ See the file COPYING.txt for details
 -->
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei"
-  ident="teidata.enumeratedOrPointer">
-  <desc versionDate="2020-02-12" xml:lang="en">defines attribute values which contain either a word
-    from an enumerated list or a URI.</desc>
+  ident="teidata.authority">
+  <desc versionDate="2020-02-12" xml:lang="en">defines attribute values which derive from an 
+    authority list, which may be a word from an enumerated list or a URI.</desc>
   <content>
     <alternate>
       <dataRef key="teidata.enumerated"/>

--- a/P5/Source/Specs/teidata.enumeratedOrPointer.xml
+++ b/P5/Source/Specs/teidata.enumeratedOrPointer.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright TEI Consortium. 
+Dual-licensed under CC-by and BSD2 licences 
+See the file COPYING.txt for details
+-->
+<?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei"
+  ident="teidata.enumeratedOrPointer">
+  <desc versionDate="2020-02-12" xml:lang="en">defines attribute values which contain either a word
+    from an enumerated list or a URI.</desc>
+  <content>
+    <alternate>
+      <dataRef key="teidata.enumerated"/>
+      <dataRef key="teidata.pointer"> </dataRef>
+    </alternate>
+  </content>
+  <remarks versionDate="2020-02-12" xml:lang="en">
+    <p>Attribute values with this datatype should either come from a value list in the attribute
+      specification (<ident type="datatype">teidata.enumerated</ident>) or be a valid URI (<ident
+        type="datatype">teidata.pointer</ident>).</p>
+  </remarks>
+</dataSpec>


### PR DESCRIPTION
As discussed in Council meeting yesterday, the problem of move/@where could be addressed by a datatype that permits either words from a value list or URIs. This pull request implements that feature.