### PR TITLE
Sydb stylesheets issue 417

### DIFF
--- a/P5/Source/Specs/att.deprecated.xml
+++ b/P5/Source/Specs/att.deprecated.xml
@@ -1,10 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 Copyright TEI Consortium. 
 Dual-licensed under CC-by and BSD2 licences 
 See the file COPYING.txt for details
 $Date$
 $Id$
---><?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><classSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" type="atts" ident="att.deprecated" predeclare="true">
+-->
+<?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<classSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" type="atts" ident="att.deprecated" predeclare="true">
   <desc versionDate="2013-05-16" xml:lang="en">provides attributes indicating how a deprecated feature will be treated in future releases.</desc>
   <desc versionDate="2019-04-08" xml:lang="ja">非推奨の機能を将来のリリースでどのように扱うかを示す属性を提供する。</desc>
   <attList>
@@ -12,7 +15,18 @@ $Id$
       <desc versionDate="2013-05-16" xml:lang="en">provides a date before which the construct being defined
       will not be removed.</desc>
       <desc versionDate="2019-04-08" xml:lang="ja">定義されている構文が削除される前の日付を提供する．</desc>
-      <datatype minOccurs="1" maxOccurs="1"><dataRef name="date"/></datatype>
+      <datatype minOccurs="1" maxOccurs="1">
+        <!--
+            WARNING: In the 'valid' target of the build process the
+            validity of @validUntil is tested against xsd:date not by
+            using the schema generated from this definition, but
+            rather by an ad-hoc test in an XSLT program, namely
+            P5/Utilities/extractegXML.xsl. Thus if we ever change the
+            datatype here, we may well need to change it there as
+            well. —Syd, 2022-02-02
+        -->
+        <dataRef name="date"/>
+      </datatype>
       <constraintSpec scheme="schematron" ident="deprecation-two-month-warning">
         <constraint>
           <sch:rule context="tei:*[@validUntil]">
@@ -66,8 +80,7 @@ $Id$
         the future. E.g., the documentation for such a construct might
         include the phrase <mentioned>warning: deprecated</mentioned>
         in red.</p>
-      </remarks>
-      
+      </remarks>      
       <remarks versionDate="2019-04-08" xml:lang="ja">
         <p>この属性の値は，（<code>yyyy-mm-dd</code>の形式で）日付を表し，属性がODDに追加された日付より後である必要がある。技術的には，この属性は，指定された日付まで定義されているマークアップ言語の将来のリリースで構造を残す意図のみを表明し，その日付以降に何が起こるかについて主張しない。実際には，<att>validUntil</att>日付の直後に定義されるマークアップ言語の将来のリリースからコンストラクトが削除されることが期待されます。</p>
         <p>ODDプロセッサは，通常，<att>validUntil</att>日付が過去のものである仕様要素を処理しない．ODDプロセッサは，通常，<att>validUntil</att>の日付を持つコンストラクトについてユーザに警告する。例えば，そのような構造のドキュメントには，<mentioned>warning：deprecated</mentioned>というフレーズが赤で表示される。</p>

--- a/P5/Utilities/extractegXML.xsl
+++ b/P5/Utilities/extractegXML.xsl
@@ -10,10 +10,11 @@
     ago by the amazing Sebastian Rahtz.
     
     Read in TEI P5, write out
-    a) a directory (./valid/) full of one-file-per-example each of which has a
+    a) a directory (./valid/) full of files, one for each example in
+       P5, each of which contains nothing but a copy of that single
        single example
-    b) a driver file (normal output of this stylesheet) that refers to each of
-       those files.
+    b) a driver file (normal output of this stylesheet) that refers to
+       each of those files.
 
     (Above is part of original program; feature described below added 2021-09-17
     by Syd Bauman and Martin Holmes in attempt to fix Stylesheets issue 417.)
@@ -107,7 +108,29 @@
       <xsl:text>-</xsl:text>
     </xsl:for-each>
   </xsl:template>
-  
+
+  <!-- ********* mode "copy_egXML_checking_validUntil" ********* -->
+  <!-- 
+       Everything is just copied over (see <xsl:mode> above), except
+       any @validUntil attribute is
+       1) checked to see that its value is, in fact, a valid W3C date;
+       2) converted to a date 1 year in the future from today.
+
+       The point of (2) is to guarentee that the next validation step
+       does not complain about the value of a particular @validUntil
+       being in the past or too soon or whatever. But that means said
+       next validation step will not be testing the actual value of
+       @validUntil, but rather our made-up value which will always be
+       valid. So we do (1) to test the format of the provided value,
+       so the user is told if it is not a valid value.
+       
+       NOTE: This means that if the datatype of @validUntil is ever
+       changed in the TEI _Guidelines_ the test here would have to
+       change accordingly. (I.e. we are testing @validUntil against
+       xsd:date here not because we happen to love xsd:dates, but
+       rather because @validUntil is defined as an xsd:date in
+       P5/Source/Specs/att.deprecated.xml)
+  -->
   <xsl:template match="@validUntil" mode="copy_egXML_checking_validUntil">
     <!--
       First, knock off leading & trailing spaces, which are allowed in the

