### PR TITLE
revising restrictive pronouns in specs: which to that

### DIFF
--- a/P5/Source/Specs/att.cReferencing.xml
+++ b/P5/Source/Specs/att.cReferencing.xml
@@ -5,7 +5,7 @@
     $Date$
     $Id$
 --><?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" type="atts" ident="att.cReferencing">
-  <desc versionDate="2021-08-22" xml:lang="en">provides attributes which may be used to supply a
+  <desc versionDate="2021-08-22" xml:lang="en">provides attributes that may be used to supply a
   <term>canonical reference</term> as a means of identifying the
   target of a pointer.</desc>
   <desc xml:lang="ja" versionDate="2018-12-31">ポインタのターゲットを識別する手段として<term>canonical reference</term>を提供するために使用される属性を提供する。</desc>

--- a/P5/Source/Specs/att.canonical.xml
+++ b/P5/Source/Specs/att.canonical.xml
@@ -5,7 +5,7 @@
     $Date$
     $Id$
 --><?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" type="atts" ident="att.canonical">
-  <desc versionDate="2008-09-05" xml:lang="en">provides attributes which can be used to associate a representation such as a name or title
+  <desc versionDate="2008-09-05" xml:lang="en">provides attributes that can be used to associate a representation such as a name or title
     with canonical information about the object being named or referenced.</desc>
   <desc versionDate="2009-05-25" xml:lang="fr">fournit des attributs qui peuvent être utilisés pour
     associer une représentation telle qu'un nom ou un titre à l'information canonique concernant

--- a/P5/Source/Specs/att.coordinated.xml
+++ b/P5/Source/Specs/att.coordinated.xml
@@ -5,7 +5,7 @@ See the file COPYING.txt for details
 $Date$
 $Id$
 --><?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><classSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="transcr" type="atts" ident="att.coordinated">
-  <desc versionDate="2016-02-16" xml:lang="en">provides attributes which can be used to position their parent 
+  <desc versionDate="2016-02-16" xml:lang="en">provides attributes that can be used to position their parent 
     element within a two dimensional coordinate system.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">이차원 좌표 체계 내에서 위치될 수 있는 요소</desc>
   <desc versionDate="2008-04-06" xml:lang="es">los elementos se pueden colocar dentro de un sistema de coordenadas bidimensional.</desc>

--- a/P5/Source/Specs/att.datcat.xml
+++ b/P5/Source/Specs/att.datcat.xml
@@ -8,7 +8,7 @@ $Id$
 -->
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <classSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:dcr="http://www.isocat.org/ns/dcr" module="tei" xml:id="DATCAT" type="atts" ident="att.datcat">
-  <desc versionDate="2021-08-22" xml:lang="en">provides attributes which are used to 
+  <desc versionDate="2021-08-22" xml:lang="en">provides attributes that are used to 
     align XML elements or attributes with the appropriate Data Categories (DCs) defined by the ISO 12620:2009 
     standard and stored in the Web repository called ISOCat at <ref target="http://www.isocat.org/">http://www.isocat.org/</ref>.</desc>
   <desc xml:lang="ja" versionDate="2019-05-20"><att>dcr:datacat</att>属性と<att>dcr:ValueDatacat</att>属性を提供する．これらがXML要素や属性を連携させる日付分類は、国際標準ISO 12620:2009で定義されるものであり，<ref target="http://www.isocat.org/">http://www.isocat.org/</ref>にあるISOCatと呼ばれるWebリポジトリに格納されている．</desc>

--- a/P5/Source/Specs/att.enjamb.xml
+++ b/P5/Source/Specs/att.enjamb.xml
@@ -10,7 +10,7 @@ $Id$
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">詩句跨行</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">encabalgamiento</gloss>
   <gloss versionDate="2009-05-25" xml:lang="fr"> enjambement</gloss>
