### PR TITLE
Update link in example

### DIFF
--- a/P5/Source/Specs/att.internetMedia.xml
+++ b/P5/Source/Specs/att.internetMedia.xml
@@ -38,7 +38,7 @@ ressource informatique selon une taxinomie normalisée.</desc>
   <exemplum xml:lang="en">
     <p>In this example <att>mimeType</att> is used to indicate that the URL points to a TEI XML file encoded in UTF-8.</p>
     <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#UND">
-      <ref mimeType="application/tei+xml; charset=UTF-8" target="http://sourceforge.net/p/tei/code/HEAD/tree/trunk/P5/Source/guidelines-en.xml"/>
+      <ref mimeType="application/tei+xml; charset=UTF-8" target="https://raw.githubusercontent.com/TEIC/TEI/dev/P5/Source/guidelines-en.xml"/>
     </egXML>
   </exemplum>
   <remarks versionDate="2013-12-06" xml:lang="en">


### PR DESCRIPTION
This PR not only updates the link in the example to the latest version of the file in the current repo, it actually points now to the raw version (which indeed matches the given mimeType) instead of the html representation of the file within the repo.