--- a/P5/Utilities/extractegXML.xsl
+++ b/P5/Utilities/extractegXML.xsl
@@ -1,7 +1,7 @@
 <xsl:stylesheet version="2.0"
-    xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-    xmlns:teix="http://www.tei-c.org/ns/Examples" >
+                xmlns:tei="http://www.tei-c.org/ns/1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+                xmlns:teix="http://www.tei-c.org/ns/Examples" >
 
   <xsl:key name="V" match="teix:egXML[@valid='true' or not(@valid)]" use="1"/>
   <xsl:key name="F" match="teix:egXML[@valid='feasible']" use="1"/>
@@ -10,7 +10,7 @@
     <xsl:text disable-output-escaping="yes">&lt;!DOCTYPE p [</xsl:text>
     <xsl:for-each select="key('V',1)">
       <xsl:variable name="N">
-	<xsl:call-template name="loc"/>
+        <xsl:call-template name="loc"/>
       </xsl:variable>
       <xsl:text disable-output-escaping="yes">&lt;!ENTITY </xsl:text>
       <xsl:value-of select="$N"/>
@@ -19,65 +19,64 @@
       <xsl:text disable-output-escaping="yes">"&gt;&#10;</xsl:text>
     </xsl:for-each>
     <xsl:text disable-output-escaping="yes">]&gt;</xsl:text>
-    <TEI 
-	xmlns="http://www.tei-c.org/ns/1.0">
+    <TEI xmlns="http://www.tei-c.org/ns/1.0">
       <teiHeader>
-    <fileDesc>
-      <titleStmt>
-        <title>The title</title>
-      </titleStmt>
-      <editionStmt>
-        <p/>
-      </editionStmt>
-      <publicationStmt>
-        <p/>
-      </publicationStmt>
-      <sourceDesc>
-        <p/>
-      </sourceDesc>
-    </fileDesc>
-  </teiHeader>
-  <text>
-    <body>
-      <p>
-    <xsl:for-each select="key('V',1)">
-      <xsl:variable name="N">
-	<xsl:call-template name="loc"/>
-      </xsl:variable>
-      <xsl:result-document href="valid/{$N}">
-	<xsl:copy-of select="."/>
-      </xsl:result-document>
-      <xsl:text disable-output-escaping="yes">&amp;</xsl:text>
-      <xsl:value-of select="$N"/>
-      <xsl:text>;</xsl:text>
-    </xsl:for-each>
-</p>
-    </body>
-  </text>
-</TEI>
+        <fileDesc>
+          <titleStmt>
+            <title>The title</title>
+          </titleStmt>
+          <editionStmt>
+            <p/>
+          </editionStmt>
+          <publicationStmt>
+            <p/>
+          </publicationStmt>
+          <sourceDesc>
+            <p/>
+          </sourceDesc>
+        </fileDesc>
+      </teiHeader>
+      <text>
+        <body>
+          <p>
+            <xsl:for-each select="key('V',1)">
+              <xsl:variable name="N">
+                <xsl:call-template name="loc"/>
+              </xsl:variable>
+              <xsl:result-document href="valid/{$N}">
+                <xsl:copy-of select="."/>
+              </xsl:result-document>
+              <xsl:text disable-output-escaping="yes">&amp;</xsl:text>
+              <xsl:value-of select="$N"/>
+              <xsl:text>;</xsl:text>
+            </xsl:for-each>
+          </p>
+        </body>
+      </text>
+    </TEI>
   </xsl:template>
-
+  
   <xsl:template name="loc">
     <xsl:for-each select="ancestor::tei:*|ancestor-or-self::teix:*">
       <xsl:value-of select="name(.)"/>
       <xsl:text>_</xsl:text>
       <xsl:choose>
-	<xsl:when test="@ident">
-	  <xsl:text></xsl:text>
-	  <xsl:value-of select="replace(@ident,':','')"/>
-	  <xsl:text></xsl:text>
-	</xsl:when>
-	<xsl:when test="@xml:id">
-	  <xsl:text></xsl:text>
-	  <xsl:value-of select="replace(@xml:id,':','')"/>
-	  <xsl:text></xsl:text>
-	</xsl:when>
-	<xsl:otherwise>
-	  <xsl:number/>
-	</xsl:otherwise>
+        <xsl:when test="@ident">
+          <xsl:text></xsl:text>
+          <xsl:value-of select="replace(@ident,':','')"/>
+          <xsl:text></xsl:text>
+        </xsl:when>
+        <xsl:when test="@xml:id">
+          <xsl:text></xsl:text>
+          <xsl:value-of select="replace(@xml:id,':','')"/>
+          <xsl:text></xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:number/>
+        </xsl:otherwise>
       </xsl:choose>
       <xsl:text>-</xsl:text>
     </xsl:for-each>
-</xsl:template>
+  </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
This fix addresses Stylesheets issue 417 (https://github.com/TEIC/Stylesheets/issues/417), which turned out to be a problem in the TEI repo rather than the Stylesheets repo. Schematron validation will no longer trigger an error if an expired date is used for `@validUntil` inside an `<egXML>`, but other checks on `@validUntil` will still be effective.