### PR TITLE
TEI Basic

### DIFF
--- a/P5/Exemplars/Makefile
+++ b/P5/Exemplars/Makefile
@@ -5,6 +5,7 @@ JING=java -jar ../Utilities/lib/jing.jar
 BIN=${PREFIX}/bin
 NORMALODDS= \
 	tei_bare.dtd \
+	tei_basic.dtd \
 	tei_corpus.dtd \
 	tei_drama.dtd \
 	tei_minimal.dtd \

--- a/P5/Exemplars/tei_basic.odd
+++ b/P5/Exemplars/tei_basic.odd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>TEI Basic</title>
+        <author>Hugh Cayless</author>
+      </titleStmt>
+      <publicationStmt>
+        <publisher>TEI Consortium</publisher>
+        <availability status="free">
+          <p>TEI material can be licensed differently depending on the
+          use you intend to make of it. Hence it is made available
+          under both the CC+BY and BSD-2 licences. The CC+BY licence
+          is generally appropriate for usages which treat TEI content
+          as data or documentation. The BSD-2 licence is generally
+          appropriate for usage of TEI content in a software
+          environment. For further information or clarification,
+          please contact the TEI Consortium (info@tei-c.org).</p>
+        </availability>
+      </publicationStmt>
+      <sourceDesc>
+        <p>Derived from TEI All.</p>
+      </sourceDesc>
+    </fileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <head>TEI Basic</head>
+      <p>This TEI customization describes a schema that includes
+      <emph>most</emph> of the TEI P5 modules and elements. It eliminates
+      some specialized modules and numbered divisions. TEI Basic is 
+      intended to be a better starting point for most projects than TEI
+      All. It should work for nearly all texts. You are encouraged to
+      further customize it.</p>
+      <schemaSpec ident="tei_basic" start="TEI teiCorpus" prefix="tei_" targetLang="en" docLang="en">
+        <moduleRef n="01" key="tei"/>
+        <moduleRef n="02" key="header"/>
+        <moduleRef n="03" key="core"/>
+        <moduleRef n="04" key="textstructure" except="div1 div2 div3 div4 div5 div6 div7"/>
+        <moduleRef n="05" key="gaiji"/>
+        <moduleRef n="06" key="verse"/>
+        <moduleRef n="07" key="drama"/>
+        <moduleRef n="08" key="spoken"/>
+        <moduleRef n="17" key="analysis"/>
+        <moduleRef n="10" key="msdescription"/>
+        <moduleRef n="11" key="transcr"/>
+        <moduleRef n="12" key="textcrit"/>
+        <moduleRef n="13" key="namesdates"/>
+        <moduleRef n="14" key="figures"/>
+        <moduleRef n="15" key="corpus"/>
+        <moduleRef n="16" key="linking"/>        
+        <moduleRef n="21" key="certainty"/>
+      </schemaSpec>
+    </body>
+  </text>
+</TEI>

--- a/P5/Exemplars/tei_basic.tei
+++ b/P5/Exemplars/tei_basic.tei
@@ -1,0 +1,21 @@
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title><!-- supply a title --></title>
+      </titleStmt>
+      <publicationStmt>
+        <p><!-- supply publication information--> </p>
+      </publicationStmt>
+      <sourceDesc>
+        <p><!-- supply information about the source --></p>
+      </sourceDesc>
+    </fileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <!-- the text. possibly a <p> or two? -->
+      <p/>
+    </body>
+  </text>
+</TEI>

--- a/P5/Exemplars/tei_basic.template
+++ b/P5/Exemplars/tei_basic.template
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI n="Basic"
+  xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+      </titleStmt>
+      <publicationStmt>
+        <p>Publication Information</p>
+      </publicationStmt>
+      <sourceDesc>
+        <p>Information about the source</p>
+      </sourceDesc>
+    </fileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <p>Some text here.</p>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
OK, hear me out. I've been mildly irritated for ages that the best starting point for a project that's still figuring out how it wants to encode stuff is TEI All. There's things in there that really shouldn't be used when encoding a regular document, and I've seen people pick stuff up from, say tagdocs—to be fair without properly reading the documentation, but nevertheless—that shouldn't be available at all. But starting from a more minimal schema than All is psychologically hard because users are driven by what's available when they're playing around, figuring out what to do. So what if we had an exemplar that had _almost_ everything?

I seem to remember Martin Mueller, I think when proposing what became SimplePrint, saying that what TEI needed was the equivalent of a Toyota Corolla—something relatively small but easy to understand and likely to be popular. This is not that. It's more like a midsize SUV. Which turns out to be what most people actually want in a car...Instead of 80/20, this is more like 90/95.

BUT, my thesis is that it's easier to develop a customization by refining something and that you can start with an ODD that only throws out the things you're very unlikely to use. It only removes tagdocs, iso-fs, dictionaries, nets, and numbered divs (my personal pet hate). 

Thoughts?