-  <desc versionDate="2021-08-22" xml:lang="en">provides attributes which may be used to indicate
+  <desc versionDate="2021-08-22" xml:lang="en">provides attributes that may be used to indicate
     enjambement of the parent element.</desc>
   <gloss xml:lang="ja" versionDate="2019-06-08">句またがり</gloss>
   <desc versionDate="2007-12-20" xml:lang="ko"><att>enjamb</att> 속성을 포함하는 요소를 모아놓는다.</desc>

--- a/P5/Source/Specs/att.metrical.xml
+++ b/P5/Source/Specs/att.metrical.xml
@@ -5,7 +5,7 @@ See the file COPYING.txt for details
 $Date$
 $Id$
 --><?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><classSpec xmlns="http://www.tei-c.org/ns/1.0" predeclare="true" module="verse" xml:id="METRICAL" type="atts" ident="att.metrical">
-  <desc versionDate="2005-10-10" xml:lang="en">defines a set of attributes which certain elements may use to
+  <desc versionDate="2005-10-10" xml:lang="en">defines a set of attributes that certain elements may use to
 represent metrical information.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">운율 정보를 표시하기 위하여 특정 요소들이 사용할 수 있는 속성 집합을 정의한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">定義一組特定元素所使用、表示詩行韻律的屬性。</desc>

--- a/P5/Source/Specs/att.typed.xml
+++ b/P5/Source/Specs/att.typed.xml
@@ -8,7 +8,7 @@ $Id$
 -->
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <classSpec xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.tei-c.org/ns/1.0" module="tei" xml:id="TYPED" type="atts" ident="att.typed" predeclare="true">
-  <desc versionDate="2007-10-02" xml:lang="en">provides attributes which can be used to classify or subclassify elements in any way.</desc>
+  <desc versionDate="2007-10-02" xml:lang="en">provides attributes that can be used to classify or subclassify elements in any way.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">요소의 분류 또는 하위분류에서 사용될 수 있는 속성을 제공한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">提供可依任何方法將元素分類或次要分類的一般屬性。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">要素を分類するための属性を示す．

--- a/P5/Source/Specs/interp.xml
+++ b/P5/Source/Specs/interp.xml
@@ -125,7 +125,7 @@ $Id$
     of an <gi>interp</gi> with any textual element through its
     <att>ana</att> attribute.</p>
     <p>Alternatively (or, in addition) an <gi>interp</gi> may carry an
-    <att>inst</att> attribute which points to one or more textual
+    <att>inst</att> attribute that points to one or more textual
     elements to which the analysis represented by the content of the
     <gi>interp</gi> applies.</p>
   </remarks>

--- a/P5/Source/Specs/model.xml
+++ b/P5/Source/Specs/model.xml
@@ -291,7 +291,7 @@
       </valList>
     </attDef>
     <attDef ident="useSourceRendition" usage="opt">
-      <desc versionDate="2015-08-21" xml:lang="en">whether to obey any rendition attribute which is
+      <desc versionDate="2015-08-21" xml:lang="en">whether to obey any rendition attribute that is
         present.</desc>
       <datatype>
         <dataRef key="teidata.truthValue"/>

--- a/P5/Source/Specs/modelSequence.xml
+++ b/P5/Source/Specs/modelSequence.xml
@@ -38,7 +38,7 @@
       </datatype>
     </attDef>
     <attDef ident="useSourceRendition" usage="opt">
-      <desc versionDate="2015-05-15" xml:lang="en">whether to obey any rendition attribute which is
+      <desc versionDate="2015-05-15" xml:lang="en">whether to obey any rendition attribute that is
         present</desc>
       <datatype>
         <dataRef key="teidata.truthValue"/>


### PR DESCRIPTION
This is reopening the [just-closed PR](https://github.com/TEIC/TEI/pull/2174) to finish what we just discussed: changing the restrictive pronouns in the spec `<desc>` elements from "which" to "that". These are pretty small. Just reopening for a moment to register completion of the task. 