### PR TITLE
allow <schemaSpec> in <front> and <back>

### DIFF
--- a/P5/Source/Specs/schemaSpec.xml
+++ b/P5/Source/Specs/schemaSpec.xml
@@ -29,6 +29,7 @@ $Id$
     <memberOf key="att.global"/>
     <memberOf key="model.divPart"/>
     <memberOf key="model.encodingDescPart"/>
+    <memberOf key="model.frontPart"/>
     <memberOf key="att.identified"/>
     <memberOf key="att.namespaceable"/>
     <memberOf key="att.docStatus"/>


### PR DESCRIPTION
This change is intended to catch us up to the new prose (implemented in #2041 for #1921) by putting `<schemaSpec>` into model.frontPart now, so it can be a child of `<front>` or `<back>` (which will happen in roughly late October, anyway, but should be corrected immediately). 