### PR TITLE
#2179, item 2:

### DIFF
--- a/P5/Source/Specs/constraintSpec.xml
+++ b/P5/Source/Specs/constraintSpec.xml
@@ -23,9 +23,26 @@ $Id$
         <classRef key="model.glossLike"/>
         <classRef key="model.descLike"/>
       </alternate>
-      <elementRef key="constraint" minOccurs="1" maxOccurs="1"/>
+      <elementRef key="constraint" minOccurs="0" maxOccurs="1"/>
     </sequence>
-  </content>    
+  </content>
+  <!--
+      Following <constraintSpec> might be more clearly accomplished
+      using abstract patterns, but our build process does not
+      currently support that. For an attempt at using them, see
+      https://github.com/TEIC/TEI/tree/sydb_issue-2179_1st_via_abstract_pats,
+      which was my first attempt at doing this. —Syd, 2021-10-13
+  -->
+  <constraintSpec scheme="schematron" ident="constraint-unless-delete">
+    <constraint>
+      <sch:rule context="tei:constraintSpec[ @mode eq 'delete' ]">
+        <sch:report test="child::tei:constraint">This 'constraintSpec' element has a mode= of "delete" even though it has a child constraint. Change the mode= to "add", "change", or "replace", or remove the 'constraint' child.</sch:report>
+      </sch:rule>
+      <sch:rule context="tei:constraintSpec[ @mode = ('add','replace') ]">
+        <sch:assert test="child::tei:constraint">This 'constraintSpec' element has a mode= of "<sch:value-of select="@mode"/>", but does not a 'constraint' child element. Specify a constraint or change the mode= to "delete".</sch:assert>
+      </sch:rule>
+    </constraint>
+  </constraintSpec>
   <constraintSpec ident="sch_no_more" scheme="schematron">
     <desc xml:lang="en" versionDate="2018-07-06">Relationship between scheme attribute and contents: Schematron 1.x</desc>
     <constraint>


### PR DESCRIPTION
Insist that `<constraintSpec>` elements in mode "add" or "replace" do have a child `<constraint>`, and those in "delete" do not.