### PR TITLE
Attlocatable issue 1910

### DIFF
--- a/P5/Source/Guidelines/en/BIB-Bibliography.xml
+++ b/P5/Source/Guidelines/en/BIB-Bibliography.xml
@@ -424,7 +424,7 @@ $Id$
                 <author>Grallert, Till</author>, <title>Tools for the Computational Normalisation and Analysis of Food Prices 
                   and Food Riots in the Eastern Mediterranean (Bilād al-Shām) in the 19th and 20th Centuries</title>.
                 <publisher>Zenodo</publisher>, <date>2021</date>. 
-                <ref target="https://doi.org/10.5281/zenodo.5159020">https://doi.org/10.5281/zenodo.5159020</ref>.
+                <ptr target="https://doi.org/10.5281/zenodo.5159020"/>.
               </bibl>
               <bibl xml:id="PH-eg-07">
                 <author>Graves, Robert</author>. <title>Rough draft of letter to Desmond Flower</title>. <date>17 Dec
@@ -666,7 +666,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                     McCarty</editor>. <pubPlace>London</pubPlace>: <publisher>Ashgate</publisher> (<date>2012</date>).</bibl>
                     <bibl xml:id="NDGEOGste-Falls"><author>McCarthy, Niall</author>, <title level="a">No Parachute: The Highest Falls People Survived</title>,
                     <title level="m">Statista</title>, <date when="2020-11-18">November 18, 2020</date>.
-                    <ref target="https://www.statista.com/chart/19708/known-occasions-where-people-survived-falls/">https://www.statista.com/chart/19708/known-occasions-where-people-survived-falls/</ref>
+                    <ptr target="https://www.statista.com/chart/19708/known-occasions-where-people-survived-falls/"/>.
                     </bibl>
                     <bibl xml:id="DSHD-eg-30"><author>Melville, Herman</author>, <title level="m">Moby Dick</title>.
                     (<date>1851</date>).</bibl>

--- a/P5/Source/Guidelines/en/BIB-Bibliography.xml
+++ b/P5/Source/Guidelines/en/BIB-Bibliography.xml
@@ -420,6 +420,12 @@ $Id$
               <bibl xml:id="G2S">
                 <author>[Goldsmith, Oliver]</author>, <title>The History of Little GOODY TWO-SHOES; Otherwise called, Mrs.
               MARGERY TWO-SHOES...</title> (Printed for J. Newbery, <date>1766</date>). </bibl>
