### PR TITLE
subset.xsl rub-a-dubbed

### DIFF
--- a/P5/Utilities/subset.xsl
+++ b/P5/Utilities/subset.xsl
@@ -1,52 +1,122 @@
-<xsl:stylesheet version="2.0"
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-    xpath-default-namespace="http://www.tei-c.org/ns/1.0">
+<xsl:stylesheet version="3.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns="http://www.tei-c.org/ns/1.0"
+  xpath-default-namespace="http://www.tei-c.org/ns/1.0">
+  <!-- © 2020 TEI-C. See near end of file for licensing info. -->
+  <!--
+    Read in p5.xml (the TEI P5 Guidelines source XML), and write out
+    a subset thereof that contains only:
+     * the metadata (i.e., the <teiHeader>),
+     * the division structure (each <div> with just its attributes and
+       heading),
+     * the bibliography structure (each bibliographic entry with just
+       its @xml:id), and most importantly
+     * the specification elements.
+    The output (typically referred to as "p5subset.xml") is intended
+    for use in ODD processing that produces schemas and reference
+    documentation, for which the 6+ MiB of prose is not needed.
+  -->
+  <!--
+    Note: the xmlns default namespace declaration on <stylesheet> is
+    not technically needed, but is there just to make explicit that
+    both the input and output are TEI.
+  -->
+  <!--
+    Written years ago, probably in XSLT 1.0, by Sebastian Rahtz.
+    Re-written in XSLT 3.0 2020-05-10/11 by Syd Bauman.
 
-  <xsl:template match="/">
-    <TEI xmlns="http://www.tei-c.org/ns/1.0">
-      <xsl:copy-of select="TEI/teiHeader"/>
-      <text>
-	<xsl:for-each select="TEI/text/front">
-	  <xsl:copy>
-	    <xsl:call-template name="subdivs"/>
-	  </xsl:copy>
-	</xsl:for-each>
-	<xsl:for-each select="TEI/text/body">
-	  <xsl:copy>
-	    <xsl:call-template name="subdivs"/>
-	  </xsl:copy>
-	</xsl:for-each>
-	<xsl:for-each select="TEI/text/back">
-	  <xsl:copy>
-	    <xsl:call-template name="subdivs"/>
-	  </xsl:copy>
-	</xsl:for-each>
-      </text>
-    </TEI>
+    ――Revision Hx――
+    2020-08-19 by Syd Bauman: Retain shells of bibliographic entries
+    in case something (that is kept) points to them.
+    2020-08-29 by Syd Bauman: Turns out we can't keep indent=yes, as
+    Saxon (both 9.9 and 10.0) inserts a whitespace-only text node at
+    the end of a <gloss> or <desc> (and probably anything else) if it
+    happens to end with a child element.
+    2020-08-30 by Syd Bauman: Better commenting. Also just copy @xml:id
+    of bibliographic entries rather than processing them.
+  -->
+
+  <xsl:output method="xml" indent="no"/>
+  
+  <!-- In most cases, skip the element, but consider its children: -->
+  <xsl:mode on-no-match="shallow-skip"/>
+  
+  <!-- The important parts get copied over in their entirety: -->
+  <xsl:template name="keep_important_stuff_with_contents"
+      match="teiHeader | elementSpec | macroSpec | classSpec | moduleSpec | dataSpec">
+    <xsl:text>&#x0A;</xsl:text>
+    <xsl:copy-of select="." /> <!--Note that comments & PIs are copied, too-->
   </xsl:template>
 
-  <xsl:template name="subdivs">
-    <xsl:apply-templates/>
+  <!-- Each main structural element is kept, but its contents is kept
+       or ditched based on its own merit[1] -->
+  <xsl:template match="TEI | text | front | body | back">
+    <xsl:text>&#x0A;</xsl:text>
+    <xsl:copy>
+      <xsl:apply-templates/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Keep stub bibliography entries just in case someone points to them -->
+  <xsl:template match="listBibl/bibl[@xml:id]|listBibl/biblStruct[@xml:id]">
+    <xsl:text>&#x0A;</xsl:text>
+    <xsl:copy>
+      <xsl:copy-of select="@xml:id"/>
+    </xsl:copy>
   </xsl:template>
   
-  <xsl:template match="@*|text()|processing-instruction()"/>
-  
-  <xsl:template match="*">
-    <xsl:choose>
-      <xsl:when test="self::div">
-	<xsl:copy>
-	  <xsl:copy-of select="@*"/>	  <xsl:copy-of select="head"/>
-	  <xsl:apply-templates/>
-	</xsl:copy>
-      </xsl:when>
-      <xsl:when test="self::elementSpec|self::macroSpec|self::classSpec|self::moduleSpec|self::dataSpec">
-	<xsl:copy-of select="."/>
-      </xsl:when>
-      <xsl:otherwise>
-	<xsl:apply-templates/>
-      </xsl:otherwise>
-    </xsl:choose>
+  <!--
+    Process divisions just so we have a structure thereof; keep the
+    element itself and its heading, but keep the rest of its contents
+    based on its own merit[1]
+  -->
+  <xsl:template match="div" name="keep_skeleton">
+    <xsl:text>&#x0A;</xsl:text>
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <xsl:copy-of select="head"/>
+      <xsl:apply-templates/>
+    </xsl:copy>
   </xsl:template>
-	
+
+  <!--
+      Footnote [1]: That is, throw away or keep the content based on
+      the rest of this stylesheet — keep that which is matched by the
+      keep_important_stuff_with_contents template, above, toss the
+      rest.
+  -->
 
 </xsl:stylesheet>
