### PR TITLE
lowered the reporting level of (possibly) misplaced L/R quotation mar…

### DIFF
--- a/P5/Exemplars/tei_jtei.odd
+++ b/P5/Exemplars/tei_jtei.odd
@@ -3133,9 +3133,9 @@
           </constraintSpec>
           <constraintSpec ident="jtei.sch-LRquotes" scheme="schematron">
             <constraint>
-              <sch:rule context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag)][matches(., $apos.typographic)]">
+              <sch:rule context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag)][matches(., $apos.typographic)]" role="warning">
                 <sch:report test="matches(., '\W[’]\D') or matches(., '[‘](\W|$)') or matches(., '\w[‘]\w')">
-                  Left and Right Single Quotation Marks should be used in the right place.
+                  Left and Right Single Quotation Marks should be used in the right place. Please check their placement in this text node.
                 </sch:report>
               </sch:rule>
             </constraint>

--- a/P5/Exemplars/tei_jtei.odd
+++ b/P5/Exemplars/tei_jtei.odd
@@ -3115,7 +3115,7 @@
           
           <constraintSpec ident="jtei.sch-straightApos" scheme="schematron">
             <constraint>
-              <sch:rule context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag)]">
+              <sch:rule context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag|ancestor::tei:mentioned)]">
                 <sch:report test="matches(., $apos.straight)" sqf:fix="apostrophe.replace">
                   "Straight apostrophe" characters are not permitted. Please use the
                   Right Single Quotation Mark (U+2019 or ’) character instead. On the other hand, if the straight 


### PR DESCRIPTION
…ks to "warning" in order not to invalidate documents in which initial L quotation marks occur (e.g. Sanskrit text)