### PR TITLE
Warn if an attDef with a non-colonized @ident has a @ns attribute

### DIFF
--- a/P5/Source/Specs/attDef.xml
+++ b/P5/Source/Specs/attDef.xml
@@ -39,6 +39,13 @@ $Id$
         <elementRef key="remarks" minOccurs="0" maxOccurs="unbounded"/>
     </sequence>
   </content>
+  <constraintSpec ident="attDefNsNCIdent" scheme="schematron">
+    <constraint>
+      <sch:rule context="tei:attDef[@ns]">
+        <sch:report test="not(contains(@ident, ':'))" role="nonfatal">Attribute: This definition of the @<sch:value-of select="@ident"/> attribute declares a namespace URI and uses an unprefixed name. By definition unprefixed attributes are in no namespace. The declared namespace URI will not have an effect.</sch:report>
+      </sch:rule>
+    </constraint>
+  </constraintSpec>
   <constraintSpec ident="attDefContents" scheme="schematron">
     <constraint>
       <ns xmlns="http://purl.oclc.org/dsdl/schematron" prefix="teix" uri="http://www.tei-c.org/ns/Examples"/>


### PR DESCRIPTION
As pointed out in [1] attributes with an unprefixed ("non-colonized") name are in the empty namespace as opposed to unprefixed element names that are in the default namespace. A @‍ns attribute on an attDef with a non-colonized @‍ident thus has no effect. It would bind the default namespace to the value in @‍ns but it would not put the attribute in this namespace.

[1] https://github.com/TEIC/Stylesheets/issues/237#issuecomment-285476102