+              <bibl xml:id="HDUDECL-TG">
+                <author>Grallert, Till</author>, <title>Tools for the Computational Normalisation and Analysis of Food Prices 
+                  and Food Riots in the Eastern Mediterranean (Bilād al-Shām) in the 19th and 20th Centuries</title>.
+                <publisher>Zenodo</publisher>, <date>2021</date>. 
+                <ref target="https://doi.org/10.5281/zenodo.5159020">https://doi.org/10.5281/zenodo.5159020</ref>.
+              </bibl>
               <bibl xml:id="PH-eg-07">
                 <author>Graves, Robert</author>. <title>Rough draft of letter to Desmond Flower</title>. <date>17 Dec
                 1938</date>. (from <title level="m">Diary of Robert Graves 1935-39 and ancillary materials</title>, compiled

--- a/P5/Source/Guidelines/en/BIB-Bibliography.xml
+++ b/P5/Source/Guidelines/en/BIB-Bibliography.xml
@@ -664,6 +664,10 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                     level="m">Collaborative Research in the Digital Humanities</title>: A volume in honour of Harold Short on the
                     occasion of his 65th birthday, September 2010, ed. <editor>Marilyn Deegan</editor> and <editor>Willard
                     McCarty</editor>. <pubPlace>London</pubPlace>: <publisher>Ashgate</publisher> (<date>2012</date>).</bibl>
+                    <bibl xml:id="NDGEOGste-Falls"><author>McCarthy, Niall</author>, <title level="a">No Parachute: The Highest Falls People Survived</title>,
+                    <title level="m">Statista</title>, <date when="2020-11-18">November 18, 2020</date>.
+                    <ref target="https://www.statista.com/chart/19708/known-occasions-where-people-survived-falls/">https://www.statista.com/chart/19708/known-occasions-where-people-survived-falls/</ref>
+                    </bibl>
                     <bibl xml:id="DSHD-eg-30"><author>Melville, Herman</author>, <title level="m">Moby Dick</title>.
                     (<date>1851</date>).</bibl>
                     <!-- ?check Melville, Moby Dick (but where?) -->
@@ -1839,7 +1843,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>DeRose</surname>
                                           </editor>
                                           <title level="m">XML Path Language (XPath) Version 1.0</title>
-                                          <ptr target="http://www.w3.org/TR/xpath/"/>
+                                          <ptr target="https://www.w3.org/TR/xpath/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="1999-11-16">16 November 1999</date>
@@ -1873,10 +1877,58 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname> Siméon</surname>
                                           </editor>
                                           <title level="m">XML Path Language (XPath) 2.0</title>
-                                          <ptr target="http://www.w3.org/TR/xpath20/"/>
+                                          <ptr target="https://www.w3.org/TR/xpath20/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2007-01-23">23 January 2007</date>
+                                          </imprint>
+                                        </monogr>
+                                      </biblStruct>
+                                      <biblStruct xml:id="XPATH30">
+                                        <monogr>
+                                          <editor>
+                                            <forename>Jonathan</forename>
+                                            <surname>Robie</surname>
+                                          </editor>
+                                          <editor>
+                                            <forename>Don</forename>
+                                            <surname>Chamberlin</surname>
+                                          </editor>
+                                          <editor>
+                                            <forename>Michael</forename>
+                                            <surname>Dyck</surname>
+                                          </editor>
+                                          <editor>
+                                            <forename>Jon</forename>
+                                            <surname>Snelson</surname>
+                                          </editor>
+                                          <title level="m">XML Path Language (XPath) 3.0</title>
+                                          <ptr target="https://www.w3.org/TR/xpath-30/"/>
+                                          <imprint>
+                                            <publisher>W3C</publisher>
+                                            <date when="2014-04-08">8 April 2014</date>
+                                          </imprint>
+                                        </monogr>
+                                      </biblStruct>
+                                      <biblStruct xml:id="XPATH31">
+                                        <monogr>
+                                          <editor>
+                                            <forename>Jonathan</forename>
+                                            <surname>Robie</surname>
+                                          </editor>
+                                          <editor>
+                                            <forename>Michael</forename>
+                                            <surname>Dyck</surname>
+                                          </editor>
+                                          <editor>
+                                            <forename>Josh</forename>
+                                            <surname>Spiegel</surname>
+                                          </editor>
+                                          <title level="m">XML Path Language (XPath) 3.1</title>
+                                          <ptr target="https://www.w3.org/TR/xpath-31/"/>
+                                          <imprint>
+                                            <publisher>W3C</publisher>
+                                            <date when="2017-03-21">21 March 2017</date>
                                           </imprint>
                                         </monogr>
                                       </biblStruct>

--- a/P5/Source/Guidelines/en/HD-Header.xml
+++ b/P5/Source/Guidelines/en/HD-Header.xml
@@ -1799,10 +1799,11 @@ more than one language, as in the following example:
       <specList>
         <specDesc key="unitDef"/>
         <specDesc key="unit"/>
-        <specDesc key="conversion" atts="formula fromUnit toUnit from to notBefore notAfter when"/> 
+        <specDesc key="conversion" atts="formula fromUnit toUnit from to notBefore notAfter when where"/> 
         <specDesc key="att.formula" atts="formula"/>
+        <specDesc key="att.locatable" atts="where"/>
       </specList>
-Within the <gi>unitDef</gi>, a <gi>conversion</gi> element may be used to store information relating to conversion between units. The <gi>conversion</gi> element holds a special pair of attributes, <att>fromUnit</att> and <att>toUnit</att>, which serve to indicate the direction of a calculation from one unit of measure (stored in <att>fromUnit</att>) to another (stored in <att>toUnit</att>). A mathematical calculation to define the relation between these units may be stored in <att>formula</att>, as shown in the following examples. The <att>formula</att> attribute takes a value expressed as an XPath expression, which means that division must be expressed with <q>div</q> so as not to be confused with the forward slash used in path navigation. 
+Within the <gi>unitDef</gi>, a <gi>conversion</gi> element may be used to store information relating to conversion between units. The <gi>conversion</gi> element holds a special pair of attributes, <att>fromUnit</att> and <att>toUnit</att>, which serve to indicate the direction of a calculation from one unit of measure (stored in <att>fromUnit</att>) to another (stored in <att>toUnit</att>). A mathematical calculation to define the relation between these units may be stored in <att>formula</att>, as shown in the following examples. The <att>formula</att> attribute takes a value expressed as an XPath expression, which means that division must be expressed with <q>div</q> so as not to be confused with the forward slash used in path navigation. The <gi>conversion</gi> element may also hold attributes to store dates and date ranges as well as location(s) that specify when and where a conversion formula was used.
     </p>
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="en" source="#ZUPKO">
       <encodingDesc>
@@ -1840,11 +1841,25 @@ Within the <gi>unitDef</gi>, a <gi>conversion</gi> element may be used to store 
        </unitDecl>
      </encodingDesc>
     </egXML>
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#NONE">
+        <unitDef type="volume" xml:id="shunbul">
+          <label xml:lang="ar-Latn-x-ijmes">shunbul</label>
+          <label xml:lang="ar">شنبل</label>
+          <conversion formula="$fromUnit * 2.5" fromUnit="#shunbul" toUnit="#kile" when="1873" where="#acre #tripoli"/>
+          <conversion formula="$fromUnit * 2.25" fromUnit="#shunbul" toUnit="#kile" when="1878"  where="#acre #tripoli"/>
+          <conversion formula="$fromUnit * 3" from="1891" fromUnit="#shunbul" to="1910" toUnit="#kile" where="#aleppo"/>
+          <conversion formula="$fromUnit * 2.5" fromUnit="#shunbul" toUnit="#kile_istanbul" when="1860" where="#aleppo"/>
+          <conversion formula="$fromUnit * 72" fromUnit="#shunbul" toUnit="#madd" when="1893" where="#damascus"/>
+          <desc xml:lang="en">The <foreign xml:lang="ar-Latn-x-ijmes">shunbul</foreign> was the main unit to measure grain in the Northern parts of Greater Syria.</desc>
+        </unitDef>
+      </egXML>
+    
     <specGrp xml:id="D2256" n="The unit declaration">
       <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/unitDecl.xml"/>
       <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/unitDef.xml"/>
       <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/conversion.xml"/> 
       <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/att.formula.xml"/>
+      <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/att.locatable.xml"/>
     </specGrp>
   </div>
   <div type="div3" xml:id="HDSCHSPEC"><head>The Schema Specification</head>

--- a/P5/Source/Guidelines/en/HD-Header.xml
+++ b/P5/Source/Guidelines/en/HD-Header.xml
@@ -1799,11 +1799,16 @@ more than one language, as in the following example:
       <specList>
         <specDesc key="unitDef"/>
         <specDesc key="unit"/>
-        <specDesc key="conversion" atts="formula fromUnit toUnit from to notBefore notAfter when where"/> 
+        <specDesc key="conversion" atts="fromUnit toUnit from to notBefore notAfter when"/> 
         <specDesc key="att.formula" atts="formula"/>
         <specDesc key="att.locatable" atts="where"/>
       </specList>
-Within the <gi>unitDef</gi>, a <gi>conversion</gi> element may be used to store information relating to conversion between units. The <gi>conversion</gi> element holds a special pair of attributes, <att>fromUnit</att> and <att>toUnit</att>, which serve to indicate the direction of a calculation from one unit of measure (stored in <att>fromUnit</att>) to another (stored in <att>toUnit</att>). A mathematical calculation to define the relation between these units may be stored in <att>formula</att>, as shown in the following examples. The <att>formula</att> attribute takes a value expressed as an XPath expression, which means that division must be expressed with <q>div</q> so as not to be confused with the forward slash used in path navigation. The <gi>conversion</gi> element may also hold attributes to store dates and date ranges as well as location(s) that specify when and where a conversion formula was used.
+Within the <gi>unitDef</gi>, a <gi>conversion</gi> element may be used to store information relating to conversion between units. 
+      The <gi>conversion</gi> element holds a special pair of attributes, <att>fromUnit</att> and <att>toUnit</att>, which serve to indicate the direction of a calculation from one unit of measure (stored in <att>fromUnit</att>) to another (stored in <att>toUnit</att>). 
+      A mathematical calculation to define the relation between these units may be stored in <att>formula</att>, as shown in the following examples.  
+      The <att>formula</att> attribute takes a value expressed as an XPath expression, for which see <ptr target="#XPATH31"/>. 
+      Among other things, this means that division must be expressed with <q>div</q> as opposed to the more common forward slash (<q>/</q>, U+002F), so as not to be confused with path navigation.
+      The <gi>conversion</gi> element may also use attributes to store dates and date ranges as well as location(s) that specify when and where a conversion formula was applied.
     </p>
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="en" source="#ZUPKO">
       <encodingDesc>

--- a/P5/Source/Guidelines/en/HD-Header.xml
+++ b/P5/Source/Guidelines/en/HD-Header.xml
@@ -1841,7 +1841,7 @@ Within the <gi>unitDef</gi>, a <gi>conversion</gi> element may be used to store 
        </unitDecl>
      </encodingDesc>
     </egXML>
-    <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#NONE">
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#HDUDECL-TG">
         <unitDef type="volume" xml:id="shunbul">
           <label xml:lang="ar-Latn-x-ijmes">shunbul</label>
           <label xml:lang="ar">شنبل</label>

--- a/P5/Source/Guidelines/en/ND-NamesDates.xml
+++ b/P5/Source/Guidelines/en/ND-NamesDates.xml
@@ -1942,18 +1942,13 @@ exemplifying here too? -->
             </listEvent>
           </standOff>
         </egXML>
-        <p>The next example demonstrates the use of the <att>where</att> attribute with <gi>event</gi>, coordinated with location information stored in <gi>listPlace</gi>.</p>
+        <p>The next example demonstrates the use of the
+        <att>where</att> attribute with <gi>event</gi>, coordinated
+        with location information stored in <gi>listPlace</gi>.</p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#NDGEOGste-Falls">
           <standOff>
             <!-- ========= events ========= -->
             <listEvent>
-              <event xml:id="jat367" where="#l-Seb" when="1972-01-26T16:01:29Z">
-                <head>Bombing of Yugoslav Airlines Flight 367</head>
-                <head type="short">JAT 367</head>
-                <ab type="altitude"><measure unit="m" quantity="10050"/></ab>
-                <ab type="survivor"><persName ref="#p-VV">Весна Вуловић</persName></ab>
-                <ptr type="furtherInfo" target="https://en.wikipedia.org/wiki/JAT_Flight_367"/>
-              </event>
               <event xml:id="DB-3F" where="#WWIIEast" when="1942-01">
                 <head>Luftwaffe shoots down Ilyushin Il-4</head>
                 <head type="short">DB-3F</head>
@@ -1972,6 +1967,19 @@ exemplifying here too? -->
                 <ab type="altitude"><measure unit="m" quantity="5490"/></ab>
                 <ab type="survivor"><persName ref="#p-NA">Nicholas Alkemade</persName></ab>
               </event>
+              <event xml:id="LANSA508" where="#l-PI" when="1971-12-04">
+                <head>LANSA 508 struck by lightning</head>
+                <head type="short">Amazon rainforest</head>
+                <ab type="altitude"><measure unit="m" quantity="3000"/></ab>
+                <ab type="survivor"><persName ref="#p-JK">Juliane Diller (née Koepcke)</persName></ab>
+              </event>
+              <event xml:id="jat367" where="#l-Seb" when="1972-01-26T16:01:29Z">
+                <head>Bombing of Yugoslav Airlines Flight 367</head>
+                <head type="short">JAT 367</head>
+                <ab type="altitude"><measure unit="m" quantity="10050"/></ab>
+                <ab type="survivor"><persName ref="#p-VV">Весна Вуловић</persName></ab>
+                <ptr type="furtherInfo" target="https://en.wikipedia.org/wiki/JAT_Flight_367"/>
+              </event>
               <event xml:id="BG" where="#l-KorZ" when="1996">
                 <head>SAS parachute failure</head>
                 <head type="short">Bear Grylls</head>
@@ -1984,12 +1992,6 @@ exemplifying here too? -->
                 <ab type="altitude"><measure unit="m" quantity="3353"/></ab>
                 <ab type="survivor"><persName ref="#p-CM">Christine McKenzie</persName></ab>
               </event>
-              <event xml:id="LANSA508" where="#l-PI" when="1971-12-04">
-                <head>LANSA 508 struck by lightning</head>
-                <head type="short">Amazon rainforest</head>
-                <ab type="altitude"><measure unit="m" quantity="3000"/></ab>
-                <ab type="survivor"><persName ref="#p-JK">Juliane Diller (née Koepcke)</persName></ab>
-              </event>
               <event xml:id="JBK" where="#l-Kam" when="2009-05">
                 <head>Cameraman fails to open chute</head>
                 <head type="short">Sport videographer</head>
@@ -1999,21 +2001,28 @@ exemplifying here too? -->
             </listEvent>
             <!-- ========= places ========= -->
             <listPlace>
-              <place xml:id="l-Seb">
-                <placeName xml:lang="de">Sebnitz</placeName>
-                <location>
-                  <geo>50.966667,14.283333</geo>
-                </location>
-              </place>
-              <place xml:id="l-WWIIEast">
-                <name>Eastern Front</name>
-                <ptr type="furtherInfo" target="https://en.wikipedia.org/wiki/Eastern_Front_(World_War_II)"/>
-              </place>
               <place xml:id="l-GSN">
                 <placeName xml:lang="fr">Gare de Saint-Nazaire</placeName>
                 <location>
                   <geo>47.28657,-2.21171</geo>
                 </location>
+              </place>
+              <place xml:id="l-Joh">
+                <placeName>Johannesburg</placeName>
+                <location>
+                  <country>South Africa</country>
+                  <region type="province">Gauteng</region>
+                </location>
+              </place>
+              <place xml:id="l-Kam">
+                <placeName xml:lang="ru">Камчатке</placeName>
+                <location>
+                  <country>Russia</country>
+                  <region>Kamchatka Krai</region>
+                </location>
+              </place>
+              <place xml:id="l-Ken">
+                <country>Kenya</country>
               </place>
               <place xml:id="l-Obe" xml:lang="de">
                 <placeName>Oberkirchen</placeName>
@@ -2026,25 +2035,6 @@ exemplifying here too? -->
                   <geo cert="low">51.154,8.357</geo>
                 </location>
               </place>
-              <place xml:id="l-Sch">
-                <placeName xml:lang="de">Schmallenberg</placeName>
-                <placeName xml:lang="wep">Smalmereg</placeName>
-                <location>
-                </location>
-              </place>
-              <place xml:id="l-Ken">
-                <country>Kenya</country>
-              </place>
-              <place xml:id="l-Zam">
-                <country>Zambia</country>
-              </place>
-              <place xml:id="l-Joh">
-                <placeName>Johannesburg</placeName>
-                <location>
-                  <country>South Africa</country>
-                  <region type="province">Gauteng</region>
-                </location>
-              </place>
               <place xml:id="l-PI" xml:lang="es">
                 <placeName>Puerto Inca</placeName>
                 <location>
@@ -2053,13 +2043,25 @@ exemplifying here too? -->
                   <district>Puerto Inca</district>
                 </location>
               </place>
-              <place xml:id="l-Kam">
-                <placeName xml:lang="ru">Камчатке</placeName>
+              <place xml:id="l-Sch">
+                <placeName xml:lang="de">Schmallenberg</placeName>
+                <placeName xml:lang="wep">Smalmereg</placeName>
                 <location>
-                  <country>Russia</country>
-                  <region>Kamchatka Krai</region>
                 </location>
               </place>
+              <place xml:id="l-Seb">
+                <placeName xml:lang="de">Sebnitz</placeName>
+                <location>
+                  <geo>50.966667,14.283333</geo>
+                </location>
+              </place>
+              <place xml:id="l-WWIIEast">
+                <name>Eastern Front</name>
+                <ptr type="furtherInfo" target="https://en.wikipedia.org/wiki/Eastern_Front_(World_War_II)"/>
+              </place>
+              <place xml:id="l-Zam">
+                <country>Zambia</country>
+              </place>        
             </listPlace>
             <!-- ========= people ========= -->
             <listPerson>

--- a/P5/Source/Guidelines/en/ND-NamesDates.xml
+++ b/P5/Source/Guidelines/en/ND-NamesDates.xml
@@ -816,6 +816,7 @@ target="#CONA"/>).  The tag -->The
           <specDesc key="state"/>
           <specDesc key="trait"/>
           <specDesc key="event" atts="where"/>
