### PR TITLE
For Stylesheets 471:

### DIFF
--- a/P5/Source/Guidelines/en/AI-AnalyticMechanisms.xml
+++ b/P5/Source/Guidelines/en/AI-AnalyticMechanisms.xml
@@ -848,11 +848,8 @@ Output from the system consists of a segmented and tokenized version
 of the text, in which word class codes have been associated with each
 token. CLAWS offers outputs in a variety of non-XML and XML formats:
 for example, the simplest format for the sample sentence would be:
-<eg xml:space="preserve"><![CDATA[
-The_AT0 victim_NN1 's_POS friends_NN2 told_VVD police_NN2 that_CJT Kruger_NP0 
-drove_VVD into_PRP the_AT0 quarry_NN1 and_CJC never_AV0 surfaced_VVD
-]]></eg>
-</p>
+<eg xml:space="preserve"><![CDATA[The_AT0 victim_NN1 's_POS friends_NN2 told_VVD police_NN2 that_CJT Kruger_NP0 
+drove_VVD into_PRP the_AT0 quarry_NN1 and_CJC never_AV0 surfaced_VVD]]></eg></p>
 <p>This may be easily transformed into an equivalent TEI XML representation:
 
 <egXML xmlns="http://www.tei-c.org/ns/Examples"><s><w ana="#AT0">The </w> 
@@ -901,11 +898,10 @@ used to point to each interpretation is clearly defined. A further
 analysis into phrase and clause elements can be superimposed on the
 word and morpheme tagging in the preceding illustration. For example,
 CLAWS provides the following constituent analysis of the sample
-sentence (the word class codes have been deleted): <eg xml:space="preserve"><![CDATA[
-[N [G The victim's G] friends N] [V told [N police N] [Fn that 
+sentence (the word class codes have been deleted):
+<eg xml:space="preserve"><![CDATA[[N [G The victim's G] friends N] [V told [N police N] [Fn that 
 [N Krueger N] [V [V& drove [P into [N the quarry N]P]V&] and 
-[V+ never surfaced V+]V]Fn]V]]]></eg>
- </p>
+[V+ never surfaced V+]V]Fn]V]]]></eg></p>
 <p>Treating the labels on the brackets as phrase or clause
 interpretations, this analysis of the structure of the example sentence
 can be combined with the word class analysis and represented as follows

--- a/P5/Source/Guidelines/en/SA-LinkingSegmentationAlignment.xml
+++ b/P5/Source/Guidelines/en/SA-LinkingSegmentationAlignment.xml
@@ -2989,23 +2989,19 @@ range. For example, given the following source document:
   </body>
 </egXML>
   and the following external document:
-<eg xml:space="preserve"><![CDATA[
-  <body>
+<eg xml:space="preserve"><![CDATA[  <body>
      <div><include href="example1.xml" xmlns="http://www.w3.org/2001/XInclude"
 xpointer="range(xpath(id('par1')//emph),xpath(id('par2')//emph))"/>
      </div>
- </body>   
-]]></eg>
+ </body>   ]]></eg>
   the resulting document after XInclude processing of this external document
   would be:
-<eg xml:space="preserve"><![CDATA[
-   <body>
+<eg xml:space="preserve"><![CDATA[   <body>
    <div>
      <p xml:id="par1">home, <emph>home</emph> on Brokeback Mountain.</p>
      <p xml:id="par2">That was the <emph>song</emph> that I sang</p>
    </div>
-   </body>
-]]></eg>
+   </body>]]></eg>
   The result of the inclusion is two paragraph elements, while
   the original range designated in the source document
   overlapped two paragraph fragments. 

--- a/P5/Source/Guidelines/en/SG-GentleIntroduction.xml
+++ b/P5/Source/Guidelines/en/SG-GentleIntroduction.xml
@@ -487,14 +487,12 @@ text being encoded.</p>
 
 <div type="div3" xml:id="SG141bis"><head>An Example Schema</head>
 <p>For the purposes of illustrating how a schema works to restrict how XML may be written, we use the RELAX NG compact syntax in what follows. The following schema can be used to validate our example poem:
-<eg xml:space="preserve"><![CDATA[
-anthology_p = element anthology { poem_p+ }
+<eg xml:space="preserve"><![CDATA[anthology_p = element anthology { poem_p+ }
 poem_p = element poem { heading_p?, stanza_p+ }
 stanza_p = element stanza {line_p+}
 heading_p = element heading { text }
 line_p = element line { text }
-start = anthology_p
-]]></eg>
+start = anthology_p]]></eg>
 </p>
 
 <p>Note that this is not the only way in which a RELAX NG schema might
@@ -610,8 +608,8 @@ moment), <!--ebb: This note now seems unnecessary, and the linked example isn't 
 that the fact that verse paragraphs need not start on a line boundary
 seriously complicates the issue; see further section <ptr target="#SG152"/>.</note>--> so no additional elements need be defined
 for it. We could define a couplet as a <gi scheme="imaginary">firstLine</gi> followed by a
-  <gi scheme="imaginary">secondLine</gi>, which distinction might be useful in a study of rhyme schemes.<note place="bottom">This example is probably not a good practice for most XML projects, since XPath provides ways of distinguishing elements in an XML structure by their position, or the order in which they appear in relation to one another, without the need to give them distinct names.</note> <eg><![CDATA[
-couplet_p = element couplet {firstLine_p, secondLine_p}]]></eg>
+  <gi scheme="imaginary">secondLine</gi>, which distinction might be useful in a study of rhyme schemes.<note place="bottom">This example is probably not a good practice for most XML projects, since XPath provides ways of distinguishing elements in an XML structure by their position, or the order in which they appear in relation to one another, without the need to give them distinct names.</note>
+  <eg><![CDATA[couplet_p = element couplet {firstLine_p, secondLine_p}]]></eg>
 <!-- Can't believe it's a good idea to use as an example -->
 	<!-- something we would never do ourselves.              -->
 	<!-- Why not define SONNET, OCTET, QUATRAIN, SESTET?     --></p>
@@ -848,8 +846,7 @@ within the definition for every element to which the attribute is
 attached. We therefore modify the definition for the
 <code>poem_p</code> pattern given above as follows:
 
-<eg xml:space="preserve"><![CDATA[poem_p = element poem {att.status?, heading_p?, stanza_p+}
-]]></eg>
+<eg xml:space="preserve"><![CDATA[poem_p = element poem { att.status?, heading_p?, stanza_p+ }]]></eg>
 
 In RELAX NG, an element pattern simply includes any attribute patterns
 applicable to it along with its other constituents, as shown
@@ -1249,11 +1246,8 @@ references encountered are therefore treated as if they were plain
 text. For example, when we come to write the users' manual for our
 anthology, we may find ourselves often producing text like the
 following:
-<eg xml:space="preserve"><![CDATA[
-Here is an example of the use of the <gi>line</gi> element:
-<![CDATA[<line>[...]</line>]]]]><![CDATA[>
-]]></eg>
-</p>
+<eg xml:space="preserve"><![CDATA[Here is an example of the use of the <gi>line</gi> element:
+<![CDATA[<line>[...]</line>]]]]><![CDATA[>]]></eg></p>
 
 </div>
 </div>

--- a/P5/Source/Guidelines/en/TD-DocumentationElements.xml
+++ b/P5/Source/Guidelines/en/TD-DocumentationElements.xml
@@ -489,13 +489,12 @@ element -->
       <p>When, as here, an example contains valid XML markup, the <gi>egXML</gi> element should be used. In
         such a case, it will clearly be necessary to distinguish the markup within the example from the markup
         of the document itself. In an XML environment, this is easily done by using a different name space for
-        the content of the <gi>egXML</gi> element. For example: <eg xml:space="preserve"><![CDATA[<p>The <gi>term</gi> element may be used 
+        the content of the <gi>egXML</gi> element. For example:
+        <eg xml:space="preserve"><![CDATA[<p>The <gi>term</gi> element may be used 
 to mark any technical term, thus:
 <egXML xmlns="http://www.tei-c.org/ns/Examples">
   This <term>recursion</term> is 
-  giving me a headache.</egXML></p>
-]]></eg>
-      </p>
+  giving me a headache.</egXML></p>]]></eg></p>
       <!-- Removed following erroneous example per ticket https://sourceforge.net/p/tei/bugs/631/-->
       <!--<p>When this approach is taken, but it is also desired to use markup within
 the example for example to indicate some aspect of its formatting, the
@@ -533,13 +532,13 @@ used for recording how parts of the example was rendered.</item>
 to mark any technical term, thus:
 <egXML xmlns="http://www.tei-c.org/ns/Examples">
   This &lt;term&gt;recursion&lt;/term&gt; is 
