### PR TITLE
Oxford commas and other tiny tweaks in FT

### DIFF
--- a/P5/Source/Guidelines/en/FT-TablesFormulaeGraphics.xml
+++ b/P5/Source/Guidelines/en/FT-TablesFormulaeGraphics.xml
@@ -8,7 +8,7 @@ $Id$
 -->
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <div xmlns="http://www.tei-c.org/ns/1.0" type="div1" xml:id="FT" n="22">
-  <head>Tables, Formulæ, Graphics and Notated Music</head>
+  <head>Tables, Formulæ, Graphics, and Notated Music</head>
   <p>Many documents, both historical and contemporary, include not only text,
     but also graphics, artwork, and other images. Although some types of images
     can be represented directly with markup, it is more common practice to
@@ -24,13 +24,13 @@ $Id$
     formulaic notations, for which no notation is defined in these
     Guidelines.</p>
   <p>Finally, documents may contain musical notation, embedded in a manner
-    similar to tables, graphs and formulæ.</p>
+    similar to tables, graphs, and formulæ.</p>
   <p>These areas (graphics, tabular material, and mathematical or other formulæ,
     and music) have in common that they have received considerable attention
     from many other standards bodies or similar professional groups. In part
     because of this, they may frequently be most conveniently encoded and
     processed using some notation not defined by these Guidelines. For these
-    reasons, and others, we consider tables, formulæ, graphics and notated music
+    reasons, and others, we consider tables, formulæ, graphics, and notated music
     together in this chapter.</p>
   <p>As with text markup in general, many incompatible formats have been
     proposed for the representation of graphics, formulæ, and tables in
@@ -123,8 +123,10 @@ this is rarely if ever done in practice.</note-->
         Guidelines distinguish the roles of <term>label</term> and
           <term>data</term> only, but the encoder may define other roles, such
         as <q>derived</q>, <q>numeric</q>, etc., as appropriate. </p>
-      <p>These three attributes are provided by the attribute class <ident type="class">att.tableDecoration</ident> of which both <gi>cell</gi>
-        and <gi>row</gi> are members; see further <ptr target="#STECAT"/>. </p>
+      <p>These three attributes are provided by the attribute class
+      <ident type="class">att.tableDecoration</ident> of which both
+      <gi>cell</gi> and <gi>row</gi> are members; see further <ptr
+      target="#STECAT"/>. </p>
       <p>The following simple example demonstrates how the data presented as a
         labelled list in section <ptr target="#COLI"/> might be represented by
         an encoder wishing to preserve its original appearance as a table:
@@ -261,7 +263,7 @@ this is rarely if ever done in practice.</note-->
       <p>The content of table elements is not limited to <gi>head</gi> and
           <gi>row</gi>. Milestone elements such as <gi>cb</gi> and <gi>lb</gi>
         allow breaks to be signalled inside tables; <gi>figure</gi> provides an
-        option for including data which is not amenable to normal row/cell
+        option for including data which is not amenable to normal row and cell
         analysis; and other elements such as <gi>epigraph</gi> and
           <gi>trailer</gi> provide options for including text which is clearly
         part of the table, but outside the actual tabular layout. This example
@@ -559,14 +561,14 @@ discussion at .</note-->
       described in writings of various kinds. This applies to both historical
       and contemporary documents, even though methods of notating music have
       changed considerably in western history. In most cases, music notation
-      enters the text flow in a way similar to figures, images or graphs. On
+      enters the text flow in a way similar to figures, images, or graphs. On
       other occasions, elements of music notation are treated as inline
       characters in running text.</p>
     <p><gi>notatedMusic</gi> provides a way to signal the presence of music
       notation in text, but defer to other representations, which are not
       covered by the TEI guidelines, to describe the music notation itself. In
-      fact, several commercial, academic and standard bodies have developed
-      digital representations of music notation, and given the topic's
+      fact several commercial, academic, and standard bodies have developed
+      digital representations of music notation; and given the topic's
       complexity, these representations often focus on different aspects and
       adopt different methodologies. Therefore, <gi>notatedMusic</gi> only
       defines a container element to encode the occurrence of music notation and