+          <specDesc key="att.locatable" atts="where"/>
           <specDesc key="listEvent"/>
           <!-- PB, 19-04-2012
     <specDesc key="listState"/>

--- a/P5/Source/Guidelines/en/ND-NamesDates.xml
+++ b/P5/Source/Guidelines/en/ND-NamesDates.xml
@@ -815,7 +815,7 @@ target="#CONA"/>).  The tag -->The
         of one or other of the above three classes. Generic elements for state, trait, and event are also defined: <specList>
           <specDesc key="state"/>
           <specDesc key="trait"/>
-          <specDesc key="event" atts="where"/>
+          <specDesc key="event"/>
           <specDesc key="att.locatable" atts="where"/>
           <specDesc key="listEvent"/>
           <!-- PB, 19-04-2012
@@ -1923,8 +1923,9 @@ exemplifying here too? -->
                 <desc>France ceded to Great Britain its claims to the <orgName>Hudson's Bay Company</orgName> territories in
                 <placeName>Rupert's Land</placeName>, <placeName>Newfoundland</placeName>, and <placeName>Acadia</placeName> and
                 recognized British suzerainty over <orgName type="tribe">the Iroquois</orgName> but retained its other pre-war
-                North American possessions, including <placeName key="PEI">Île-Saint-Jean</placeName> (now <placeName key="PEI"
-                >Prince Edward Island</placeName>)...</desc>
+                North American possessions, including 
+                <placeName key="PEI">Île-Saint-Jean</placeName> 
+                (now <placeName key="PEI">Prince Edward Island</placeName>)...</desc>
               </event>
               <event when="1774" key="14-GeoIII-c83">
                 <label>Quebec Act</label>