-  giving me a headache.</egXML></p>
-]]></eg> or, equivalently: <eg xml:space="preserve"><![CDATA[<p>The <gi>term</gi> element may be used 
+  giving me a headache.</egXML></p>]]></eg> or, equivalently:
+        <eg xml:space="preserve"><![CDATA[<p>The <gi>term</gi> element may be used 
 to mark any technical term, thus:
 <egXML xmlns="http://www.tei-c.org/ns/Examples"><![CDATA[
   This <term>recursion</term> is 
-  giving me a headache.]]]]><![CDATA[></egXML></p>
-]]></eg> However, escaping the markup in this way will make it impossible to validate, and should therefore
+  giving me a headache.]]]]><![CDATA[></egXML></p>]]></eg>
+        However, escaping the markup in this way will make it impossible to validate, and should therefore
         generally be avoided. </p>
       <p>If the XML contained in an example is not well-formed then it must either be enclosed in a CDATA
         marked section, or <soCalled>escaped</soCalled> as above: this applies whether the <gi>eg</gi> or

--- a/P5/Source/Guidelines/en/USE.xml
+++ b/P5/Source/Guidelines/en/USE.xml
@@ -1606,8 +1606,8 @@ that practice. -->
             </content>
             <!-- ... -->
           </elementSpec>
-        </egXML> A simple rendering to RELAX NG produces this: <eg xml:space="preserve"><![CDATA[
-performance =
+        </egXML> A simple rendering to RELAX NG produces this:
+        <eg xml:space="preserve"><![CDATA[performance =
  element performance { 
   (model.divTop | model.global)*,
   (model.common, model.global*)+,
@@ -1626,19 +1626,17 @@ performance =
   att.global.linking.attribute.prev,
   att.global.linking.attribute.exclude,
   att.global.linking.attribute.select
-}
-]]></eg> In the above, a subsequent redefinition of the attribute class (such as <ident type="class"
+}]]></eg> In the above, a subsequent redefinition of the attribute class (such as <ident type="class"
           >att.global</ident>) would have no effect, since references to such classes have been
         expanded to reference their constituent attributes.</p>
-      <p> The equivalent parameterized version might look like this: <eg xml:space="preserve"><![CDATA[
-performance =
+      <p> The equivalent parameterized version might look like this:
+        <eg xml:space="preserve"><![CDATA[performance =
   element performance { performance.content, performance.attributes }
 performance.content =
   (model.divTop | model.global)*,
   (model.common, model.global*)+,
   (model.divBottom, model.global*)*
-performance.attributes = att.global.attributes, empty
-]]></eg> Here, the attribute class <ident type="class">att.global</ident> is provided via an
+performance.attributes = att.global.attributes, empty]]></eg> Here, the attribute class <ident type="class">att.global</ident> is provided via an
         explicit reference (<code>att.global.attributes</code>), and can therefore be redefined.
         Moreover, the attributes are separated from the content model, allowing either to be
         overridden.</p>
@@ -1729,9 +1727,8 @@ xsi:schemaLocation { list { teidata.namespace, teidata.pointer }+ }]]></eg> insi
                   <!--...-->
                 </elementSpec>
               </schemaSpec>
-            </egXML> may generate a RELAX NG (compact syntax) pattern like this: <eg><![CDATA[
- tei_sp = element sp { ... }
-]]></eg> References to these patterns (or, in DTDs, parameter entities) also need to be prefixed
+            </egXML> may generate a RELAX NG (compact syntax) pattern like this:
+            <eg><![CDATA[ tei_sp = element sp { ... }]]></eg> References to these patterns (or, in DTDs, parameter entities) also need to be prefixed
             with the same value. </item>
 
           <item>If an element or attribute is being created, its default name is the value of the
@@ -1754,11 +1751,9 @@ xsi:schemaLocation { list { teidata.namespace, teidata.pointer }+ }]]></eg> insi
                 <!-- ... -->
               </elementSpec>
             </egXML> might generate a RELAX NG schema fragment like the following, if the locale is
-            determined to be French: <eg xml:space="preserve"><![CDATA[
-head =
+            determined to be French: <eg xml:space="preserve"><![CDATA[head =
   ## en-tête
-  element head { head.content, head.attributes }
-]]></eg>
+  element head { head.content, head.attributes }]]></eg>
           </item>
         </list> Alternatively, a selection might be made on the basis of the value of the
           <att>version</att> attribute which these elements carry as members of the <ident