@@ -866,7 +868,7 @@ discussion at .</note-->
     <head>Overview of Basic Graphics Concepts</head>
     <p>The first major distinction in graphic representation is that between
       raster graphics and vector graphics. A <term>raster image</term> is a list
-      of points, or dots. Scanners, fax machines and other simple devices easily
+      of points, or dots. Scanners, fax machines, and other simple devices easily
       produce digital raster images, and such images are therefore quite common.
       A <term>vector image</term>, in contrast, is a list of geometrical
       objects, such as lines, circles, arcs, or even cubes. These are much more
@@ -973,17 +975,17 @@ discussion at .</note-->
           plain-text encodings; the non-binary forms are safer for blind
           interchange, especially over networks. Documentation on CGM is
           available from ISO and from its member national bodies such as AFNOR,
-          ANSI, BSI, DIN, JIS, etc. </item>
+          ANSI, BSI, DIN, JIS, etc.</item>
         <label>SVG: Scalable Vector Graphics format</label>
         <item>SVG is a language for describing two-dimensional vector and mixed
           vector or raster graphics in XML. It is defined by the Scalable Vector
           Graphics (SVG) 1.0 Specification, W3C Recommendation, 04 September
-          2001, and is available at <ptr target="http://www.w3.org/TR/2001/REC-SVG-20010904/"/>. </item>
+          2001, and is available at <ptr target="http://www.w3.org/TR/2001/REC-SVG-20010904/"/>.</item>
         <label>PICT: Macintosh drawing format</label>
-        <item>This format is universally supported on Macintosh (tm) systems,
+        <item>This format is universally supported on Macintosh™ systems,
           and readable by a limited range of software for other systems.
           Documentation is available from Apple Computer Company, Cupertino,
-          California USA. </item>
+          California USA.</item>
       </list>
     </div>
     <div type="div3" xml:id="FTGRARGF">
@@ -995,7 +997,7 @@ discussion at .</note-->
           well-compressed storage of raster images. Indexed-color, grayscale,
           and truecolor images are supported, plus an optional alpha channel.
           Sample depths range from 1 to 16 bits. It is defined by IETF RFC 2083,
-          March 1997. </item>
+          March 1997.</item>
         <label>TIFF: Tagged Image File Format</label>
         <item>Currently the most widely supported raster image format,
           especially for black and white images, TIFF is also one of the few
@@ -1009,29 +1011,29 @@ discussion at .</note-->
           header for any document including TIFF images. TIFF is owned by Aldus
           Corporation. Documentation on TIFF is available from them at Craigcook
           Castle, Craigcook Road, Edinburgh EH4 3UH, Scotland, or 411 First
-          Avenue South, Seattle, Washington 98104 USA. </item>
+          Avenue South, Seattle, Washington 98104 USA.</item>
         <label>GIF: Graphics Interchange Format</label>
         <item>Raster images are widely available in this form, which was created
           by CompuServe Information Services, but has by now been implemented
           for many other systems as well. Documentation on GIF is copyright by,
           and is available from, CompuServe Incorporated, Graphics Technology
-          Department, 5000 Arlington Center Boulevard, Columbus, Ohio 43220 USA. </item>
+          Department, 5000 Arlington Center Boulevard, Columbus, Ohio 43220 USA.</item>
         <label>PBM: Portable Bit Map</label>
         <item>PBM files are easy to process, eschewing all compression in favor
           of transparency of file format. PBM files can, of course, be
           compressed by generic file-compression tools for storage and transfer.
           Public domain software exists which will convert many other formats to
           and from PBM. Documentation on PBM is copyright by Jeff Poskanzer, and
-          is available widely on the Internet. </item>
+          is available widely on the Internet.</item>
         <label>PCX: IBM PC raster format</label>
         <item>This format is used by most IBM PC paint programs, and supports
           both monochrome and polychromatic images. Documentation is available
           from ZSoft Corporation, Technical Support Department, ATTN: Technical