@@ -1939,6 +1940,176 @@ exemplifying here too? -->
                 <orgName type="tribe">Lenape</orgName> or Delawares.</desc>
               </event>
             </listEvent>
+          </standOff>
+        </egXML>
+        <p>The next example demonstrates the use of the <att>where</att> attribute with <gi>event</gi>, coordinated with location information stored in <gi>listPlace</gi>.</p>
+        <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#NDGEOGste-Falls">
+          <standOff>
+            <!-- ========= events ========= -->
+            <listEvent>
+              <event xml:id="jat367" where="#l-Seb" when="1972-01-26T16:01:29Z">
+                <head>Bombing of Yugoslav Airlines Flight 367</head>
+                <head type="short">JAT 367</head>
+                <ab type="altitude"><measure unit="m" quantity="10050"/></ab>
+                <ab type="survivor"><persName ref="#p-VV">Весна Вуловић</persName></ab>
+                <ptr type="furtherInfo" target="https://en.wikipedia.org/wiki/JAT_Flight_367"/>
+              </event>
+              <event xml:id="DB-3F" where="#WWIIEast" when="1942-01">
+                <head>Luftwaffe shoots down Ilyushin Il-4</head>
+                <head type="short">DB-3F</head>
+                <ab type="altitude"><measure unit="m" quantity="7000"/></ab>
+                <ab type="survivor"><persName ref="#p-IC">Іван Чиссов</persName></ab>
+              </event>
+              <event xml:id="SCP" where="#l-GSN" when="1943-01-03">
+                <head>Snap, Crackle, Pop is shot down by German flak</head>
+                <head type="short">B-17</head>
+                <ab type="altitude"><measure unit="m" quantity="6700"/></ab>
+                <ab type="survivor"><persName ref="#p-AM">Alan Magee</persName></ab>
+              </event>
+              <event xml:id="DS664" where="#l-Obe" when="1944-03-24">
+                <head>Avro Lancaster shot down by Junkers Ju 88</head>
+                <head type="short">Lancaster</head>
+                <ab type="altitude"><measure unit="m" quantity="5490"/></ab>
+                <ab type="survivor"><persName ref="#p-NA">Nicholas Alkemade</persName></ab>
+              </event>
+              <event xml:id="BG" where="#l-KorZ" when="1996">
+                <head>SAS parachute failure</head>
+                <head type="short">Bear Grylls</head>
+                <ab type="altitude"><measure unit="m" quantity="4877"/></ab>
+                <ab type="survivor"><persName ref="#p-BG"></persName></ab>
+              </event>
+              <event xml:id="CM" where="#l-Joh" when="2004-08-22">
+                <head>Johannesburg parachute failure</head>
+                <head type="short">Christine McKenzie</head>
+                <ab type="altitude"><measure unit="m" quantity="3353"/></ab>
+                <ab type="survivor"><persName ref="#p-CM">Christine McKenzie</persName></ab>
+              </event>
+              <event xml:id="LANSA508" where="#l-PI" when="1971-12-04">
+                <head>LANSA 508 struck by lightning</head>
+                <head type="short">Amazon rainforest</head>
+                <ab type="altitude"><measure unit="m" quantity="3000"/></ab>
+                <ab type="survivor"><persName ref="#p-JK">Juliane Diller (née Koepcke)</persName></ab>
+              </event>
+              <event xml:id="JBK" where="#l-Kam" when="2009-05">
+                <head>Cameraman fails to open chute</head>
+                <head type="short">Sport videographer</head>
+                <ab type="altitude"><measure unit="m" quantity="1829"/></ab>
+                <ab type="survivor"><persName ref="#p-JB"></persName></ab>
+              </event>
+            </listEvent>
+            <!-- ========= places ========= -->
+            <listPlace>
+              <place xml:id="l-Seb">
+                <placeName xml:lang="de">Sebnitz</placeName>
+                <location>
+                  <geo>50.966667,14.283333</geo>
+                </location>
+              </place>
+              <place xml:id="l-WWIIEast">
+                <name>Eastern Front</name>
+                <ptr type="furtherInfo" target="https://en.wikipedia.org/wiki/Eastern_Front_(World_War_II)"/>
+              </place>
+              <place xml:id="l-GSN">
+                <placeName xml:lang="fr">Gare de Saint-Nazaire</placeName>
+                <location>
+                  <geo>47.28657,-2.21171</geo>
+                </location>
+              </place>
+              <place xml:id="l-Obe" xml:lang="de">
+                <placeName>Oberkirchen</placeName>
+                <location>
+                  <country>Deutschland</country>
+                  <region type="state">Nordrhein-Westfalen</region>
+                  <region>Arnsberg</region>
+                  <district>Hochsauerlandkreis</district>
+                  <settlement>Schmallenberg</settlement>
+                  <geo cert="low">51.154,8.357</geo>
+                </location>
+              </place>
+              <place xml:id="l-Sch">
+                <placeName xml:lang="de">Schmallenberg</placeName>
+                <placeName xml:lang="wep">Smalmereg</placeName>
+                <location>
+                </location>
+              </place>
+              <place xml:id="l-Ken">
+                <country>Kenya</country>
+              </place>
+              <place xml:id="l-Zam">
+                <country>Zambia</country>
+              </place>
+              <place xml:id="l-Joh">
+                <placeName>Johannesburg</placeName>
+                <location>
+                  <country>South Africa</country>
+                  <region type="province">Gauteng</region>
+                </location>
+              </place>
+              <place xml:id="l-PI" xml:lang="es">
+                <placeName>Puerto Inca</placeName>
+                <location>
+                  <country>Peru</country>
+                  <region>Huánuco</region>
+                  <district>Puerto Inca</district>
+                </location>
+              </place>
+              <place xml:id="l-Kam">
+                <placeName xml:lang="ru">Камчатке</placeName>
+                <location>
+                  <country>Russia</country>
+                  <region>Kamchatka Krai</region>
+                </location>
+              </place>
+            </listPlace>
+            <!-- ========= people ========= -->
+            <listPerson>
+              <person xml:id="p-VV">
+                <persName xml:lang="sr-Cyrl">Весна Вуловић</persName>
+                <persName xml:lang="sr-Latn">Vesna Vulović</persName>
+                <birth when="1950-01-03"/>
+                <death when="2016-12-23"/>
+                <ptr type="furtherInfo" target="https://en.wikipedia.org/wiki/Vesna_Vulovi%C4%87"/>
+              </person>
+              <person xml:id="p-IC">
+                <persName xml:lang="uk-Cyrl">Іван Михайлович Чиссов</persName>
+                <persName xml:lang="ru-Cyrl">Иван Михайлович Чисов</persName>
+                <persName xml:lang="uk-Latn">Ivan Mikhailovich Chisov</persName>
+                <birth when="1916"/>
+                <death when="1986"/>
+                <ptr type="furtherInfo" target="https://en.wikipedia.org/wiki/Ivan_Chisov"/>
+              </person>
+              <person xml:id="p-AM">
+                <persName>Alan Eugene Magee</persName>
+                <birth when="1919-01-13"/>
+                <death when="2003-12-20"/>
+                <ptr type="furtherInfo" target="https://en.wikipedia.org/wiki/Alan_Magee"/>
+              </person>
+              <person xml:id="p-NA">
+                <persName>Nicholas Stephen Alkemade</persName>
+                <birth when="1922-12-10"/>
+                <death when="1987-06-22"/>
+                <ptr type="furtherInfo" target="https://en.wikipedia.org/wiki/Nicholas_Alkemade"/>
+              </person>
+              <person xml:id="p-BG">
+                <persName>Edward Michael Grylls</persName>
+                <birth when="1974-06-07"/>
+                <ptr type="furtherInfo" target="https://www.beargrylls.com/pages/about-bear-grylls"/>
+              </person>
+              <person xml:id="p-JK">
+                <persName>Juliane Koepcke</persName>
+                <birth when="1954-10-10"/>
+                <ptr type="furtherInfo" target="https://en.wikipedia.org/wiki/Juliane_Koepcke"/>
+              </person>
+              <person xml:id="p-JB">
+                <persName>James Boole</persName>
+                <birth>1978, give or take a year</birth>
+                <ptr type="furtherInfo" target="https://www.facebook.com/james.boole/?ref=page_internal"/>
+              </person>
+            </listPerson>
+            <!-- ========= conjunctions and disjunctions ========= -->
+            <altGrp type="location">
+              <alt xml:id="l-KorZ" target="#l-Ken #l-Zam"/>
+            </altGrp>
           </standOff>
         </egXML>
 