@@ -2056,7 +2051,8 @@ will come to grief.--></p>
             </content>
           </elementSpec>
         </egXML> If DTD fragments are being generated (for use as described in <ptr target="#STPE"
-        />), this will result in the following: <eg xml:space="preserve"><![CDATA[<!ENTITY % faith 'INCLUDE' >
+        />), this will result in the following:
+        <eg xml:space="preserve"><![CDATA[<!ENTITY % faith 'INCLUDE' >
 <![ %faith; [
 
 <!--doc:specifies the faith,  religion, or belief set of a person. -->
@@ -2066,8 +2062,7 @@ will come to grief.--></p>
  %att.global.attributes;
  %att.editLike.attributes;
  %att.datable.attributes; >
-]]]]><![CDATA[>
-]]></eg> Here the whole stanza is contained in a marked section (for use as described in <ptr
+]]]]><![CDATA[>]]></eg> Here the whole stanza is contained in a marked section (for use as described in <ptr
           target="#STPEEX"/>), the element name is parameterized (see <ptr target="#STPEGI"/>), and
         the class attributes are entity references derived from the <gi>memberOf</gi> records in
           <gi>classes</gi>. Note the additional attribute which provides a default <att scheme="XML"
@@ -2076,8 +2071,8 @@ will come to grief.--></p>
         automatically without the document author even being aware of it.</p>
 
       <p>A simpler rendition for a flattened DTD generated from a customization will result in the
-        following, with no containing marked section, and no parameterized name: <eg xml:space="preserve"><![CDATA[
-<!ELEMENT faith %macro.phraseSeq;>
+        following, with no containing marked section, and no parameterized name:
+        <eg xml:space="preserve"><![CDATA[<!ELEMENT faith %macro.phraseSeq;>
 <!ATTLIST faith xmlns CDATA "http://www.tei-c.org/ns/1.0">
 <!ATTLIST faith
  %att.global.attribute.xmlspace;
@@ -2102,8 +2097,7 @@ will come to grief.--></p>
  %att.datable.w3c.attribute.notBefore;
  %att.datable.w3c.attribute.notAfter;
  %att.datable.w3c.attribute.from;
- %att.datable.w3c.attribute.to;>
-]]></eg> Here the attributes from classes have been expanded into individual entity references.</p>
+ %att.datable.w3c.attribute.to;>]]></eg> Here the attributes from classes have been expanded into individual entity references.</p>
 
 
 
@@ -2181,16 +2175,15 @@ will come to grief.--></p>
             >tei</ident> module. The declarations for each DTD fragment constituting the module are
           contained within such marked sections. For example, the parameter entity <ident type="pe"
             >TEI.linking</ident> appears twice in <ident type="file">tei.dtd</ident>, once for the
-            <ident type="frag">linking-decl</ident> schema fragment: <eg xml:space="preserve"><![CDATA[
-<!ENTITY % TEI.linking 'IGNORE' >
+            <ident type="frag">linking-decl</ident> schema fragment:
+          <eg xml:space="preserve"><![CDATA[<!ENTITY % TEI.linking 'IGNORE' >
 <![%TEI.linking;[
 <!ENTITY % file.linking-decl PUBLIC '-//TEI P5//ENTITIES Linking, Segmentation, and Alignment//EN' 'linking-decl.dtd' >
 %file.linking-decl;
-]] >]]></eg> and once for the <ident type="frag">linking</ident> schema fragment: <eg xml:space="preserve"><![CDATA[
-<![%TEI.linking;[
+]] >]]></eg> and once for the <ident type="frag">linking</ident> schema fragment:
+          <eg xml:space="preserve"><![CDATA[<![%TEI.linking;[
 <!ENTITY % file.linking PUBLIC '-//TEI P5//ELEMENTS Linking, Segmentation, and Alignment//EN' 'linking.dtd' >
-%file.linking;
-]] >]]></eg> If TEI.linking has its default value of IGNORE, neither declaration has any effect. If
+%file.linking;]] >]]></eg> If TEI.linking has its default value of IGNORE, neither declaration has any effect. If
           however it has the value INCLUDE, then the content of each marked section is acted upon:
           the parameter entities <ident type="pe">file.linking</ident> and <ident type="pe"
             >file.linking-decl</ident> are referenced, which has the effect of embedding the content
