### PR TITLE
type= on interpLike elements

### DIFF
--- a/P5/Source/Guidelines/en/AI-AnalyticMechanisms.xml
+++ b/P5/Source/Guidelines/en/AI-AnalyticMechanisms.xml
@@ -520,8 +520,17 @@ is desired then it may point to <gi>category</gi> element at a suitable level in
 structured vocabulary to particular passages of text are provided by the
 <gi>span</gi> and <gi>interp</gi> elements, and their associated
 grouping elements <gi>spanGrp</gi> and <gi>interpGrp</gi>.
-<specList><specDesc key="span"/><specDesc key="spanGrp"/><specDesc key="interp"/><specDesc key="interpGrp"/></specList>
- </p>
+<specList><specDesc key="span"/><specDesc key="spanGrp"/><specDesc key="interp"/><specDesc key="interpGrp"/></specList></p>
+<!--
+    When Stylesheets bug #370 is fixed we plan to move @type from
+    <interp>, <interpGrp>, <span>, and <spanGrp> into att.interpLike.
+    When that happens, the next bit should be changed to:
+
+<p>These elements are all members of the class <ident type="class">att.interpLike</ident>, and thus share the following attributes:
+<specList><specDesc key="att.interpLike" atts="inst type"/></specList>
+
+    —Syd, 2020-10-30
+-->
 <p>These elements are all members of the class <ident type="class">att.interpLike</ident>, and thus share the following attribute:
 <specList><specDesc key="att.interpLike" atts="inst"/></specList>
   They also inherit the following attributes from <ident type="class">att.global.responsibility</ident>:

--- a/P5/Source/Specs/att.interpLike.xml
+++ b/P5/Source/Specs/att.interpLike.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 Copyright TEI Consortium. 
 Dual-licensed under CC-by and BSD2 licences 
 See the file COPYING.txt for details
 $Date$
 $Id$
---><?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" xml:id="CLINTERP" type="atts" ident="att.interpLike">
+-->
+<?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" xml:id="CLINTERP" type="atts" ident="att.interpLike">
   <desc versionDate="2006-01-05" xml:lang="en">provides attributes for elements which represent a formal analysis or interpretation.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">형식적 분석 또는 해석을 표상하는 요소의 속성을 제공한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">提供元素的屬性，這些元素代表一正式分析或詮釋。</desc>
@@ -14,7 +16,19 @@ $Id$
   <desc versionDate="2007-05-04" xml:lang="es">proporciona atributos para elementos que represental un análisis o interpretación formal.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">assegna degli attributi agli elementi che rappresentano un'analisi o un'interpretazione formali</desc>
   <classes>
+    <memberOf key="att.typed"/>
   </classes>