+
+<!--
+    Copyright 2020 TEI-Consortium
+    Available under The 2-Clause BSD License
+    (https://opensource.org/licenses/BSD-2-Clause):
+
+    Redistribution and use in source and binary forms, with or
+    without modification, are permitted provided that the following
+    conditions are met:
+
+    1. Redistributions of source code must retain the above
+       copyright notice, this list of conditions and the
+       following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials 
+       provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+    CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+    TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+    TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+    THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.
+-->

--- a/P5/Utilities/subset.xsl
+++ b/P5/Utilities/subset.xsl
@@ -6,7 +6,7 @@
   <!--
     Read in p5.xml (the TEI P5 Guidelines source XML), and write out
     a subset thereof that contains only:
-     * the metadata (i.e., the <teiHeader>),
+     * the metadata (that is, the <teiHeader>),
      * the division structure (each <div> with just its attributes and
        heading),
      * the bibliography structure (each bibliographic entry with just
@@ -45,7 +45,7 @@
   <xsl:template name="keep_important_stuff_with_contents"
       match="teiHeader | elementSpec | macroSpec | classSpec | moduleSpec | dataSpec">
     <xsl:text>&#x0A;</xsl:text>
-    <xsl:copy-of select="." /> <!--Note that comments & PIs are copied, too-->
+    <xsl:copy-of select="." /> <!--Comments & PIs inside me are copied, too-->
   </xsl:template>
 
   <!-- Each main structural element is kept, but its contents is kept


### PR DESCRIPTION
### old
The program P5/Utilities/subset.xsl is used to generate p5subset.xml. It has been the same program for years, almost decades. The current version is completely XSLT 1 except for the use of `@xpath-default-namespace`, has **no** comments at all, has at least one case of bizarre indentation, and does not take advantage of XSLT’s default processing model.[1]

### new
This new version is a complete XSLT 3.0 re-write, and is (IMHO) well commented. It does exactly the same thing (in principle) with one addition:  it also puts skeleton bibliographic entries into the subset, so that when a `<ref>` points to one from a `<desc>` (or anything else that makes it into the subset) there is no “target not found” problem.

### testing so far
I have compared the output of this routine to the output of the current one, and as far as I can tell (other than the bibliography) all changes are insignificant: either insignificant whitespace or positioning of namespace declarations.

I have tested locally by building P5, which worked as well as it ever does on my machine; by running Stylesheets/Test2 which passed completely; and by running Stylesheets/Test which failed because of a change from `<ref>` to `<ptr>` in the testdrama.odd test. I _think_ this is because somewhere in ODD processing a `<ptr>` whose target is found is handled differently than one whose target is not found, and with the new p5subset the targets are found. After replacing expected-results/testdrama.compiled.xml with the actual-results/testdrama.compiled.xml the tests ran fine. (Well, as fine as they usually do on my machine, as I do not have `xetex` installed.)  

### reviewing

I requested a whole bunch of reviewers, but that is not because I think it needs lots of reviews. I only think it needs 1 or 2 successful reviews. I listed a lot of you because I thought some might find this an interesting task.

### manual testing

If you, the reviewer, wish to test this locally by hand (rather than by executing the entire build process), you could try the following:
1. process P5/Source/guidelines-en.xml with Utilities/expand.xsl
1. process the output of above with the current Utilities/subset.xsl in the dev branch
1. also process it with the new Utilities/subset.xsl in this branch
1. compare the results

On my machine this might look something like the following.
~~~sh
$ cd ~/Documents/TEI_dev/P5
$ saxon.bash Utilities/expand.xsl Source/guidelines-en.xml > /tmp/GLs_expanded.xml
$ cd /tmp/
$ saxon.bash ~/Documents/TEI_dev/P5/Utilities/subset.xsl GLs_expanded.xml > subset_dev.xml
$ saxon.bash ~/Documents/TEI_sydb-rub-subset-generation/P5/Utilities/subset.xsl GLs_expanded.xml > subset_syds_rubbed_subsetter.xml
$ diff -C0 subset_dev.xml subset_syds_rubbed_subsetter.xml 
~~~
Then you will probably want to make various innocent tweaks to subset_dev.xml to make it easier to compare.[2] Most useful, I think, would be to insert a newline in front of every `<div>` and `<*Spec>` element, perhaps with something like `perl -pe 's,<((class|data|element|macro|module)Spec|div),\n$&,g;' < subset_dev.xml > subset_dev_4_comp.xml`. That one change will remove hundreds of false positives and add one or two.

----

### foonotes

[1] That is, it uses a conditional inside a template where multiple templates would (at least IMHO) be more natural XSLT, and thus more readable and understandable. And we see this sort of structure frequently in the TEI Stylesheets:
~~~xml
  <xsl:template match="*">
    <xsl:choose>
      <xsl:when test="self::one">
        <!-- do one stuff here -->
      </xsl:when>
      <xsl:when test="self::two | self::three">
        <!-- do two and three stuff here -->
      </xsl:when>
      <xsl:otherwise>
        <!-- do four, five, six, seven, and eight stuff here -->
      </xsl:otherwise>
    </xsl:choose>
  </xsl:template>
~~~
Rather than the simpler, shorter, clearer, more obvious
~~~xml
  <xsl:template match="one">
    <!-- do one stuff here -->
  </xsl:template>
  
  <xsl:template match="two | three">
    <!-- do two and three stuff here -->
  </xsl:template>
  
  <xsl:template match="*">
    <!-- do four, five, six, seven, and eight stuff here -->
  </xsl:template>
~~~

[2] By “innocent” I mean changes you know will not make any meaningful difference to the XML tree.