--- a/P5/Source/Guidelines/en/ND-NamesDates.xml
+++ b/P5/Source/Guidelines/en/ND-NamesDates.xml
@@ -2114,7 +2114,12 @@ exemplifying here too? -->
             </altGrp>
           </standOff>
         </egXML>
-
+        <p>The <att>where</att> attribute on <gi>event</gi> can point to multiple 
+          canonical place descriptions, which should indicate 
+          that the event took place in multiple locations. For example, the November 2015
+          Paris Attacks took place at six different locations in Paris; this
+          might be encoded as an <gi>event</gi> with a <att>where</att>
+          attribute with six space-separated values.</p>
       </div>
       <div xml:id="place-rel">
         <head>Relations Between Places</head>

--- a/P5/Source/Specs/att.locatable.xml
+++ b/P5/Source/Specs/att.locatable.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright TEI Consortium. 
+Dual-licensed under CC-by and BSD2 licences 
+See the file COPYING.txt for details
+$Date$
+$Id$
+-->
+<?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tagdocs"
+           type="atts" ident="att.locatable" predeclare="true">
+  <desc versionDate="2021-07-29" xml:lang="en">provides attributes for referencing locations by pointing to entries in a canonical list of places.</desc>
+  <attList>
+    <attDef ident="where" usage="opt">
+      <desc versionDate="2021-07-29" xml:lang="en">indicates one or more locations by pointing to a <gi>place</gi> element</desc>
+      <desc versionDate="2021-07-29" xml:lang="fr">indique une ou plusieurs localisations en pointant vers un élément <gi>place</gi></desc>
+      <desc versionDate="2021-07-29" xml:lang="es">indica una o más localizaciónes señalando un elemento <gi>place</gi></desc>
+      <desc versionDate="2021-07-29" xml:lang="it">indica una o più posizioni facendo riferimento a un elemento <gi>place</gi></desc>
+      <datatype maxOccurs="unbounded"><dataRef key="teidata.pointer"/></datatype>
+    </attDef>
+  </attList>
+</classSpec>