+  <!--
+      We would like to have a replacement @type attribute defined
+      here, so that all members of this class (currently just
+      <(interp|span)(Grp)?>) can inherit better semantics. But due to
+      a known bug (Stylesheets issue #370) doing so breaks the build.
+      Thus I am TEMPORARILY (I hope) copying the definition of @type
+      out of this file and into each of the four memebers: <interp>,
+      <interpGrp>, <span>, and <spanGrp>. So if you need to make any
+      changes to the @type attribute, sorry to say you will need to
+      make it in 4 different places.
+  -->
   <attList>
     <attDef ident="inst" usage="opt">
       <gloss versionDate="2007-07-02" xml:lang="en">instances</gloss>
@@ -34,7 +48,7 @@ by the current element.</desc>
       <datatype maxOccurs="unbounded"><dataRef key="teidata.pointer"/></datatype>
       <remarks versionDate="2005-10-10" xml:lang="en">
         <p>The current element should be an analytic one.  The element
-	pointed at should be a textual one.</p>
+        pointed at should be a textual one.</p>
       </remarks>
       <remarks xml:lang="fr" versionDate="2007-06-12">
         <p>L'élément courant doit être analytique. L'élément pointé doit être textuel.
@@ -46,7 +60,7 @@ by the current element.</desc>
       <remarks xml:lang="ja" versionDate="2008-04-05">
         <p>当該要素は，分析的なものであるべき．参照されている要素は，
         テキストであるべき．
-	</p>
+        </p>
       </remarks>
     </attDef>
   </attList>

--- a/P5/Source/Specs/interp.xml
+++ b/P5/Source/Specs/interp.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 Copyright TEI Consortium. 
 Dual-licensed under CC-by and BSD2 licences 
 See the file COPYING.txt for details
 $Date$
 $Id$
---><?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="analysis" ident="interp">
+-->
+<?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="analysis" ident="interp">
   <gloss versionDate="2005-01-14" xml:lang="en">interpretation</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">해석</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">解釋</gloss>
@@ -12,32 +14,95 @@ $Id$
   <gloss versionDate="2007-06-12" xml:lang="fr">interprétation</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">interpretación</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">interpretazione</gloss>
-  <desc versionDate="2005-07-30" xml:lang="en">summarizes a specific interpretative annotation which can be linked to a span of text.</desc>
+  <desc versionDate="2005-07-30" xml:lang="en">summarizes a specific
+  interpretative annotation which can be linked to a span of
+  text.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">텍스트의 범위에 연결될 수 있는 명시적인 해석적 부호를 요약한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">標明和某一文字段相連結的特定解釋性註釋。</desc>
   <desc versionDate="2008-04-06" xml:lang="ja">あるテキスト部分とリンクする，特定の解釈的注釈をまとめる．</desc>
-  <desc versionDate="2009-02-13" xml:lang="fr">interprétation sous la forme d'une annotation concise,
-    pouvant être liée à un passage dans un texte</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">resume una anotación interpretativa específica que puede
-    ser conectada con un periodo de texto.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">riassume una specifica annotazione interpretativa che può
-    essere associata ad una porzione di testo</desc>
+  <desc versionDate="2009-02-13" xml:lang="fr">interprétation sous la
+  forme d'une annotation concise, pouvant être liée à un passage dans
+  un texte</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">resume una anotación
+  interpretativa específica que puede ser conectada con un periodo de
+  texto.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">riassume una specifica
+  annotazione interpretativa che può essere associata ad una porzione
+  di testo</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.interpLike"/>
-    <memberOf key="att.typed" />
     <memberOf key="model.global.meta"/>
   </classes>
   <content>
-    
-      <alternate minOccurs="0" maxOccurs="unbounded">
-        <textNode/>
-        <classRef key="model.gLike"/>
-        <classRef key="model.descLike"/>
-        <classRef key="model.certLike"/>
-      </alternate>
-    
+    <alternate minOccurs="0" maxOccurs="unbounded">
+      <textNode/>
+      <classRef key="model.gLike"/>
+      <classRef key="model.descLike"/>
+      <classRef key="model.certLike"/>
+    </alternate>
   </content>
+  <attList>
+    <!--
+	The following <attDef> is a copy of the one in the
+	specifications of <interpGrp>, <span>, and <spanGrp>. It
+	*should* be part of the specification of att.interpLike rather
+	than in the specifications of the individual members of that
+	class. However, a bug in the Stylesheets means that won't work
+	at the moment. (See Stylesheets issue #370.)
+    -->
+    <attDef ident="type" usage="rec" mode="replace">
+      <desc versionDate="2005-10-10" xml:lang="en">indicates what kind of phenomenon is being noted in the passage.</desc>
+      <desc versionDate="2007-12-20" xml:lang="ko">현 단락에 표기되고 있는 현상의 종류를 나타낸다.</desc>
+      <desc versionDate="2007-05-02" xml:lang="zh-TW">指出段落中所註解的現象類別。</desc>
+      <desc versionDate="2008-04-05" xml:lang="ja">当該部分で，どのような面が指摘されているのかを示す．</desc>
+      <desc versionDate="2007-06-12" xml:lang="fr">indique quel genre de phénomène est noté dans le
+      passage.</desc>
+      <desc versionDate="2007-05-04" xml:lang="es">indica que tipo de fenómeno está siendo anotado en el pasaje.</desc>
+      <desc versionDate="2007-01-21" xml:lang="it">indica quale sia il fenomeno osservato nella porzione di testo in questione</desc>
+      <datatype><dataRef key="teidata.enumerated"/></datatype>
+      <valList type="open">
+	<valItem ident="image">
+	  <desc versionDate="2007-06-27" xml:lang="en">identifies an image in the passage.</desc>
+	  <desc versionDate="2007-12-20" xml:lang="ko">단락에서 이미지를 식별한다.</desc>
+	  <desc versionDate="2007-05-02" xml:lang="zh-TW">標明段落中的影像。</desc>
+	  <desc versionDate="2008-04-06" xml:lang="es">identifica una imagen en el pasaje.</desc>
+	  <desc versionDate="2008-04-05" xml:lang="ja">当該部分の画像を指示する．</desc>
+	  <desc versionDate="2008-03-30" xml:lang="fr">identifie une image dans le passage.</desc>
+	  <desc versionDate="2007-01-21" xml:lang="it">identifica un'immagine all'interno della porzione di testo</desc>
+	</valItem>
+	<valItem ident="character">
+	  <desc versionDate="2007-06-27" xml:lang="en">identifies a character associated with the passage.</desc>
+	  <desc versionDate="2007-12-20" xml:lang="ko">단락과 연관된 문자를 식별한다.</desc>
+	  <desc versionDate="2007-05-02" xml:lang="zh-TW">標明與段落相關聯的人物。</desc>
+	  <desc versionDate="2008-04-06" xml:lang="es">identifica un carácter asociado al pasaje.</desc>
+	  <desc versionDate="2008-04-05" xml:lang="ja">当該部分に関連する文字を指示する．</desc>
+	  <desc versionDate="2009-05-27" xml:lang="fr">identifie un personnage associé au
+	  passage.</desc>
+	  <desc versionDate="2007-01-21" xml:lang="it">identifica un personaggio associato al brano in questione</desc>
+	</valItem>
+	<valItem ident="theme">
+	  <desc versionDate="2007-06-27" xml:lang="en">identifies a theme in the passage.</desc>
+	  <desc versionDate="2007-12-20" xml:lang="ko">단락에서 주제를 식별한다.</desc>
+	  <desc versionDate="2007-05-02" xml:lang="zh-TW">標明段落中的主題。</desc>
+	  <desc versionDate="2008-04-06" xml:lang="es">identifica un tema en el pasaje.</desc>
+	  <desc versionDate="2008-04-05" xml:lang="ja">当該部分にあるテーマを指示する．</desc>
+	  <desc versionDate="2008-03-30" xml:lang="fr">identifie un thème dans le passage.</desc>
+	  <desc versionDate="2007-01-21" xml:lang="it">identifica un tema rispetto al brano in questione</desc>
+	</valItem>
+	<valItem ident="allusion">
+	  <desc versionDate="2007-06-27" xml:lang="en">identifies an allusion to another text.</desc>
+	  <desc versionDate="2007-12-20" xml:lang="ko">다른 텍스트에 대한 언급을 식별한다.</desc>
+	  <desc versionDate="2007-05-02" xml:lang="zh-TW">標明另一個文本的引用。</desc>
+	  <desc versionDate="2008-04-06" xml:lang="es">identifica una alusión a otro texto.</desc>
+	  <desc versionDate="2008-04-05" xml:lang="ja">別テキストへの言及．</desc>
+	  <desc versionDate="2008-03-30" xml:lang="fr">identifie une allusion à un autre
+	  texte.</desc>
+	  <desc versionDate="2007-01-21" xml:lang="it">identifica un'allusione a un altro testo</desc>
+	</valItem>
+      </valList>
+    </attDef>
+  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <interp type="structuralunit" xml:id="ana_am">aftermath</interp>

--- a/P5/Source/Specs/interpGrp.xml
+++ b/P5/Source/Specs/interpGrp.xml
@@ -1,10 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 Copyright TEI Consortium. 
 Dual-licensed under CC-by and BSD2 licences 
 See the file COPYING.txt for details
 $Date$
 $Id$
---><?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="analysis" ident="interpGrp">
+-->
+<?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0"
+             xmlns:xi="http://www.w3.org/2001/XInclude"
+             module="analysis" ident="interpGrp">
   <gloss versionDate="2005-01-14" xml:lang="en">interpretation group</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">해석 집단</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">解釋群組</gloss>
@@ -25,19 +30,75 @@ $Id$
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.interpLike"/>
-    <memberOf key="att.typed" />
     <memberOf key="model.global.meta"/>
   </classes>
   <content>
     <sequence>
-      
-        <classRef key="model.descLike" minOccurs="0" maxOccurs="unbounded"/>
-      
-      
-        <elementRef key="interp" minOccurs="1" maxOccurs="unbounded"/>
-      
+      <classRef key="model.descLike" minOccurs="0" maxOccurs="unbounded"/>
+      <elementRef key="interp" minOccurs="1" maxOccurs="unbounded"/>
     </sequence>
   </content>
+  <attList>
+    <!--
+	The following <attDef> is a copy of the one in the
+	specifications of <interpGrp>, <span>, and <spanGrp>. It
+	*should* be part of the specification of att.interpLike rather
+	than in the specifications of the individual members of that
+	class. However, a bug in the Stylesheets means that won't work
+	at the moment. (See Stylesheets issue #370.)
+    -->
+    <attDef ident="type" usage="rec" mode="replace">
+      <desc versionDate="2005-10-10" xml:lang="en">indicates what kind of phenomenon is being noted in the passage.</desc>
+      <desc versionDate="2007-12-20" xml:lang="ko">현 단락에 표기되고 있는 현상의 종류를 나타낸다.</desc>
+      <desc versionDate="2007-05-02" xml:lang="zh-TW">指出段落中所註解的現象類別。</desc>
+      <desc versionDate="2008-04-05" xml:lang="ja">当該部分で，どのような面が指摘されているのかを示す．</desc>
+      <desc versionDate="2007-06-12" xml:lang="fr">indique quel genre de phénomène est noté dans le
+      passage.</desc>
+      <desc versionDate="2007-05-04" xml:lang="es">indica que tipo de fenómeno está siendo anotado en el pasaje.</desc>
+      <desc versionDate="2007-01-21" xml:lang="it">indica quale sia il fenomeno osservato nella porzione di testo in questione</desc>
+      <datatype><dataRef key="teidata.enumerated"/></datatype>
+      <valList type="open">
+	<valItem ident="image">
+	  <desc versionDate="2007-06-27" xml:lang="en">identifies an image in the passage.</desc>
+	  <desc versionDate="2007-12-20" xml:lang="ko">단락에서 이미지를 식별한다.</desc>
+	  <desc versionDate="2007-05-02" xml:lang="zh-TW">標明段落中的影像。</desc>
+	  <desc versionDate="2008-04-06" xml:lang="es">identifica una imagen en el pasaje.</desc>
+	  <desc versionDate="2008-04-05" xml:lang="ja">当該部分の画像を指示する．</desc>
+	  <desc versionDate="2008-03-30" xml:lang="fr">identifie une image dans le passage.</desc>
+	  <desc versionDate="2007-01-21" xml:lang="it">identifica un'immagine all'interno della porzione di testo</desc>
+	</valItem>
+	<valItem ident="character">
+	  <desc versionDate="2007-06-27" xml:lang="en">identifies a character associated with the passage.</desc>
+	  <desc versionDate="2007-12-20" xml:lang="ko">단락과 연관된 문자를 식별한다.</desc>
+	  <desc versionDate="2007-05-02" xml:lang="zh-TW">標明與段落相關聯的人物。</desc>
+	  <desc versionDate="2008-04-06" xml:lang="es">identifica un carácter asociado al pasaje.</desc>
+	  <desc versionDate="2008-04-05" xml:lang="ja">当該部分に関連する文字を指示する．</desc>
+	  <desc versionDate="2009-05-27" xml:lang="fr">identifie un personnage associé au
+	  passage.</desc>
+	  <desc versionDate="2007-01-21" xml:lang="it">identifica un personaggio associato al brano in questione</desc>
+	</valItem>
+	<valItem ident="theme">
+	  <desc versionDate="2007-06-27" xml:lang="en">identifies a theme in the passage.</desc>
+	  <desc versionDate="2007-12-20" xml:lang="ko">단락에서 주제를 식별한다.</desc>
+	  <desc versionDate="2007-05-02" xml:lang="zh-TW">標明段落中的主題。</desc>
+	  <desc versionDate="2008-04-06" xml:lang="es">identifica un tema en el pasaje.</desc>
+	  <desc versionDate="2008-04-05" xml:lang="ja">当該部分にあるテーマを指示する．</desc>
+	  <desc versionDate="2008-03-30" xml:lang="fr">identifie un thème dans le passage.</desc>
+	  <desc versionDate="2007-01-21" xml:lang="it">identifica un tema rispetto al brano in questione</desc>
+	</valItem>
+	<valItem ident="allusion">
+	  <desc versionDate="2007-06-27" xml:lang="en">identifies an allusion to another text.</desc>
+	  <desc versionDate="2007-12-20" xml:lang="ko">다른 텍스트에 대한 언급을 식별한다.</desc>
+	  <desc versionDate="2007-05-02" xml:lang="zh-TW">標明另一個文本的引用。</desc>
+	  <desc versionDate="2008-04-06" xml:lang="es">identifica una alusión a otro texto.</desc>
+	  <desc versionDate="2008-04-05" xml:lang="ja">別テキストへの言及．</desc>
+	  <desc versionDate="2008-03-30" xml:lang="fr">identifie une allusion à un autre
+	  texte.</desc>
+	  <desc versionDate="2007-01-21" xml:lang="it">identifica un'allusione a un altro testo</desc>
+	</valItem>
+      </valList>
+    </attDef>
+  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <interpGrp resp="#TMA" type="structuralunit">

--- a/P5/Source/Specs/span.xml
+++ b/P5/Source/Specs/span.xml
@@ -1,10 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 Copyright TEI Consortium. 
 Dual-licensed under CC-by and BSD2 licences 
 See the file COPYING.txt for details
 $Date$
 $Id$
---><?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="analysis" ident="span">
+-->
+<?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0"
+             xmlns:xi="http://www.w3.org/2001/XInclude"
+             module="analysis" ident="span">
   <desc versionDate="2005-01-14" xml:lang="en">associates an interpretative annotation directly with a span of text.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">해석적 부호를 텍스트의 일정 부분과 직접적으로 연결시킨다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">將詮釋性註釋直接和一段文字段連結。</desc>
@@ -19,7 +24,6 @@ $Id$
     <memberOf key="att.global"/>
     <memberOf key="att.interpLike"/>
     <memberOf key="att.pointing"/>
-    <memberOf key="att.typed" />
     <memberOf key="model.global.meta"/>
   </classes>
   <content>
@@ -29,7 +33,7 @@ $Id$
     <constraint>
       <report xmlns="http://purl.oclc.org/dsdl/schematron" test="@from and @target">
 Only one of the attributes @target and @from may be supplied on <name/>
-         </report>
+      </report>
     </constraint>
   </constraintSpec>
   <constraintSpec ident="targetto" scheme="schematron">
@@ -52,6 +56,65 @@ The attributes @to and @from on <name/> may each contain only a single value</re
     </constraint>
   </constraintSpec>
   <attList>
+    <!--
+        The following <attDef> is a copy of the one in the
+        specifications of <interpGrp>, <span>, and <spanGrp>. It
+        *should* be part of the specification of att.interpLike rather
+        than in the specifications of the individual members of that
+        class. However, a bug in the Stylesheets means that won't work
+        at the moment. (See Stylesheets issue #370.)
+    -->
+    <attDef ident="type" usage="rec" mode="replace">
+      <desc versionDate="2005-10-10" xml:lang="en">indicates what kind of phenomenon is being noted in the passage.</desc>
+      <desc versionDate="2007-12-20" xml:lang="ko">현 단락에 표기되고 있는 현상의 종류를 나타낸다.</desc>
+      <desc versionDate="2007-05-02" xml:lang="zh-TW">指出段落中所註解的現象類別。</desc>
+      <desc versionDate="2008-04-05" xml:lang="ja">当該部分で，どのような面が指摘されているのかを示す．</desc>
+      <desc versionDate="2007-06-12" xml:lang="fr">indique quel genre de phénomène est noté dans le
+      passage.</desc>
+      <desc versionDate="2007-05-04" xml:lang="es">indica que tipo de fenómeno está siendo anotado en el pasaje.</desc>
+      <desc versionDate="2007-01-21" xml:lang="it">indica quale sia il fenomeno osservato nella porzione di testo in questione</desc>
+      <datatype><dataRef key="teidata.enumerated"/></datatype>
+      <valList type="open">
+        <valItem ident="image">
+          <desc versionDate="2007-06-27" xml:lang="en">identifies an image in the passage.</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">단락에서 이미지를 식별한다.</desc>
+          <desc versionDate="2007-05-02" xml:lang="zh-TW">標明段落中的影像。</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">identifica una imagen en el pasaje.</desc>
+          <desc versionDate="2008-04-05" xml:lang="ja">当該部分の画像を指示する．</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">identifie une image dans le passage.</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">identifica un'immagine all'interno della porzione di testo</desc>
+        </valItem>
+        <valItem ident="character">
+          <desc versionDate="2007-06-27" xml:lang="en">identifies a character associated with the passage.</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">단락과 연관된 문자를 식별한다.</desc>
+          <desc versionDate="2007-05-02" xml:lang="zh-TW">標明與段落相關聯的人物。</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">identifica un carácter asociado al pasaje.</desc>
+          <desc versionDate="2008-04-05" xml:lang="ja">当該部分に関連する文字を指示する．</desc>
+          <desc versionDate="2009-05-27" xml:lang="fr">identifie un personnage associé au
+          passage.</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">identifica un personaggio associato al brano in questione</desc>
+        </valItem>
+        <valItem ident="theme">
+          <desc versionDate="2007-06-27" xml:lang="en">identifies a theme in the passage.</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">단락에서 주제를 식별한다.</desc>
+          <desc versionDate="2007-05-02" xml:lang="zh-TW">標明段落中的主題。</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">identifica un tema en el pasaje.</desc>
+          <desc versionDate="2008-04-05" xml:lang="ja">当該部分にあるテーマを指示する．</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">identifie un thème dans le passage.</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">identifica un tema rispetto al brano in questione</desc>
+        </valItem>
+        <valItem ident="allusion">
+          <desc versionDate="2007-06-27" xml:lang="en">identifies an allusion to another text.</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">다른 텍스트에 대한 언급을 식별한다.</desc>
+          <desc versionDate="2007-05-02" xml:lang="zh-TW">標明另一個文本的引用。</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">identifica una alusión a otro texto.</desc>
+          <desc versionDate="2008-04-05" xml:lang="ja">別テキストへの言及．</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">identifie une allusion à un autre
+          texte.</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">identifica un'allusione a un altro testo</desc>
+        </valItem>
+      </valList>
+    </attDef>
     <attDef ident="from" usage="opt">
       <desc versionDate="2013-01-15" xml:lang="en">gives the identifier of the node which is the starting point of the span of text being annotated; if not accompanied by a <att>to</att> attribute, gives the identifier of the node of the entire span of text being annotated.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">현재 부호를 붙이는 단락의 처음을 명시함; <att>to</att> 속성과 같이 쓰이지 않으면

--- a/P5/Source/Specs/spanGrp.xml
+++ b/P5/Source/Specs/spanGrp.xml
@@ -1,10 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 Copyright TEI Consortium. 
 Dual-licensed under CC-by and BSD2 licences 
 See the file COPYING.txt for details
 $Date$
 $Id$
---><?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="analysis" ident="spanGrp">
+-->
+<?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0"
+             xmlns:xi="http://www.w3.org/2001/XInclude"
+             module="analysis" ident="spanGrp">
   <gloss versionDate="2005-01-14" xml:lang="en">span group</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">범위 집단</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">文字段群組</gloss>
@@ -22,14 +27,72 @@ $Id$
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.interpLike"/>
-    <memberOf key="att.typed" />
     <memberOf key="model.global.meta"/>
   </classes>
-  <content>
-    
-      <elementRef key="span" minOccurs="0" maxOccurs="unbounded"/>
-    
+  <content>    
+    <elementRef key="span" minOccurs="0" maxOccurs="unbounded"/>
   </content>
+  <attList>
+    <!--
+        The following <attDef> is a copy of the one in the
+        specifications of <interpGrp>, <span>, and <spanGrp>. It
+        *should* be part of the specification of att.interpLike rather
+        than in the specifications of the individual members of that
+        class. However, a bug in the Stylesheets means that won't work
+        at the moment. (See Stylesheets issue #370.)
+    -->
+    <attDef ident="type" usage="rec" mode="change">
+      <desc versionDate="2005-10-10" xml:lang="en">indicates what kind of phenomenon is being noted in the passage.</desc>
+      <desc versionDate="2007-12-20" xml:lang="ko">현 단락에 표기되고 있는 현상의 종류를 나타낸다.</desc>
+      <desc versionDate="2007-05-02" xml:lang="zh-TW">指出段落中所註解的現象類別。</desc>
+      <desc versionDate="2008-04-05" xml:lang="ja">当該部分で，どのような面が指摘されているのかを示す．</desc>
+      <desc versionDate="2007-06-12" xml:lang="fr">indique quel genre de phénomène est noté dans le
+      passage.</desc>
+      <desc versionDate="2007-05-04" xml:lang="es">indica que tipo de fenómeno está siendo anotado en el pasaje.</desc>
+      <desc versionDate="2007-01-21" xml:lang="it">indica quale sia il fenomeno osservato nella porzione di testo in questione</desc>
+      <datatype><dataRef key="teidata.enumerated"/></datatype>
+      <valList type="open">
+        <valItem ident="image">
+          <desc versionDate="2007-06-27" xml:lang="en">identifies an image in the passage.</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">단락에서 이미지를 식별한다.</desc>
+          <desc versionDate="2007-05-02" xml:lang="zh-TW">標明段落中的影像。</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">identifica una imagen en el pasaje.</desc>
+          <desc versionDate="2008-04-05" xml:lang="ja">当該部分の画像を指示する．</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">identifie une image dans le passage.</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">identifica un'immagine all'interno della porzione di testo</desc>
+        </valItem>
+        <valItem ident="character">
+          <desc versionDate="2007-06-27" xml:lang="en">identifies a character associated with the passage.</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">단락과 연관된 문자를 식별한다.</desc>
+          <desc versionDate="2007-05-02" xml:lang="zh-TW">標明與段落相關聯的人物。</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">identifica un carácter asociado al pasaje.</desc>
+          <desc versionDate="2008-04-05" xml:lang="ja">当該部分に関連する文字を指示する．</desc>
+          <desc versionDate="2009-05-27" xml:lang="fr">identifie un personnage associé au
+          passage.</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">identifica un personaggio associato al brano in questione</desc>
+        </valItem>
+        <valItem ident="theme">
+          <desc versionDate="2007-06-27" xml:lang="en">identifies a theme in the passage.</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">단락에서 주제를 식별한다.</desc>
+          <desc versionDate="2007-05-02" xml:lang="zh-TW">標明段落中的主題。</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">identifica un tema en el pasaje.</desc>
+          <desc versionDate="2008-04-05" xml:lang="ja">当該部分にあるテーマを指示する．</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">identifie un thème dans le passage.</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">identifica un tema rispetto al brano in questione</desc>
+        </valItem>
+        <valItem ident="allusion">
+          <desc versionDate="2007-06-27" xml:lang="en">identifies an allusion to another text.</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">다른 텍스트에 대한 언급을 식별한다.</desc>
+          <desc versionDate="2007-05-02" xml:lang="zh-TW">標明另一個文本的引用。</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">identifica una alusión a otro texto.</desc>
+          <desc versionDate="2008-04-05" xml:lang="ja">別テキストへの言及．</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">identifie une allusion à un autre
+          texte.</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">identifica un'allusione a un altro testo</desc>
+        </valItem>
+      </valList>
+    </attDef>
+  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#CONAAB-eg-150">
       <u xml:id="UU1">Can I have ten oranges and a kilo of bananas please?</u>

--- a/P5/Source/Specs/spanGrp.xml
+++ b/P5/Source/Specs/spanGrp.xml
@@ -41,7 +41,7 @@ $Id$
         class. However, a bug in the Stylesheets means that won't work
         at the moment. (See Stylesheets issue #370.)
     -->
-    <attDef ident="type" usage="rec" mode="change">
+    <attDef ident="type" usage="rec" mode="replace">
       <desc versionDate="2005-10-10" xml:lang="en">indicates what kind of phenomenon is being noted in the passage.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">현 단락에 표기되고 있는 현상의 종류를 나타낸다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">指出段落中所註解的現象類別。</desc>


### PR DESCRIPTION
Turns out we can’t fix #2012 the way we think it should be fixed because of Stylesheets bug 370. So here I have made an outright copy of the type= attribute we wanted to have in att.interpLike (and thus inherited by interp, interpGrp, span, and spanGrp) directly on interp, interpGrp, span, and spanGrp. I have included comments to explain what was going on, thus to make it easy to do the right thing when bug 370 is fixed. Each of this comments contains the string U+0023 370 for easier finding. (Although there may be a few false positives.)