### PR TITLE
allow name in place; close #1484

### DIFF
--- a/P5/Source/Specs/name.xml
+++ b/P5/Source/Specs/name.xml
@@ -24,6 +24,7 @@
     <memberOf key="att.global"/>
     <memberOf key="model.nameLike.agent"/>
     <memberOf key="model.personPart"/>
+    <memberOf key="model.placeNamePart"/>
     <memberOf key="att.personal"/>
     <memberOf key="att.datable"/>
     <memberOf key="att.editLike"/>


### PR DESCRIPTION
as requested in #1484 person and place elements should allow 'name' child similar to org 
person already does allow name, so only adding name to model.placeNamePart to cover places