--- a/P5/Source/Specs/att.locatable.xml
+++ b/P5/Source/Specs/att.locatable.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tagdocs"
+<classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei"
            type="atts" ident="att.locatable" predeclare="true">
   <desc versionDate="2021-07-29" xml:lang="en">provides attributes for referencing locations by pointing to entries in a canonical list of places.</desc>
   <attList>
@@ -19,4 +19,7 @@ $Id$
       <datatype maxOccurs="unbounded"><dataRef key="teidata.pointer"/></datatype>
     </attDef>
   </attList>
+  <listRef>
+    <ptr target="#HDUDECL" type="div3"/>
+  </listRef>
 </classSpec>

--- a/P5/Source/Specs/att.locatable.xml
+++ b/P5/Source/Specs/att.locatable.xml
@@ -12,10 +12,10 @@ $Id$
   <desc versionDate="2021-07-29" xml:lang="en">provides attributes for referencing locations by pointing to entries in a canonical list of places.</desc>
   <attList>
     <attDef ident="where" usage="opt">
-      <desc versionDate="2021-07-29" xml:lang="en">indicates one or more locations by pointing to a <gi>place</gi> element</desc>
-      <desc versionDate="2021-07-29" xml:lang="fr">indique une ou plusieurs localisations en pointant vers un élément <gi>place</gi></desc>
-      <desc versionDate="2021-07-29" xml:lang="es">indica una o más localizaciónes señalando un elemento <gi>place</gi></desc>
-      <desc versionDate="2021-07-29" xml:lang="it">indica una o più posizioni facendo riferimento a un elemento <gi>place</gi></desc>
+      <desc versionDate="2021-07-29" xml:lang="en">indicates one or more locations by pointing to a <gi>place</gi> element or other canonical description.</desc>
+      <desc versionDate="2021-07-29" xml:lang="fr">indique une ou plusieurs localisations en pointant vers un élément <gi>place</gi> ou autre description canonique.</desc>
+      <desc versionDate="2021-07-29" xml:lang="es">indica una o más localizaciónes señalando un elemento <gi>place</gi> u otra descripción canónica.</desc>
+      <desc versionDate="2021-07-29" xml:lang="it">indica una o più posizioni facendo riferimento a un elemento <gi>place</gi> o altra descrizione canonica.</desc>
       <datatype maxOccurs="unbounded"><dataRef key="teidata.pointer"/></datatype>
     </attDef>
   </attList>