-          Reference Manual, 450 Franklin Rd. Suite 100, Marietta, GA 30067 USA. </item>
+          Reference Manual, 450 Franklin Rd. Suite 100, Marietta, GA 30067 USA.</item>
         <label>BMP: Microsoft bitmap format</label>
         <item>This format is the standard raster format for computer using
-          Microsoft Windows (tm) or Presentation Manager (tm). Documentation is
-          available from Microsoft Corporation. </item>
+          Microsoft Windows™ or Presentation Manager™. Documentation is
+          available from Microsoft Corporation.</item>
       </list>
     </div>
     <div type="div3" xml:id="FTGRAMPEG">
@@ -1043,7 +1045,7 @@ discussion at .</note-->
           monochrome and polychromatic images with a variety of compression
           techniques. JPEG per se, like CCITT Group IV, must be encapsulated
           before transmission; this can be done via TIFF, or via the JPEG File
-          Interchange Format (JFIF), as commonly done for Internet delivery. </item>
+          Interchange Format (JFIF), as commonly done for Internet delivery.</item>
         <label>QuickTime: Apple real-time image system</label>
         <item>QuickTime is a proprietary method introduced by Apple Computer
           Company to synchronize the display of various data. The data can
@@ -1051,13 +1053,13 @@ discussion at .</note-->
           things. Viewers for QuickTime productions are available for Apple and
           other computers. Further information is available from Apple Computer
           Incorporated, 10201 North de Anza Boulevard MS 23AQ, Cupertino,
-          California 95014 USA. </item>
+          California 95014 USA.</item>
         <label>Photo-CD: Kodak Photo Compact Disk format</label>
         <item>This format was introduced by Kodak for rasterizing photographs
           and storing them on CD-ROMs (about one hundred 35mm file images fit on
           one disk), for display on televisions or CD-I systems. Information on
           Photo-CD is available from Kodak Limited, Research and Development,
-          Headstone Drive, Harrow, Middlesex HA1 4TY, UK. </item>
+          Headstone Drive, Harrow, Middlesex HA1 4TY, UK.</item>
         <label>SMIL: Synchronized Multimedia Integration Language format</label>
         <item>SMIL is a W3C Recommendation which supports the integration of
           independent multimedia objects into a synchronized multimedia
@@ -1081,7 +1083,7 @@ discussion at .</note-->
           designed for Web clients that support direct playback from SMIL 2.0
           markup. SMIL 2.0 (<ptr target="http://www.w3.org/TR/2001/REC-smil20-20010807/"/>) became a
           W3C Recommendation on August 7, 2001, becoming the first vocabulary to
-          provide XML Schema support and to have reached such status. </item>
+          provide XML Schema support and to have reached such status.</item>
       </list>
       <p>As noted above, the reader will encounter many, many other graphics
         formats. </p>

--- a/P5/Source/Guidelines/en/FT-TablesFormulaeGraphics.xml
+++ b/P5/Source/Guidelines/en/FT-TablesFormulaeGraphics.xml
@@ -568,7 +568,7 @@ discussion at .</note-->
       notation in text, but defer to other representations, which are not
       covered by the TEI guidelines, to describe the music notation itself. In
       fact several commercial, academic, and standard bodies have developed
-      digital representations of music notation; and given the topic's
+      digital representations of music notation. Given the topic's
       complexity, these representations often focus on different aspects and
       adopt different methodologies. Therefore, <gi>notatedMusic</gi> only
       defines a container element to encode the occurrence of music notation and


### PR DESCRIPTION
 * mostly adding Oxford commas
 * also changed “(tm)” to “™”
 * minor whitespace changes, some inadvertent, some on purpose.

These are very minor changes. As far as I am concerned, once any reviewer who understands the rules of English punctuation better than I do says it is OK, this can be merged. (I.e., I think either @ebeshero or @JanelleJenstad could act as both reviewer and merger.)