@@ -2253,12 +2246,10 @@ will come to grief.--></p>
         <p>These declarations are generated by an ODD processor when TEI DTD fragments are created. </p>
 
         <p> In the RELAX NG schemas, all elements are normally defined using a pattern with the same
-          name as the element (as described in <ptr target="#IM-naming"/>): for example <eg xml:space="preserve"><![CDATA[
-abbr = element abbr { abbr.content, abbr.attributes }
-]]></eg> The easiest way of renaming the element is thus simply to rewrite the pattern with a
-          different element name; any references use the pattern, not the element, name. <eg xml:space="preserve"><![CDATA[
-abbr = element abbrev { abbr.content, abbr.attributes }
-]]></eg> More complex revisions, such as redefining the content of the element (defined by the
+          name as the element (as described in <ptr target="#IM-naming"/>): for example
+          <eg xml:space="preserve"><![CDATA[abbr = element abbr { abbr.content, abbr.attributes }]]></eg> The easiest way of renaming the element is thus simply to rewrite the pattern with a
+          different element name; any references use the pattern, not the element, name.
+          <eg xml:space="preserve"><![CDATA[abbr = element abbrev { abbr.content, abbr.attributes }]]></eg> More complex revisions, such as redefining the content of the element (defined by the
           pattern <ident type="rng">abbr.content</ident>) or its attributes (defined by the pattern
             <ident type="rng">abbr.attributes</ident>) can be accomplished in a similar way, using
           the features of the RELAX NG language. The recommended method of carrying out such

--- a/P5/guidelines.css
+++ b/P5/guidelines.css
@@ -719,6 +719,10 @@ a.bookmarklink:hover {
     text-decoration: underline;
     color: blue;
 }
+a.anchorlink {
+    float: right;
+    text-decoration: none;
+}
 h3:hover span.bookmarklink a.bookmarklink span.pilcrow,
 h4:hover span.bookmarklink a.bookmarklink span.pilcrow,
 h5:hover span.bookmarklink a.bookmarklink span.pilcrow {

--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -61,7 +61,23 @@ $Id$
 	      <anyElement/>
 	    </alternate>
           </content>
-        </elementSpec>
+	</elementSpec>
+	<elementSpec ident="eg" mode="change" module="tagdocs">
+	  <constraintSpec ident="no_leading_nor_trailing_new_newlines" scheme="schematron">
+	    <desc xml:lang="en" versionDate="2020-12-18">
+	      In order to prevent inconsistent <soCalled>sizes</soCalled> of the box
+	      that holds the example in the HTML output, and even moreso to avoid
+	      getting the <quote>bibliography Show all ⚓</quote> looking ugly at the
+	      bottom, there should be no leading nor trailing newlines. If you really
+	      want a newline at the beginning, precede it with U+00A0 (NO-BREAK SPACE);
+	      if you really want a newline at the end, follow it with U+00A0.
+	    </desc>
+	    <constraint>
+	      <sch:report test="matches( .//text()[last()], '&#x0A;\s*$')">trailing newline not allowed</sch:report>
+	      <sch:report test="matches( .//text()[1],      '^\s*&#x0A;')">leading newline not allowed</sch:report>
+	    </constraint>
+	  </constraintSpec>
+	</elementSpec>
         <macroSpec ident="anyISOSchematron" mode="add">
           <content>
             <element xmlns="http://relaxng.org/ns/structure/1.0">


### PR DESCRIPTION
See [Stylesheets repo PR 481](https://github.com/TEIC/Stylesheets/pull/481) (which itself is about Stylesheets ticket 471, hence the name), in particular [today’s comment](https://github.com/TEIC/Stylesheets/pull/481#issuecomment-748269928) for details. 

Summary of changes herein:

 * Update CSS for new class "anchorlink";
 * Add new constraint to `<eg>` element in p5odds, so that in the Guidelines we will never have a leading or trailing newline in an `<eg>` (because the "bibliography Show all ⚓" line looks problematic if there is a trailing newline, and besides, the boxes look inconsistent when sometimes there is and someitmes there isn't);
 * Remove leading and trailing newlines from `<eg>`s in several chapters.

This PR should be considered in conjunction with Stylesheets PR 481.