--- a/P5/Source/Specs/att.locatable.xml
+++ b/P5/Source/Specs/att.locatable.xml
@@ -21,5 +21,6 @@ $Id$
   </attList>
   <listRef>
     <ptr target="#HDUDECL" type="div3"/>
+    <ptr target="#NDGEOGste" type="div3"/>
   </listRef>
 </classSpec>

--- a/P5/Source/Specs/conversion.xml
+++ b/P5/Source/Specs/conversion.xml
@@ -10,6 +10,7 @@ $Id$
     <memberOf key="att.global"/>
     <memberOf key="att.datable"/>
     <memberOf key="att.formula"/>
+    <memberOf key="att.locatable"/>
   </classes>
   <content><empty/></content>
   <attList>

--- a/P5/Source/Specs/event.xml
+++ b/P5/Source/Specs/event.xml
@@ -28,6 +28,7 @@
     <memberOf key="att.naming"/>
     <memberOf key="att.sortable"/>
     <memberOf key="model.eventLike"/>
+    <memberOf key="att.locatable"/>
   </classes>
   <content>
     <sequence>
@@ -48,18 +49,6 @@
         <elementRef key="event" minOccurs="0" maxOccurs="unbounded"/>
       </sequence>
   </content>
-  <attList>
-    <attDef ident="where" usage="opt">
-      <desc versionDate="2007-06-11" xml:lang="en">indicates the location of an event by pointing to a <gi>place</gi> element</desc>
-      <desc versionDate="2007-12-20" xml:lang="ko"><gi>place</gi> 요소를 지시함으로써 사건의 위치를 나타낸다.</desc>
-      <desc versionDate="2008-04-06" xml:lang="es">indica la localización de un acontecimiento señalando un elemento <gi>lugar</gi>
-         </desc>
-      <desc versionDate="2008-12-09" xml:lang="fr">indique la localisation d'un évènement en pointant vers un élément <gi>place</gi>
-         </desc>
-      <desc versionDate="2007-11-06" xml:lang="it">indica la posizione di un evento facendo riferimento a un elemento place</desc>
-      <datatype><dataRef key="teidata.pointer"/></datatype>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <person>


### PR DESCRIPTION
With this PR I've created an attribute class, `att.locatable` for uses of `@where` that point to canonical `<place>` entries in a placeography. It resolves #1910 (asking for `@where` on `<conversion>`), and applies the new `att.locatable` to `@where` on `<event>` as well. 