### PR TITLE
Update SA-LinkingSegmentationAlignment.xml

### DIFF
--- a/P5/Source/Guidelines/en/SA-LinkingSegmentationAlignment.xml
+++ b/P5/Source/Guidelines/en/SA-LinkingSegmentationAlignment.xml
@@ -887,9 +887,11 @@ which is either an <rs>XPATH</rs> as defined above or an
 <rs>IDREF</rs>, the value of an <att>xml:id</att>
 occurring in the document addressed by the base URI in effect
 for the pointer.</p>
-<p>Example: the pointer <code>#left(//gap[1])</code> 
+<p>Example: the pointer <code>#left(//supplied)</code>
 indicates the point between the first <code>lb</code> and the first
-  <code>gap</code> in the <ref target="#SATSXP-ex">example</ref> above.</p>
+<code>supplied</code> in the <ref target="#SATSXP-ex">example</ref> above.</p>
+<p>Example: <code>#left(//gap[1])</code> indicates the point immediately before
+the first <code>gap</code> element in line two and the string <code>si</code>.</p>
 <p>Example: <code>#left(line1)</code> indicates the point immediately before
 the <code><![CDATA[<lb n="1"/>]]></code> element.</p></div>
 


### PR DESCRIPTION
The first example for left() pointer – as far as I understand the pointing scheme – should read "second lb" instead of "first lb"