### PR TITLE
Update W3C links

### DIFF
--- a/P5/Source/Guidelines/en/BIB-Bibliography.xml
+++ b/P5/Source/Guidelines/en/BIB-Bibliography.xml
@@ -824,7 +824,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                             McCormack</editor>
                             <editor>Doug Schepers</editor>, <editor>Jonathan Watt</editor> and <editor>Patrick Dengler</editor>.
                             <publisher>World Wide Web Consortium (W3C)</publisher> (<date>22 June 2010</date>). Available from <ptr
-                            target="http://www.w3.org/TR/SVG11/"/>.
+                            target="https://www.w3.org/TR/SVG11/"/>.
                           </bibl>
                           <bibl xml:id="SERAFIN2"><title>Letter of Mikołaj Orlik to Mikołaj Serafin, Gródek, January 13 [1438]</title>. 
                             Edited by <editor>Skolimowska et al.</editor> Available from <ptr
@@ -900,10 +900,10 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                             </title><title>New York Times, </title>
                             <date>April 20, 1992</date>.
                             <!--http://www.nytimes.com/1992/04/20/world/serbs-tighten-grip-on-eastern-bosnia.html--></bibl>
-			    <bibl xml:id="SUE">SUEtheTrex, Twitter biography.
-			    <ptr target="https://twitter.com/SUEtheTrex"/>. 
-			    Accessed <date when="2020-03-25">March 25th, 2020</date>.</bibl>
-			    <bibl xml:id="COEDCOR-eg-71">
+                            <bibl xml:id="SUE">SUEtheTrex, Twitter biography.
+                            <ptr target="https://twitter.com/SUEtheTrex"/>. 
+                            Accessed <date when="2020-03-25">March 25th, 2020</date>.</bibl>
+                            <bibl xml:id="COEDCOR-eg-71">
                               <author>Swift, Jonathan</author>. <title level="m">Travels into Several Remote Nations of the World, in Four
                             Parts. By Lemuel Gulliver... </title> (<date>1735</date>).</bibl>
                             <bibl xml:id="swiftLaw"><author>Swift, Jonathan</author>. <title>Law is a bottomless pit, or the history of John
@@ -1010,12 +1010,12 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                   <!-- X -->
                                   <!-- Y -->
                                   <!-- Z -->
-				  <bibl xml:id="LZ">
-				    <author>Zimman, Lal</author>.
-				    <title>Lal Zimman</title>
-				    <ptr target="http://lalzimman.com/bio.html"/>,
-				    accessed <date when="2021-02-01">February 1, 2021</date>.
-				  </bibl>
+                                  <bibl xml:id="LZ">
+                                    <author>Zimman, Lal</author>.
+                                    <title>Lal Zimman</title>
+                                    <ptr target="http://lalzimman.com/bio.html"/>,
+                                    accessed <date when="2021-02-01">February 1, 2021</date>.
+                                  </bibl>
                                   <bibl xml:id="SA-eg-04">
                                     <title level="a">Zuigan calls himself "Master"</title>. <author>Mumon Ekai</author>. (In <title level="m">The
                                   Gateless Gate</title>, Case 12.) </bibl>
@@ -1541,7 +1541,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Walsh</surname>
                                           </editor>
                                           <title level="m">XPointer Framework</title>
-                                          <ptr target="http://www.w3.org/TR/xptr-framework/"/>
+                                          <ptr target="https://www.w3.org/TR/xptr-framework/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2003-03-25">25 March 2003</date>
@@ -1567,7 +1567,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Walsh</surname>
                                           </editor>
                                           <title level="m">XPointer element() Scheme</title>
-                                          <ptr target="http://www.w3.org/TR/xptr-element/"/>
+                                          <ptr target="https://www.w3.org/TR/xptr-element/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2003-03-25">25 March 2003</date>
@@ -1577,7 +1577,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                       <biblStruct xml:id="XHTML">
                                         <monogr>
                                           <title level="m">XHTML™ 1.0 The Extensible HyperText Markup Language (Second Edition)</title>
-                                          <ptr target="http://www.w3.org/TR/xhtml/"/>
+                                          <ptr target="https://www.w3.org/TR/xhtml/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2000-01-26">26 January 2000</date>
@@ -1599,7 +1599,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Jacobs</surname>
                                           </editor>
                                           <title level="m"> HTML 4.01 Specification</title>
-                                          <ptr target="http://www.w3.org/TR/html401/"/>
+                                          <ptr target="https://www.w3.org/TR/html401/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="1999-12-24">24 December 1999</date>
@@ -1625,7 +1625,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Poppelier</surname>
                                           </editor>
                                           <title level="m">Mathematical Markup Language (MathML) Version 2.0 (Second edition)</title>
-                                          <ptr target="http://www.w3.org/TR/MathML2/"/>
+                                          <ptr target="https://www.w3.org/TR/MathML2/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2003-10-21">21 October 2003</date>
@@ -1643,7 +1643,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Malhotra</surname>
                                           </editor>
                                           <title level="m">XML Schema Part 2: Datatypes Second Edition</title>
-                                          <ptr target="http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/"/>
+                                          <ptr target="https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2004-10-28">28 October 2004</date>
@@ -1657,7 +1657,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Berglund</surname>
                                           </editor>
                                           <title level="m">Extensible Stylesheet Language (XSL) Version 1.1</title>
-                                          <ptr target="http://www.w3.org/TR/xsl11/"/>
+                                          <ptr target="https://www.w3.org/TR/xsl11/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2006-12-05">5 December 2006</date>
@@ -1671,7 +1671,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Clark</surname>
                                           </editor>
                                           <title level="m">XSL Transformations (XSLT) Version 1.0</title>
-                                          <ptr target="http://www.w3.org/TR/xslt/"/>
+                                          <ptr target="https://www.w3.org/TR/xslt/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="1999-11-16">16 November 1999</date>
@@ -1729,7 +1729,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Yergau</surname>
                                           </editor>
                                           <title level="m">Extensible Markup Language (XML) Version 1.0 (Fourth edition)</title>
-                                          <ptr target="http://www.w3.org/TR/REC-xml/"/>
+                                          <ptr target="https://www.w3.org/TR/REC-xml/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2006-08-16">16 August 2006</date>
@@ -1755,7 +1755,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Lie</surname>
                                           </editor>
                                           <title level="m">Cascading Style Sheets Level 2 Revision 1</title>
-                                          <ptr target="http://www.w3.org/TR/CSS2/"/>
+                                          <ptr target="https://www.w3.org/TR/CSS2/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2011-06-07">7 June 2011</date>
@@ -1773,7 +1773,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Bos</surname>
                                           </editor>
                                           <title level="m">Cascading Style Sheets, Level 1</title>
-                                          <ptr target="http://www.w3.org/TR/REC-CSS1/"/>
+                                          <ptr target="https://www.w3.org/TR/REC-CSS1/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="1999-01-11">11 January 1999</date>
@@ -1790,7 +1790,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Ishi</surname>
                                           </editor>
                                           <title level="m">CSS Writing Modes Level 3 (W3C Candidate Recommendation)</title>
-                                          <ptr target="http://www.w3.org/TR/css-writing-modes-3/"/>
+                                          <ptr target="https://www.w3.org/TR/css-writing-modes-3/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2015-12-15">15 December 2015</date>
@@ -1816,7 +1816,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Schulze</surname>
                                           </editor>
                                           <title level="m">CSS Transforms Module Level 1 (W3C Working Draft)</title>
-                                          <ptr target="http://www.w3.org/TR/css-transforms/"/>
+                                          <ptr target="https://www.w3.org/TR/css-transforms/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2013-11-26">26 November 2013</date>
@@ -1856,7 +1856,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Tobin</surname>
                                           </editor>
                                           <title level="m">XML Base (Second Edition)</title>
-                                          <ptr target="http://www.w3.org/TR/xmlbase/"/>
+                                          <ptr target="https://www.w3.org/TR/xmlbase/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2009-01-28">28 January 2009</date>
@@ -1982,7 +1982,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Tobin</surname>
                                           </editor>
                                           <title level="m">Namespaces in XML 1.0 (second edition)</title>
-                                          <ptr target="http://www.w3.org/TR/xml-names/"/>
+                                          <ptr target="https://www.w3.org/TR/xml-names/"/>
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2006-08-16">16 August 2006</date>
@@ -2057,32 +2057,32 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                           </imprint>
                                         </monogr>
                                       </biblStruct>
-				      <biblStruct xml:id="WAV">
-					<monogr>
-					  <editor>
-					    <forename>Robert</forename>
-					    <surname>Sanderson</surname>
-					  </editor>
-					  <editor>					    
-					    <forename>Paolo</forename>
-					    <surname>Ciccarese</surname>
-					  </editor>
-					  <editor>
-					    <forename>Benjamin</forename>
-					    <surname>Young</surname>
-					  </editor>
-					  <title>Web Annotation Vocabulary</title>
-					  <ptr target="https://www.w3.org/TR/annotation-vocab/"/>
+                                      <biblStruct xml:id="WAV">
+                                        <monogr>
+                                          <editor>
+                                            <forename>Robert</forename>
+                                            <surname>Sanderson</surname>
+                                          </editor>
+                                          <editor>
+                                            <forename>Paolo</forename>
+                                            <surname>Ciccarese</surname>
+                                          </editor>
+                                          <editor>
+                                            <forename>Benjamin</forename>
+                                            <surname>Young</surname>
+                                          </editor>
+                                          <title>Web Annotation Vocabulary</title>
+                                          <ptr target="https://www.w3.org/TR/annotation-vocab/" />
                                           <imprint>
                                             <publisher>W3C</publisher>
                                             <date when="2017-02-23">23 February 2017</date>
                                           </imprint>
-					</monogr>
-				      </biblStruct>
+                                        </monogr>
+                                      </biblStruct>
                                       <biblStruct xml:id="CH-BIBL-3">
                                         <monogr>
                                           <title>The Unicode Standard, Version 5.0</title>
-                                          <ptr target="http://www.unicode.org/"/>
+                                          <ptr target="https://www.unicode.org/"/>
                                           <author>Unicode Consortium</author>
                                           <imprint>
                                             <publisher>Addison-Wesley Professional</publisher>
@@ -2141,7 +2141,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                             <surname>Freytag</surname>
                                           </author>
                                           <title level="m">Unicode Character Database</title>
-                                          <ptr target="http://www.unicode.org/Public/UNIDATA/UCD.html"/>
+                                          <ptr target="https://www.unicode.org/Public/UNIDATA/UCD.html"/>
                                           <imprint>
                                             <publisher>Unicode Consortium</publisher>
                                             <date>2006</date>
@@ -2296,7 +2296,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                           </author>
                                           <title level="m">The Unicode Character Property Model</title>
                                           <title level="s">Unicode Technical Report #23</title>
-                                          <ptr target="http://www.unicode.org/reports/tr23/"/>
+                                          <ptr target="https://www.unicode.org/reports/tr23/"/>
                                           <imprint>
                                             <date>2006</date>
                                           </imprint>
@@ -2318,7 +2318,7 @@ Papers of the Presidents: 1789-1897</title>, Washington,
                                           </author>
                                           <title level="m">Unicode Bidirectional Algorithm</title>
                                           <title level="s">Unicode Standard Annex #9</title>
-                                          <ptr target="http://www.unicode.org/reports/tr9/"/>
+                                          <ptr target="https://www.unicode.org/reports/tr9/"/>
                                           <imprint>
                                             <date>2017-05-04</date>
                                           </imprint>

--- a/P5/Source/Guidelines/en/CH-LanguagesCharacterSets.xml
+++ b/P5/Source/Guidelines/en/CH-LanguagesCharacterSets.xml
@@ -100,7 +100,7 @@ and is available at <ptr
 target="http://www.iana.org/assignments/language-subtag-registry"/>.
 For a good general overview of the construction of language tags, see
 <ptr
-target="http://www.w3.org/International/articles/language-tags/"/>,
+target="https://www.w3.org/International/articles/language-tags/"/>,
 and for a practical step-by-step guide, see <ptr
 target="https://www.w3.org/International/questions/qa-choosing-language-tags.en.php"/>.</p>
 <p>In addition to the list of registered subtags, BCP 47 provides
@@ -343,7 +343,7 @@ dates, and predefined value lists.</note></p></div>
    Consortium and an ISO work group (ISO/IEC JTC1
    SC2/WG2) have developed a detailed model of the relationship
    between characters and glyphs. This model, presented in <ref
-     target="http://www.unicode.org/reports/tr17/">Unicode Technical
+     target="https://www.unicode.org/reports/tr17/">Unicode Technical
      Report 17: Character Encoding Model</ref>, is the underpinning
    of much standards work since, including the current chapter.</p>
    <p>The model makes explicit the distinction between two different
@@ -566,11 +566,11 @@ dates, and predefined value lists.</note></p></div>
    by one or more combining characters into the corresponding precomposed 
    characters. The World Wide Web Consortium has produced a document entitled
    <title>Character Model for the World Wide Web 1.0</title><note place="bottom">Available at
-    <ptr target="http://www.w3.org/TR/charmod/"/>.</note>, which among other things
+    <ptr target="https://www.w3.org/TR/charmod/"/>.</note>, which among other things
    discusses normalization issues and outlines some relevant
    principles. An authoritative reference is Unicode Standard Annex
    #15 <title>Unicode Normalization Forms</title><note place="bottom">available at
-    <ptr target="http://www.unicode.org/reports/tr15/"/></note>. </p> 
+    <ptr target="https://www.unicode.org/reports/tr15/"/></note>. </p> 
    <p>It is important that every Unicode-based project should agree
    on, consistently implement, and fully document a comprehensive and
    coherent normalization practice. As well as ensuring data integrity
@@ -586,7 +586,7 @@ dates, and predefined value lists.</note></p></div>
    <head><!--4.6.3 -->Character Semantics</head>    
    <p>In addition to the Universal Character Set itself, the
     Unicode Consortium maintains a database of additional character
-    semantics<note place="bottom"><ptr target="http://www.unicode.org/ucd/"/></note>. This
+    semantics<note place="bottom"><ptr target="https://www.unicode.org/ucd/"/></note>. This
     includes names for each character code point and normative
     properties for it.  Character properties, as given in this
     database, determine the semantics and thus the intended use of a
@@ -602,7 +602,7 @@ dates, and predefined value lists.</note></p></div>
    value, directionality, and, (where applicable) status as a
    <soCalled>compatibility character</soCalled><note place="bottom">For
    further details, see <title>The Unicode Character Property
-   Model</title> (Unicode Technical Report #23), at <ptr target="http://www.unicode.org/reports/tr23/"/>.</note>. Where a
+   Model</title> (Unicode Technical Report #23), at <ptr target="https://www.unicode.org/reports/tr23/"/>.</note>. Where a
    project undertakes local definition of characters with code points
    in the PUA, it is desirable that any relevant additional
    information about the characters concerned should be recorded in an

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -2355,14 +2355,14 @@ representation of the date given as content of the <gi>date</gi>
 element. The format used should be a valid W3C schema datatype.<note place="bottom">The datatypes are taken from the W3C Recommendation <title ref="#XSD2">XML Schema Part 2: Datatypes Second Edition</title>. 
 The permitted datatypes are:
 <list rend="bulleted">
-<item><ref target="http://www.w3.org/TR/xmlschema-2/#date">date</ref></item>
-<item><ref target="http://www.w3.org/TR/xmlschema-2/#gYear">gYear</ref></item>
-<item><ref target="http://www.w3.org/TR/xmlschema-2/#gMonth">gMonth</ref></item>
-<item><ref target="http://www.w3.org/TR/xmlschema-2/#gDay">gDay</ref></item>
-<item><ref target="http://www.w3.org/TR/xmlschema-2/#gYearMonth">gYearMonth</ref></item>
-<item><ref target="http://www.w3.org/TR/xmlschema-2/#gMonthDay">gMonthDay</ref></item>
-<item><ref target="http://www.w3.org/TR/xmlschema-2/#time">time</ref></item>
-<item><ref target="http://www.w3.org/TR/xmlschema-2/#dateTime">dateTime</ref></item>
+<item><ref target="https://www.w3.org/TR/xmlschema-2/#date">date</ref></item>
+<item><ref target="https://www.w3.org/TR/xmlschema-2/#gYear">gYear</ref></item>
+<item><ref target="https://www.w3.org/TR/xmlschema-2/#gMonth">gMonth</ref></item>
+<item><ref target="https://www.w3.org/TR/xmlschema-2/#gDay">gDay</ref></item>
+<item><ref target="https://www.w3.org/TR/xmlschema-2/#gYearMonth">gYearMonth</ref></item>
+<item><ref target="https://www.w3.org/TR/xmlschema-2/#gMonthDay">gMonthDay</ref></item>
+<item><ref target="https://www.w3.org/TR/xmlschema-2/#time">time</ref></item>
+<item><ref target="https://www.w3.org/TR/xmlschema-2/#dateTime">dateTime</ref></item>
 </list>
 There 
 is one exception: these Guidelines permit a time to be expressed as only a number of hours, or as a number of hours and minutes,
@@ -2484,10 +2484,10 @@ attribute) to the more complex usage of a full URI with
 embedded XPointers. For example, the source of the following paragraph
 looks something like this: 
   <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#NONE"><p>...
-The complete XPointer specification is managed by the W3C<note place="foot"><ptr target="http://www.w3.org/TR/xptr-framework/"/>, 
-<ptr target="http://www.w3.org/TR/xptr-element/"/>, 
-<ptr target="http://www.w3.org/TR/xptr-xmlns/"/>, and 
-<ptr target="http://www.w3.org/TR/xptr-xpointer/"/></note>;
+The complete XPointer specification is managed by the W3C<note place="foot"><ptr target="https://www.w3.org/TR/xptr-framework/"/>, 
+<ptr target="https://www.w3.org/TR/xptr-element/"/>, 
+<ptr target="https://www.w3.org/TR/xptr-xmlns/"/>, and 
+<ptr target="https://www.w3.org/TR/xptr-xpointer/"/></note>;
 for a discussion of TEI schemes for XPointer, see 
 <ptr target="#eSATS"/>.</p>
 <!--... -->
@@ -2499,7 +2499,7 @@ Alternatively, if no explicit link is to
 be encoded, but it is simply required to mark the phrase as a
 cross-reference, the <gi>ref</gi> element may be used without a
 <att>target</att> attribute.</p>
-<p>For an introduction to the use of links in general, see <ptr target="#SA"/>. The complete XPointer specification is managed by the W3C<note place="foot"><ptr target="http://www.w3.org/TR/xptr-framework/"/>, <ptr target="http://www.w3.org/TR/xptr-element/"/>, <ptr target="http://www.w3.org/TR/xptr-xmlns/"/>, and <ptr target="http://www.w3.org/TR/xptr-xpointer/"/></note>; for a discussion of
+<p>For an introduction to the use of links in general, see <ptr target="#SA"/>. The complete XPointer specification is managed by the W3C<note place="foot"><ptr target="https://www.w3.org/TR/xptr-framework/"/>, <ptr target="https://www.w3.org/TR/xptr-element/"/>, <ptr target="https://www.w3.org/TR/xptr-xmlns/"/>, and <ptr target="https://www.w3.org/TR/xptr-xpointer/"/></note>; for a discussion of
 TEI schemes for XPointer, see <ptr target="#SATS"/>.</p>
 <p>
 <specList><specDesc key="ptr"/><specDesc key="ref"/></specList>
@@ -2650,7 +2650,7 @@ appropriate value for the <att>rend</att> attribute. Suggested values
   Some of these values may of course be combined; a list may be inline, but also be rendered with 
   numbers. An example appears below. For more sophisticated and detailed description of list rendering, consider using the <att>style</att>
   attribute with Cascading Stylesheet properties and values, as described in the W3C's
-  <ref target="http://www.w3.org/TR/css-lists-3/">CSS Lists and Counters Module Level 3</ref>.</p>
+  <ref target="https://www.w3.org/TR/css-lists-3/">CSS Lists and Counters Module Level 3</ref>.</p>
 
 <p>Each distinct item in the list should be encoded as a distinct
 <gi>item</gi> element.  If the numbering or other identification for the

--- a/P5/Source/Guidelines/en/FT-TablesFormulaeGraphics.xml
+++ b/P5/Source/Guidelines/en/FT-TablesFormulaeGraphics.xml
@@ -325,21 +325,21 @@ Technical Resolution 9503:1995, Exchange Table Model Document Type
 version of this is also defined in <title>OASIS Technical Memorandum TR 9901:1999,
 		XML Exchange Table Model DTD</title> (<ptr
 		target="http://www.oasis-open.org/specs/tm9901.html"/>). </p>-->
-      <!--	<p>With the ascent of the Web, the HTML table model (<ptr target="http://www.w3.org/TR/html4/struct/tables.html"/>) has become very popular and widespread in use. The
+      <!--	<p>With the ascent of the Web, the HTML table model (<ptr target="https://www.w3.org/TR/html4/struct/tables.html"/>) has become very popular and widespread in use. The
 last few years have seen a growing access to information via devices
 of varying capabilities, ranging from desktop computers to handheld
 mobile phones.  In response to this demand, HTML has been both
 reformulated into XML and modularized into a family of modules (see
-<ptr target="http://www.w3.org/TR/xhtml-modularization"/>) with semantically related elements. This
-family includes two Table Modules: the Basic Tables Module (<ptr target="http://www.w3.org/TR/xhtml-modularization/xhtml-modularization.html#s_simpletablemodule"/>) and the Tables
-Module (<ptr target="http://www.w3.org/TR/xhtml-modularization/xhtml-modularization.html#s_tablemodule"/>). The Tables
-Module mimics the functionality of HTML 4 (<ptr target="http://www.w3.org/TR/html401/"/>)
-tables and is a part of the XHTML 1.1 (<ptr target="http://www.w3.org/TR/xhtml11"/>)
+<ptr target="https://www.w3.org/TR/xhtml-modularization"/>) with semantically related elements. This
+family includes two Table Modules: the Basic Tables Module (<ptr target="https://www.w3.org/TR/xhtml-modularization/xhtml-modularization.html#s_simpletablemodule"/>) and the Tables
+Module (<ptr target="https://www.w3.org/TR/xhtml-modularization/xhtml-modularization.html#s_tablemodule"/>). The Tables
+Module mimics the functionality of HTML 4 (<ptr target="https://www.w3.org/TR/html401/"/>)
+tables and is a part of the XHTML 1.1 (<ptr target="https://www.w3.org/TR/xhtml11"/>)
 document type. The Basic Tables Module is a
 <soCalled>diluted</soCalled> version of the Tables Module, retaining
 only the minimal functionality with the purpose of extending XHTML's
 reach onto resource-constrained devices. It is a part of the XHTML
-Basic document type (<ptr target="http://www.w3.org/TR/xhtml-basic"/>).</p>-->
+Basic document type (<ptr target="https://www.w3.org/TR/xhtml-basic"/>).</p>-->
       <p>The XHTML table model (<ptr target="#XHTML"/>) is based on the HTML
         table model (<ptr target="#HTML4"/>). Both models support arrangement of
         arbitrary data into rows and columns of cells. Table rows and columns
@@ -347,13 +347,12 @@ Basic document type (<ptr target="http://www.w3.org/TR/xhtml-basic"/>).</p>-->
         rendered by user agents in ways that emphasize this structure. Support
         for incremental rendering of tables and for rendering on
           <soCalled>non-visual</soCalled> user agents
-        <!-- (<ptr
-	target="http://www.w3.org/TR/html4/struct/tables.html#non-visual-rendering"/>)-->
+        <!-- (<ptr target="https://www.w3.org/TR/html4/struct/tables.html#non-visual-rendering"/>)-->
         is also available. Special elements and attributes are provided to
         associate metadata with tables. They indicate the table's purpose, or
         are for the benefit of people using speech or Braille-based user agents.
         Tables are not recommended for use purely as a means to lay out document
-        content, as this leads to many accessibility problems (see further <ptr target="http://www.w3.org/TR/WCAG10-HTML-TECHS/#tables"/>).
+        content, as this leads to many accessibility problems (see further <ptr target="https://www.w3.org/TR/WCAG10-HTML-TECHS/#tables"/>).
         Stylesheets provide a far more effective means of controlling layout and
         other visual characteristics in both HTML and XML documents. </p>
     </div>
@@ -980,7 +979,7 @@ discussion at .</note-->
         <item>SVG is a language for describing two-dimensional vector and mixed
           vector or raster graphics in XML. It is defined by the Scalable Vector
           Graphics (SVG) 1.0 Specification, W3C Recommendation, 04 September
-          2001, and is available at <ptr target="http://www.w3.org/TR/2001/REC-SVG-20010904/"/>.</item>
+          2001, and is available at <ptr target="https://www.w3.org/TR/2001/REC-SVG-20010904/"/>.</item>
         <label>PICT: Macintosh drawing format</label>
         <item>This format is universally supported on Macintosh™ systems,
           and readable by a limited range of software for other systems.
@@ -1067,7 +1066,7 @@ discussion at .</note-->
           timing relationships, fine-tuned synchronization, spatial layout,
           direct inclusion of non-text and non-image media objects, hyperlink
           support for time-based media, and adaptiveness to varying user and
-          system characteristics. SMIL 1.0 (<ptr target="http://www.w3.org/TR/REC-smil/"/>) became a W3C
+          system characteristics. SMIL 1.0 (<ptr target="https://www.w3.org/TR/REC-smil/"/>) became a W3C
           Recommendation on June 15, 1998, and was further developed in SMIL
           2.0. SMIL 2.0 adds native support for transitions, animation,
           event-based interaction, extended layout facilities, and more
@@ -1077,11 +1076,11 @@ discussion at .</note-->
           and synchronization. For example, SMIL 2.0 components are used for
           integrating timing into XHTML Document Types and into SVG. SMIL 2.0
           also provides recommendations for Document Types based on SMIL 2.0
-          Modules (<ptr target="http://www.w3.org/TR/2005/REC-SMIL2-20050107/smil-modules.html"/>). One such Document Type is the SMIL 2.0 Language Profile (<ptr target="http://www.w3.org/TR/2005/REC-SMIL2-20050107/smil20-profile.html"/>). It contains support for all of the major SMIL 2.0 features
+          Modules (<ptr target="https://www.w3.org/TR/2005/REC-SMIL2-20050107/smil-modules.html"/>). One such Document Type is the SMIL 2.0 Language Profile (<ptr target="https://www.w3.org/TR/2005/REC-SMIL2-20050107/smil20-profile.html"/>). It contains support for all of the major SMIL 2.0 features
           including animation, content control, layout, linking, media object,
           meta-information, structure, timing, and transition effects and is
           designed for Web clients that support direct playback from SMIL 2.0
-          markup. SMIL 2.0 (<ptr target="http://www.w3.org/TR/2001/REC-smil20-20010807/"/>) became a
+          markup. SMIL 2.0 (<ptr target="https://www.w3.org/TR/2001/REC-smil20-20010807/"/>) became a
           W3C Recommendation on August 7, 2001, becoming the first vocabulary to
           provide XML Schema support and to have reached such status.</item>
       </list>

--- a/P5/Source/Guidelines/en/PH-PrimarySources.xml
+++ b/P5/Source/Guidelines/en/PH-PrimarySources.xml
@@ -228,7 +228,7 @@ used to define a polygon of any shape using this coordinate system:-->
             <att>points</att>, which provides a sequence of coordinates, each of which specifies a
          point on the perimeter of the zone.<note place="foot">The <att>points</att> attribute
             supplies a <soCalled>points specification</soCalled> in the same form as that required
-            by the <gi>polyline</gi> or <gi>polygon</gi> elements in the SVG standard. See <ptr target="http://www.w3.org/TR/SVG/shapes.html#PointsBNF"/>
+            by the <gi>polyline</gi> or <gi>polygon</gi> elements in the SVG standard. See <ptr target="https://www.w3.org/TR/SVG/shapes.html#PointsBNF"/>
          </note></p>
       <p>A zone may be used to define any region of interest, such as a detail or illustration, or
          some part of the surface which is to be aligned with a particular text element, or

--- a/P5/Source/Guidelines/en/SA-LinkingSegmentationAlignment.xml
+++ b/P5/Source/Guidelines/en/SA-LinkingSegmentationAlignment.xml
@@ -505,7 +505,7 @@ hierarchy and proceeding down to the context node.</p>
 <p>The following example demonstrates an absolute URI reference
 that points to a remote document: 
 <egXML xmlns="http://www.tei-c.org/ns/Examples">The current base URI in force is as defined in the
- W3C <ref target="http://www.w3.org/TR/xmlbase/">XML
+ W3C <ref target="https://www.w3.org/TR/xmlbase/">XML
  Base</ref> recommendation.</egXML></p>
 <p>This example points explicitly to a location on the Web,
 accessible via HTTP<!--, the web Protocol-->. Suppose however that we wish
@@ -746,7 +746,7 @@ kinds of object:
 <list type="gloss">
 <label>Node</label>
 <item>A node is an instance of one of the node kinds defined in
-the <ref target="http://www.w3.org/TR/xpath-datamodel/">XQuery 
+the <ref target="https://www.w3.org/TR/xpath-datamodel/">XQuery 
 1.0 and XPath 2.0 Data Model (Second Edition)</ref>. It represents 
 a single item in the XML information 	set for a document. For pointing
 purposes, the only nodes that are of interest are Text Nodes,
@@ -763,7 +763,7 @@ and behaves as though all tags had been removed. A text stream begins
 at a reference node and encompasses all of the text inside that node (if any)
 and all the text following it in document order. In XPath terms, this would
 encompass all of the text nodes beginning at a particular node, and following 
-it on the <ref target="http://www.w3.org/TR/xpath20/#axes">following axis</ref>.
+it on the <ref target="https://www.w3.org/TR/xpath20/#axes">following axis</ref>.
 </item>
 <label>Point</label>
 <item>A Point represents a dimensionless point between nodes or characters in 
@@ -813,7 +813,7 @@ towards revising this draft or issuing it as a recommendation. </p>
 
 <p><hi rend="bold">A note on namespaces</hi>: The W3C defines an 
 <name type="xpscheme">xmlns()</name> scheme (see 
-<ref target="http://www.w3.org/TR/xptr-xmlns/">XPointer xmlns() Scheme</ref>) 
+<ref target="https://www.w3.org/TR/xptr-xmlns/">XPointer xmlns() Scheme</ref>) 
 which when prepended to a resolvable pointer allows for the definition of 
 namespace prefixes to be used in XPaths in subsequent pointers. TEI Pointer 
 schemes assume that un-prefixed element names in TEI Pointer XPaths are in the 
@@ -927,7 +927,7 @@ LENGTH parameter found below in the <name type="xpscheme">string-range()</name>
 scheme) are measured in characters. What is considered a single character will
 depend (assuming the document being evaluated is in Unicode) on the 
 Normalization Form in use (see 
-<ref target="http://unicode.org/reports/tr15/">UNICODE NORMALIZATION 
+<ref target="https://unicode.org/reports/tr15/">UNICODE NORMALIZATION 
 FORMS</ref>). A letter followed by a combining diacritic counts as two 
 characters, but the same diacritic precombined with a letter would count 
 as a single character. Compare, for example, &#xE9; (<code>\u0060</code> 
@@ -1006,7 +1006,7 @@ the non-contiguous sequence <q>in mentem</q>.</p>
 <p>The match scheme locates a sequence based on matching the REGEX parameter
 against a text stream relative to the reference node identified by the first 
 parameter. REGEX is a regular expression as defined by 
-<ref target="http://www.w3.org/TR/xpath-functions/#regex-syntax">XQuery 
+<ref target="https://www.w3.org/TR/xpath-functions/#regex-syntax">XQuery 
 1.0 and XPath 2.0 Functions and Operators (Second Edition)</ref>, with some
 modifications: 
 <list>
@@ -1124,7 +1124,7 @@ specific steps to transform it into a URI reference:
 <p>The regular expression language used as the value of the
 <att>matchPattern</att> attribute is that used for the
 <term>pattern</term> facet of the World Wide Web Consortium's
-XML Schema Language in an <ref target="http://www.w3.org/TR/xmlschema-2/#regexs">Appendix to
+XML Schema Language in an <ref target="https://www.w3.org/TR/xmlschema-2/#regexs">Appendix to
 XML Schema Part 2</ref>.<note place="bottom">As always
 seems to be the case, no two regular expression languages are
 precisely the same. For those used to Perl regular expressions,
@@ -2976,17 +2976,17 @@ combination of exclusive and inclusive <gi>alt</gi> elements, as follows.
   <head>Overview of XInclude </head>
    <p>Stand-off markup which relies on the inclusion of virtual
    content is adequately supported by the W3C XInclude recommendation,
-   which is also recommended for use by these Guidelines.<note place="bottom">The version on which this text is based is the <ref target="http://www.w3.org/TR/2004/REC-xinclude-20041220/">W3C
+   which is also recommended for use by these Guidelines.<note place="bottom">The version on which this text is based is the <ref target="https://www.w3.org/TR/2004/REC-xinclude-20041220/">W3C
    Recommendation dated <date when="2004-12-20">20 December
    2004</date>.</ref>.</note> XInclude defines a namespace
    (<mentioned>http://www.w3.org/2001/XInclude</mentioned>), which in
    these Guidelines will be associated with the prefix
    <mentioned>xi:</mentioned>, and exactly two elements,
    <gi>xi:include</gi> and <gi>xi:fallback</gi>. XInclude relies on
-   the <ref target="http://www.w3.org/TR/xptr-framework/">XPointer
+   the <ref target="https://www.w3.org/TR/xptr-framework/">XPointer
    framework</ref> discussed elsewhere in this chapter to point to the
    actual fragments of text to be internalized. Although XInclude only
-   requires support for the <ref target="http://www.w3.org/TR/xptr-element/"><code>element()</code></ref>
+   requires support for the <ref target="https://www.w3.org/TR/xptr-element/"><code>element()</code></ref>
    scheme of XPointer, these Guidelines permit the use of any of the
    pointing schemes discussed in section <ptr target="#SAXP"/>.</p>
  

--- a/P5/Source/Guidelines/en/SG-GentleIntroduction.xml
+++ b/P5/Source/Guidelines/en/SG-GentleIntroduction.xml
@@ -172,13 +172,13 @@ whatever languages or writing systems they employ, use the same
 underlying character encoding (that is, the same method of
 representing as binary data those graphic forms making up a particular
 writing system).<note place="bottom">See <title>Extensible Markup
-Language (XML) 1.0</title>, available from <ptr target="http://www.w3.org/TR/REC-xml/"/>, Section 2.2
+Language (XML) 1.0</title>, available from <ptr target="https://www.w3.org/TR/REC-xml/"/>, Section 2.2
 Characters.</note> This encoding is defined by an international
 standard,<note place="bottom">ISO/IEC 10646-1993 <title>Information
 Technology — Universal Multiple-Octet Coded Character Set</title>
 (UCS)</note> which is implemented by a universal character set
 maintained by an industry group called the Unicode Consortium, and
-known as Unicode.<note place="bottom">See <ptr target="http://www.unicode.org/"/></note> Unicode 
+known as Unicode.<note place="bottom">See <ptr target="https://www.unicode.org/"/></note> Unicode 
 provides a standardized way of representing any of the many thousands of
 discrete symbols making up the world's writing systems, past and
 present. </p>
@@ -479,7 +479,7 @@ text being encoded.</p>
     ISO standard<note place="bottom"><ref target="https://www.iso.org/standard/52348.html">ISO/IEC FDIS 19757-2 Document
       Schema Definition Language (DSDL) — Part 2: Regular-grammar-based
       validation — RELAX NG</ref></note>, though other older methods include the Document Type Definition
-    (DTD) language which XML inherited from SGML and the XML Schema language (<ptr target="http://www.w3.org/XML/Schema"/>) defined by the W3C.<note place="bottom">Schema validation languages co-evolved with early markup language specifications, as summarized in <ref target="http://xml.coverpages.org/Jelliffe-schema-family-tree3-20061130.jpg">Rick Jelliffe's Family Tree of Schema Languages for Markup Languages</ref>.</note> In this chapter, and throughout these
+    (DTD) language which XML inherited from SGML and the XML Schema language (<ptr target="https://www.w3.org/XML/Schema"/>) defined by the W3C.<note place="bottom">Schema validation languages co-evolved with early markup language specifications, as summarized in <ref target="http://xml.coverpages.org/Jelliffe-schema-family-tree3-20061130.jpg">Rick Jelliffe's Family Tree of Schema Languages for Markup Languages</ref>.</note> In this chapter, and throughout these
     Guidelines, we give examples using the <soCalled>compact
       syntax</soCalled> of RELAX NG for ease of reading. The specifications for the TEI Guidelines are first expressed in the TEI language itself and a RELAX NG schema is generated from them for processing convenience. Details about schema customization using the TEI ODD language are addressed in <ptr target="#TD"/>, <ptr target="#MD"/> and <ptr target="#IM"/>.  
 </p>
@@ -1148,7 +1148,7 @@ in the same way.</p>
 representation of graphical components such as diagrams; it already
 exists in the shape of the Scalable Vector Graphics (SVG) language
 defined by the W3C.<note place="bottom">The W3C Recommendation is
-defined at <ptr target="http://www.w3.org/Graphics/SVG/"/>.</note> SVG
+defined at <ptr target="https://www.w3.org/Graphics/SVG/"/>.</note> SVG
 is a widely used and rich XML vocabulary for representing all kinds of
 two-dimensional graphics; it is also well supported by existing
 software. Using an SVG-aware drawing package, we can easily draw our
@@ -1352,7 +1352,7 @@ DTD processor will take note of this fact. </p></div>
 this question, leading to a variety of different methods of associating schemas with 
 document instances. However, a W3C Working Group Note, 
   <title level="m">Associating Schemas with XML documents</title>, 
-(<ptr target="http://www.w3.org/TR/xml-model/"/>) now provides a 
+(<ptr target="https://www.w3.org/TR/xml-model/"/>) now provides a 
 standardized method of doing this through the use of a processing instruction:
 
   <eg><![CDATA[<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng"?>]]></eg>
@@ -1399,7 +1399,7 @@ discuss it further here.</p>
 kind of pointer element to refer to the resources that need to be
 assembled, in exactly the same way as we proposed for the illustration
 in our anthology. The W3C Recommendation <title>XML Inclusions
-</title> (XInclude)<note place="bottom"><ptr target="http://www.w3.org/TR/xinclude/"/>.</note> defines a generic mechanism
+</title> (XInclude)<note place="bottom"><ptr target="https://www.w3.org/TR/xinclude/"/>.</note> defines a generic mechanism
 for this purpose, which is supported by an increasing number of XML
 processors.  </p></div>
 
@@ -1415,7 +1415,7 @@ invoked, and is thus entirely application-specific.</p>
 <p>However, since one very common application for XML documents is to
 serve them as browsable documents over the Web, the W3C has defined a
 procedure and a syntax for associating a document instance with its
-stylesheet (see <ptr target="http://www.w3.org/TR/xml-stylesheet/"/>). This Recommendation
+stylesheet (see <ptr target="https://www.w3.org/TR/xml-stylesheet/"/>). This Recommendation
 allows a document to supply a link to a default stylesheet and also to
 categorize the stylesheet according to its <term>MIME type</term>,
 for example to indicate whether the stylesheet is written in CSS or

--- a/P5/Source/Guidelines/en/ST-Infrastructure.xml
+++ b/P5/Source/Guidelines/en/ST-Infrastructure.xml
@@ -383,7 +383,7 @@ with others.--></p>
         <div xml:id="STGAid">
           <head>Element Identifiers and Labels</head>
           <p>The value supplied for the <att>xml:id</att> attribute must be a legal
-              <term>name</term>, as defined in the World Wide Web Consortium's <ref target="http://www.w3.org/TR/REC-xml/">XML Recommendation</ref>. This means that it
+              <term>name</term>, as defined in the World Wide Web Consortium's <ref target="https://www.w3.org/TR/REC-xml/">XML Recommendation</ref>. This means that it
             must begin with a letter, or the underscore character (<q>_</q>), and contain no
             characters other than letters, digits, hyphens, underscores, full stops, and certain
             combining and extension characters.<note place="bottom">The colon is also by default a
@@ -774,7 +774,7 @@ for they shall be called the children of God.</egXML>
             of consecutive tab (#x09), space (#x20), carriage return (#x0D) or linefeed (#x0A)
             characters. Like <att>xml:id</att> this attribute is defined as part of the XML
             specification and belongs to the XML namespace rather than the TEI namespace. Complete
-            information about this attribute is provided by <ref target="http://www.w3.org/TR/REC-xml/#sec-white-space">section 2.10 of the XML
+            information about this attribute is provided by <ref target="https://www.w3.org/TR/REC-xml/#sec-white-space">section 2.10 of the XML
               Specification</ref>; here we provide a summary of how its use affects users of the TEI
             scheme.</p>
           <p>The <att>xml:space</att> attribute has only two permitted values: <val>preserve</val>

--- a/P5/Source/Guidelines/en/TD-DocumentationElements.xml
+++ b/P5/Source/Guidelines/en/TD-DocumentationElements.xml
@@ -2132,7 +2132,7 @@ most recent version of the Guidelines would be used instead.--></p>
       <head>Linking Schemas to XML Documents</head>
       <p>Schemas can be linked to XML documents by means of the <tag type="pi">?xml-model?</tag> processing
         instruction described in the W3C Working Group Note <title level="m">Associating Schemas with XML
-          documents</title> (<ptr target="http://www.w3.org/TR/xml-model/"/>). <tag type="pi"
+          documents</title> (<ptr target="https://www.w3.org/TR/xml-model/"/>). <tag type="pi"
           >?xml-model?</tag> can be used for any type of schema, and may be used for multiple schemas: <eg xml:space="preserve"><![CDATA[<?xml-model href="tei_tite.rng" type="application/xml" ?>
 <?xml-model href="checkLinks.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
 <?xml-model href="tei_tite.odd" type="application/tei+xml" schematypens="http://www.tei-c.org/ns/1.0" ?>]]></eg>

--- a/P5/Source/Guidelines/en/USE.xml
+++ b/P5/Source/Guidelines/en/USE.xml
@@ -866,7 +866,7 @@ that practice. -->
       <p>These Guidelines mandate the use of well-formed XML as representation format. Documents
         must conform to the World Wide Web Consortium recommendation of the <title>Extensible Markup
           Language (XML) 1.0 (Fourth Edition)</title> or successor editions found at <ptr
-          target="http://www.w3.org/TR/xml/"/>. Other ways of
+          target="https://www.w3.org/TR/xml/"/>. Other ways of
         representing the concepts of the TEI Abstract Model are possible, and other representations
         may be considered appropriate for use in particular situations (for example, for data
         capture, or project-internal processing). But such alternative representations

--- a/P5/Source/Guidelines/en/WD-NonStandardCharacters.xml
+++ b/P5/Source/Guidelines/en/WD-NonStandardCharacters.xml
@@ -51,7 +51,7 @@ In order to determine whether a character has been encoded,
 encoders should follow the following steps:
 <list rend="numbered">
   <item><p>Check the Unicode
-  web site at <ptr target="http://www.unicode.org"/>, in particular the page <ref target="http://unicode.org/standard/where/">"Where is my
+  web site at <ptr target="https://www.unicode.org"/>, in particular the page <ref target="http://unicode.org/standard/where/">"Where is my
   Character?"</ref>, and the associated character code charts.
   Alternatively, users can check the latest published version of
   <title>The Unicode Standard</title> (<ref target="#CH-BIBL-3">Unicode Consortium (2006)</ref>), though the web site is
@@ -67,7 +67,7 @@ then you should document it. </p></item>
   <item>Check the Proposed New Characters web page (<ptr target="http://unicode.org/alloc/Pipeline.html"/>) to see whether
   the character is in line for approval.</item>
 
-<item>Ask on the Unicode email list (<ptr target="http://www.unicode.org/consortium/distlist.html"/>) to
+<item>Ask on the Unicode email list (<ptr target="https://www.unicode.org/consortium/distlist.html"/>) to
 see whether  a proposal is pending, or to determine whether this
 character is considered eligible for addition
 to the Unicode Standard.  </item>
@@ -181,7 +181,7 @@ for use by such applications in a standard way.</p>
 <p> The list of attributes (properties) for characters is modelled on
 those in the Unicode Character Database, which distinguishes
 <term>normative</term> and <term>informative</term> character
-properties. The Unicode Consortium also maintains a separate set of character properties specific to East Asian characters in the <ref target="http://www.unicode.org/charts/unihan.html">Unihan database</ref> which TEI fully supports. Lastly, non-Unicode properties may also be supplied.
+properties. The Unicode Consortium also maintains a separate set of character properties specific to East Asian characters in the <ref target="https://www.unicode.org/charts/unihan.html">Unihan database</ref> which TEI fully supports. Lastly, non-Unicode properties may also be supplied.
 Since the list of properties will vary with different versions of the
 Unicode Standard, there may not be an exact correspondence between
 them and the list of properties defined in these Guidelines.</p>
@@ -419,7 +419,7 @@ defined for this property:
 	  example the strokes making up CJK (Chinese, Japanese, and Korean) characters.  It
 	  records a class for these characters, which is used to
 	  determine how they interact typographically. The following
-	  values are defined in  the Unicode Standard: (see <ref target="http://www.unicode.org/reports/tr44/#Canonical_Combining_Class_Values">Unicode
+	  values are defined in  the Unicode Standard: (see <ref target="https://www.unicode.org/reports/tr44/#Canonical_Combining_Class_Values">Unicode
 Character Database: Canonical Combining Class Values</ref>); these were taken from version 12.1:
 <table>
 <row><cell><code>0</code></cell><cell>Spacing, split, enclosing, reordrant, and Tibetan subjoined </cell></row>
@@ -863,11 +863,11 @@ rules enabling software to render sequences of characters which have
 differing directionality properties in a predictable and reliable way,
 using only those properties. <note place="foot"> Because this
 algorithm may not always give the desired result, Unicode also
-provides a set of "directional formatting characters" (<ptr target="http://www.unicode.org/reports/tr9/#Directional_Formatting_Characters"/>). These
+provides a set of "directional formatting characters" (<ptr target="https://www.unicode.org/reports/tr9/#Directional_Formatting_Characters"/>). These
 additional codepoints can be used to signal to rendering software that
 a specific directionality setting should be turned on or off. However,
 in the case of documents encoded in XML, there is generally no need to use such
-characters, and the W3C advises against it unless markup is unavailable. (<ptr target="http://www.w3.org/International/questions/qa-bidi-controls"/>)</note>. It
+characters, and the W3C advises against it unless markup is unavailable. (<ptr target="https://www.w3.org/International/questions/qa-bidi-controls"/>)</note>. It
 should be remembered however that individual sequences of characters
 are always stored in a file in the order in which they should be read,
 irrespective of the order in which the characters making up a sequence
@@ -1014,7 +1014,7 @@ of a document will probably include many other properties of course. </p>
    i.e. 90° clockwise from their standard orientation in horizontal
    text. Characters from vertical scripts are set with their intrinsic
    orientation</quote> (<ref
-   target="http://www.w3.org/TR/css-writing-modes-3/#text-orientation">fantasai
+   target="https://www.w3.org/TR/css-writing-modes-3/#text-orientation">fantasai
    2014</ref>). Since the default value for
    <code>text-orientation</code> is <code>mixed</code>, this rule is
    not strictly required. However, if the Indonesian glyphs (which are
@@ -1040,7 +1040,7 @@ of a document will probably include many other properties of course. </p>
    upright, i.e. in their standard horizontal orientation. Characters
    from vertical scripts are set with their intrinsic orientation and
    shaped normally</quote> (<ref
-   target="http://www.w3.org/TR/css-writing-modes-3/#text-orientation">fantasai
+   target="https://www.w3.org/TR/css-writing-modes-3/#text-orientation">fantasai
    2014</ref>).</p>
    </div>
    <div type="div3" xml:id="WDWMEG3">
@@ -1129,7 +1129,7 @@ to arise in such situations, which may give rise to the
 parts of a document being displayed in unexpected ways that do
 not correspond to the natural reading order. A more detailed
    discussion of this issue from an HTML perspective is provided by a
-   W3C Internationalization Working Group report <ref target="http://www.w3.org/International/articles/inline-bidi-markup/#where">Inline
+   W3C Internationalization Working Group report <ref target="https://www.w3.org/International/articles/inline-bidi-markup/#where">Inline
    markup and bidirectional text in HTML</ref>. </p>
 
 
@@ -1280,7 +1280,7 @@ precinct at Dodona. (L.H. Jeffery Archive)</head>
 
    <p>As with other parts of the CSS specification, the intended
    effect of CSS Transforms properties and values is defined with
-   reference to a specific <ref target="http://www.w3.org/TR/CSS2/visuren.html">Visual formatting
+   reference to a specific <ref target="https://www.w3.org/TR/CSS2/visuren.html">Visual formatting
    model</ref>; the language is designed to describe how an HTML
    document should be formatted. This is not, of course, the case for
    the TEI, which lacks any explicit processing or formatting model,

--- a/P5/Source/Guidelines/fr/HD-Header.xml
+++ b/P5/Source/Guidelines/fr/HD-Header.xml
@@ -1383,8 +1383,8 @@ Restitution <gi>rendition</gi>. Des versions antérieures de ces Principes direc
 suggéraient que des spécifications dérivées de, ou compatibles avec les propriétés
 normalisées et intégrées dans l’ISO/IEC 10179 Document style and semantic
 specifications language pourraient être utiles. D’autres possibilités sont le langage CSS
-(Cascading stylesheet language <ptr target="http://www.w3.org/TR/REC-CSS1"/>), ou la
-partie du langage XSL du W3C (Extensible stylesheet language <ptr target=" http://www.w3.org/TR/xsl"/>).</p>
+(Cascading stylesheet language <ptr target="https://www.w3.org/TR/REC-CSS1"/>), ou la
+partie du langage XSL du W3C (Extensible stylesheet language <ptr target="https://www.w3.org/TR/xsl"/>).</p>
 <p>Il est inutile que l’élément <gi>rendition</gi> soit précisé par un élément Déclaration
 de balisage <gi>tagsDecl</gi>. Toutefois, il doit contenir au moins une occurrence de
 l’élément Espace de nom <gi>namespace</gi>, qui doit contenir une et une seule occurrence de la balise <gi>tagUsage</gi> pour chaque élément distinct marqué à
@@ -1684,7 +1684,7 @@ par cet en-tête,  comme définies dans le chapitre 16 Structures de profils <pt
 Noter qu’il faut spécifier un élément <gi>fsdDecl</gi>  pour chaque type distinct de
 structure de profils utilisé dans le balisage. L’élément URL <att>url</att> fournit un lien
 vers l’entité contenant une déclaration de système de profils dans laquelle cette
-structure est définie (voir le chapitre 26 Déclaration de système de profils  <ptr target=" #FD"/>).
+structure est définie (voir le chapitre 26 Déclaration de système de profils  <ptr target="#FD"/>).
 ). o
 La déclaration de système de profils est généralement  définie dans une entité externe,
 de la même manière qu’un fichier indépendant contenant un graphique est référencé par
@@ -1701,7 +1701,7 @@ et <val>myA2</val>. Leurs descriptions sont consultables à  l’url mentionnée
 Les définitions du système de profils dans lequel les structures de profils sont précisées
 se trouvent à l'URL citée plus haut.</p>
 <p>On peut trouver des exemples détaillés d’utilisation de déclarations de systèmes de
-profils et de structures de profils dans les chapitres 16 Structure de profils <ptr target=" #FS"/> et 26 Déclaration de système de profils <ptr target="#FD"/>.
+profils et de structures de profils dans les chapitres 16 Structure de profils <ptr target="#FS"/> et 26 Déclaration de système de profils <ptr target="#FD"/>.
 </p>
 <p>L’élément  <gi>fsdDecl</gi> est déclaré comme suit :
 <specGrp xml:id="D2256" n="The FSD declaration">
@@ -1801,7 +1801,7 @@ de la poésie versifiée, voir la section 8.4 Rime et analyse métrique <ptr tar
 <p>L’élément Méthode d’encodage des variantes <gi>variantEncoding</gi> est la
 dernière des neuf subdivisions facultatives de l’élément Description de l’encodage <gi>
 encodingDesc</gi>. Il est utilisé pour documenter la méthode d’encodage des variantes
-textuelles dans le texte (Voir section 19.2 Lier l’apparat critique au texte <ptr target=" #TCAPLK"/>.
+textuelles dans le texte (Voir section 19.2 Lier l’apparat critique au texte <ptr target="#TCAPLK"/>.
 <specList>
 <specDesc key="variantEncoding" atts="method location"/>
 </specList>
@@ -2078,7 +2078,7 @@ employés. Ceci se fait en indiquant la valeur utilisée pour l’attribut <att>
 identifiant un élément Taxinomie <gi>taxonomy</gi> où l’on pourra trouver des détails
 sur la source concernée. L’élément <gi>taxonomy</gi> apparaît dans la partie
 Déclaration de classification <gi>classDecl</gi> des déclarations d’encodage dans
-l’en-tête TEI, et est décrit dans la section 5.3.6 Déclaration de classification <ptr target=" #HD55"/>.Par exemple :
+l’en-tête TEI, et est décrit dans la section 5.3.6 Déclaration de classification <ptr target="#HD55"/>.Par exemple :
 <egXML xmlns="http://www.tei-c.org/ns/Examples"><keywords scheme="#lcsh">
    <list>
       <item>Gestion de bases de données</item>

--- a/P5/Source/Specs/att.global.xml
+++ b/P5/Source/Specs/att.global.xml
@@ -141,7 +141,7 @@ $Id$
         <p>The authoritative list of registered language subtags is maintained by IANA and 
           is available at <ptr target="http://www.iana.org/assignments/language-subtag-registry"/>. 
           For a good general overview of the construction of language tags, see 
-          <ptr target="http://www.w3.org/International/articles/language-tags/"/>, and for 
+          <ptr target="https://www.w3.org/International/articles/language-tags/"/>, and for 
           a practical step-by-step guide, see 
           <ptr target="https://www.w3.org/International/questions/qa-choosing-language-tags.en.php"/>.</p>
         <p>The value used must conform with BCP 47. If the value is a
@@ -167,7 +167,7 @@ $Id$
         <p>Si no se especifica ningún valor para <att>xml:lang</att>, el valor de <att>xml:lang</att> para el elemento inmediatamente englobado, se hereda; por esta razón, un valor
           se debe especificar siempre en el elemento exterior (<gi>TEI</gi>).</p>
       </remarks>
-      <remarks xml:lang="ja" versionDate="2019-06-16"><p>xml:lang の値は、直接の親要素、そのまた親要素からというように、文書の上位階層から継承されてくる。できるだけ高い適切な階層に xml:lang を指定するのが一般には望ましいが、teiHeader には関連するリソース要素と異なるデフォルト値が必要となったり、一つのTEI文書が多くの言語のテキストを含みうることには注意されたい。登録された言語タグの正式なリストはIANAが管理しており、<ptr target="http://www.iana.org/assignments/language-subtag-registry"></ptr> から確認できる。言語タグの構造についての良い概説は <ptr target="http://www.w3.org/International/articles/language-tags/"></ptr> を、手順を追った実用的なガイドは <ptr target="https://www.w3.org/International/questions/qa-choosing-language-tags.en.php"></ptr> を参照されたい。利用する値は、BCP 47 に準拠しなければならない。もし値が私用コード（<val>x-</val> から始まったり <val>-x-</val> を含む）ならば、その <att>ident</att> 属性と一致する値を持つ <gi>language</gi> 要素をTEIヘッダ内に追加して内容を説明すべきである。この説明は私用コード以外にも任意で追加できるが、<choice><abbr>IETF</abbr><expan>Internet Engineering Task Force</expan></choice> による定義と整合していなければならない。</p></remarks>
+      <remarks xml:lang="ja" versionDate="2019-06-16"><p>xml:lang の値は、直接の親要素、そのまた親要素からというように、文書の上位階層から継承されてくる。できるだけ高い適切な階層に xml:lang を指定するのが一般には望ましいが、teiHeader には関連するリソース要素と異なるデフォルト値が必要となったり、一つのTEI文書が多くの言語のテキストを含みうることには注意されたい。登録された言語タグの正式なリストはIANAが管理しており、<ptr target="http://www.iana.org/assignments/language-subtag-registry"></ptr> から確認できる。言語タグの構造についての良い概説は <ptr target="https://www.w3.org/International/articles/language-tags/"></ptr> を、手順を追った実用的なガイドは <ptr target="https://www.w3.org/International/questions/qa-choosing-language-tags.en.php"></ptr> を参照されたい。利用する値は、BCP 47 に準拠しなければならない。もし値が私用コード（<val>x-</val> から始まったり <val>-x-</val> を含む）ならば、その <att>ident</att> 属性と一致する値を持つ <gi>language</gi> 要素をTEIヘッダ内に追加して内容を説明すべきである。この説明は私用コード以外にも任意で追加できるが、<choice><abbr>IETF</abbr><expan>Internet Engineering Task Force</expan></choice> による定義と整合していなければならない。</p></remarks>
     </attDef>
     
     
@@ -283,11 +283,11 @@ $Id$
         </valItem>
       </valList>
       <remarks versionDate="2012-09-07" xml:lang="en">
-        <p>The <ref target="http://www.w3.org/TR/REC-xml/#sec-white-space">XML
+        <p>The <ref target="https://www.w3.org/TR/REC-xml/#sec-white-space">XML
       specification</ref> provides further guidance on the use of this
       attribute. Note that many parsers may not handle xml:space correctly.</p>
       </remarks>
-      <remarks xml:lang="ja" versionDate="2019-06-08"><p>この属性の利用に関する案内は<ref target="http://www.w3.org/TR/REC-xml/#sec-white-space">XML仕様</ref>を参照。xml:spaceを適切に扱うパーサーは多くない。</p></remarks>
+      <remarks xml:lang="ja" versionDate="2019-06-08"><p>この属性の利用に関する案内は<ref target="https://www.w3.org/TR/REC-xml/#sec-white-space">XML仕様</ref>を参照。xml:spaceを適切に扱うパーサーは多くない。</p></remarks>
     </attDef>
   </attList>
   <listRef>

--- a/P5/Source/Specs/att.patternReplacement.xml
+++ b/P5/Source/Specs/att.patternReplacement.xml
@@ -26,7 +26,7 @@ $Id$
         corrispondere i valori degli attributi <att>cRef</att>.</desc>-->
       <datatype><dataRef key="teidata.pattern"/></datatype>
       <remarks versionDate="2013-12-08" xml:lang="en">
-        <p>The syntax used should follow that defined by <ref target="http://www.w3.org/TR/xpath-functions/#regex-syntax">W3C XPath syntax</ref>. Note that parenthesized groups are used not only for establishing order of precedence and atoms for
+        <p>The syntax used should follow that defined by <ref target="https://www.w3.org/TR/xpath-functions/#regex-syntax">W3C XPath syntax</ref>. Note that parenthesized groups are used not only for establishing order of precedence and atoms for
           quantification, but also for creating subpatterns to be referenced by the
           <att>replacementPattern</att> attribute.</p>
       </remarks>

--- a/P5/Source/Specs/cRefPattern.xml
+++ b/P5/Source/Specs/cRefPattern.xml
@@ -47,22 +47,22 @@ $Id$
     <p>The result of the substitution may be either an absolute or a relative URI reference. In the
       latter case it is combined with the value of <att>xml:base</att> in force at the place where
       the <att>cRef</att> attribute occurs to form an absolute URI in the usual manner as prescribed
-      by <ref target="http://www.w3.org/TR/xmlbase/">XML Base</ref>.</p>
+      by <ref target="https://www.w3.org/TR/xmlbase/">XML Base</ref>.</p>
   </remarks>
   <remarks xml:lang="fr" versionDate="2007-06-12">
     <p>Le résultat de la substitution peut être la référence à une URI relative ou absolue.
       Dans ce dernier cas, il est combiné avec la valeur de l'attribut <att>xml:base</att> en
       vigueur à la place où apparaît l'attribut <att>cRef</att> pour former une URI absolue selon
-      l'usage habituel indiqué par <ref target="http://www.w3.org/TR/xmlbase/">XML Base</ref>.</p>
+      l'usage habituel indiqué par <ref target="https://www.w3.org/TR/xmlbase/">XML Base</ref>.</p>
   </remarks>
   <remarks xml:lang="es" versionDate="2008-04-06">
     <p>El resultado de la substitución puede ser una referencia URI absoluta o relativa. En el
       último caso se combina con el valor de <att>xml:base</att> en vigor en el lugar donde el
       atributo <att>cRef</att> aparece para formar un URI absoluto de manera común según lo
-      prescrito por <ref target="http://www.w3.org/TR/xmlbase/">Base de XML</ref>.</p>
+      prescrito por <ref target="https://www.w3.org/TR/xmlbase/">Base de XML</ref>.</p>
   </remarks>
   <remarks xml:lang="ja" versionDate="2008-04-05">
-    <p> 置換による結果は，絶対・相対URIであるかもしれない．相対URIの場合， <ref target="http://www.w3.org/TR/xmlbase/">XML
+    <p> 置換による結果は，絶対・相対URIであるかもしれない．相対URIの場合， <ref target="https://www.w3.org/TR/xmlbase/">XML
       Base</ref>に示され ているように，属性<att>xml:base</att>の値と共に，属性 <att>cRef</att>が絶対URIを示す場所で使用される． </p>
   </remarks>
   <listRef>

--- a/P5/Source/Specs/equiv.xml
+++ b/P5/Source/Specs/equiv.xml
@@ -32,7 +32,7 @@ $Id$
   <attList>
     <attDef ident="name" usage="opt">
       <desc versionDate="2012-10-10" xml:lang="en">a single word which follows the rules defining a
-        legal XML name (see <ptr target="http://www.w3.org/TR/REC-xml/#dt-name"/>), naming the underlying concept of which the parent is a representation.</desc>
+        legal XML name (see <ptr target="https://www.w3.org/TR/REC-xml/#dt-name"/>), naming the underlying concept of which the parent is a representation.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">부모가 표상하는 기저 개념에 대한 이름을 부여한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">說明父元素所標記的基本概念。</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">親要素の意義を表す．</desc>

--- a/P5/Source/Specs/f.xml
+++ b/P5/Source/Specs/f.xml
@@ -37,7 +37,7 @@ $Id$
   <attList>
     <attDef ident="name" usage="req">
       <desc versionDate="2012-10-10" xml:lang="en">a single word which follows the rules defining a
-        legal XML name (see <ptr target="http://www.w3.org/TR/REC-xml/#dt-name"/>), providing a name for the feature.</desc>
+        legal XML name (see <ptr target="https://www.w3.org/TR/REC-xml/#dt-name"/>), providing a name for the feature.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">자질에 대한 이름을 제공한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">功能名稱</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">当該素性の名前を示す．</desc>

--- a/P5/Source/Specs/fDecl.xml
+++ b/P5/Source/Specs/fDecl.xml
@@ -40,7 +40,7 @@ range of allowed values, and optionally its default value.</desc>
   <attList>
     <attDef ident="name" usage="req">
       <desc versionDate="2012-10-10" xml:lang="en">a single word which follows the rules defining a
-        legal XML name (see <ptr target="http://www.w3.org/TR/REC-xml/#dt-name"/>), indicating the name of the feature being declared; matches the
+        legal XML name (see <ptr target="https://www.w3.org/TR/REC-xml/#dt-name"/>), indicating the name of the feature being declared; matches the
 <att>name</att> attribute of <gi>f</gi> elements in the text.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">선언되고 있는 자질 이름을 제시한다; 텍스트 내 <gi>f</gi> 요소의 <att>name</att> 속성과 일치한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">指出所宣告的功能名稱；並符合文件中元素<gi>f</gi>的屬性<att>name</att>。</desc>

--- a/P5/Source/Specs/index.xml
+++ b/P5/Source/Specs/index.xml
@@ -36,7 +36,7 @@
   <attList>
     <attDef ident="indexName" usage="opt">
       <desc versionDate="2012-10-10" xml:lang="en">a single word which follows the rules defining a
-        legal XML name (see <ptr target="http://www.w3.org/TR/REC-xml/#dt-name"/>), supplying a name to specify which index (of several) the index entry belongs to.</desc>
+        legal XML name (see <ptr target="https://www.w3.org/TR/REC-xml/#dt-name"/>), supplying a name to specify which index (of several) the index entry belongs to.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">색인 표제 항목의 색인을 명시하기 위한 이름을 제시한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">提供該索引項目所屬索引名稱。</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">索引項目となったものを特定する名前を示す．</desc>

--- a/P5/Source/Specs/metDecl.xml
+++ b/P5/Source/Specs/metDecl.xml
@@ -183,10 +183,10 @@ $Id$
       <datatype><dataRef key="teidata.pattern"/></datatype>
       <remarks xml:lang="en" versionDate="2013-12-21"><p>The value must be a valid regular expression per the World Wide Web Consortium's
       <title ref="#XSD2">XML Schema Part 2: Datatypes Second Edition</title>,
-      <ref target="http://www.w3.org/TR/xmlschema-2/#regexs">Appendix F</ref>
+      <ref target="https://www.w3.org/TR/xmlschema-2/#regexs">Appendix F</ref>
 </p></remarks>
 <remarks xml:lang="fr" versionDate="2013-12-21"><p>La valeur doit être une expression régulière valide pour le Consortium
-        du World Wide Web <title ref="#XSD2">XML Schema Part 2: Datatypes Second Edition</title>, <ref target="http://www.w3.org/TR/xmlschema-2/#regexs">Appendix F</ref></p></remarks>
+        du World Wide Web <title ref="#XSD2">XML Schema Part 2: Datatypes Second Edition</title>, <ref target="https://www.w3.org/TR/xmlschema-2/#regexs">Appendix F</ref></p></remarks>
          
     </attDef>
   </attList>

--- a/P5/Source/Specs/prefixDef.xml
+++ b/P5/Source/Specs/prefixDef.xml
@@ -46,7 +46,7 @@ $Id$
     an absolute or a relative URI reference. In the latter case it is
     combined with the value of <att>xml:base</att> in force at the
     place where the pointing attribute occurs to form an absolute URI
-    in the usual manner as prescribed by <ref target="http://www.w3.org/TR/xmlbase/">XML Base</ref>.</p>
+    in the usual manner as prescribed by <ref target="https://www.w3.org/TR/xmlbase/">XML Base</ref>.</p>
   </remarks>
   <listRef>
     <ptr target="#SAPU"/>

--- a/P5/Source/Specs/teidata.duration.w3c.xml
+++ b/P5/Source/Specs/teidata.duration.w3c.xml
@@ -71,7 +71,7 @@ See the file COPYING.txt for details
     number-letter pairs are present, then the separator <code>T</code>
     must precede the first <soCalled>time</soCalled> number-letter
     pair.</p>
-      <p>For complete details, see the <ref target="http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#duration">W3C
+      <p>For complete details, see the <ref target="https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#duration">W3C
     specification</ref>.</p>
   </remarks>
   <remarks xml:lang="ja"
@@ -88,7 +88,7 @@ See the file COPYING.txt for details
     </p>
       <p>
     詳細については，
-    <ref target="http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#duration">
+    <ref target="https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#duration">
     W3C specification</ref>を参照のこと．
     </p>
   </remarks>
@@ -102,7 +102,7 @@ See the file COPYING.txt for details
       (minute), ou S (seconde) sont présentes, alors le séparateur
       <code>T</code> doit précéder la première paire alphanumérique
       <soCalled>time</soCalled>.</p>
-      <p>Pour des détails complets, voir <ref target="http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#duration">W3C
+      <p>Pour des détails complets, voir <ref target="https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#duration">W3C
       specification</ref>.</p>
   </remarks>
 </dataSpec>

--- a/P5/Source/Specs/teidata.enumerated.xml
+++ b/P5/Source/Specs/teidata.enumerated.xml
@@ -40,14 +40,14 @@ See the file COPYING.txt for details
   </remarks>
   <remarks xml:lang="ja"
             versionDate="2008-04-05">
-      <p> 当該データ型は，妥当なXML名前 (詳細は<ptr target="http://www.w3.org/TR/REC-xml/#dt-name"/>
+      <p> 当該データ型は，妥当なXML名前 (詳細は<ptr target="https://www.w3.org/TR/REC-xml/#dt-name"/>
       を参照のこと)である単語でなくてはならない．例えば， 属性値として空白文字，または数値で始まる名前をとることはできない． </p>
       <p> 典型例は，可能な記述またはその例のリストが，要素<gi>valList</gi> 中に属性定義として示されている． </p>
   </remarks>
   <remarks versionDate="2009-05-25"
             xml:lang="fr">
       <p>Les attributs utilisant ce type de données doivent contenir un mot qui suit les règles de
-      définition d'un nom XML valide (voir <ptr target="http://www.w3.org/TR/REC-xml/#dt-name"/>):
+      définition d'un nom XML valide (voir <ptr target="https://www.w3.org/TR/REC-xml/#dt-name"/>):
       par exemple ils ne peuvent pas contenir des blancs ni commencer par des chiffres. </p>
       <p>Normalement, la liste des possibilités documentées est fournie (ou exemplifiée) par une liste
       de valeurs dans la spécification de l'attribut associé, exprimée par un élément

--- a/P5/Source/Specs/teidata.language.xml
+++ b/P5/Source/Specs/teidata.language.xml
@@ -109,7 +109,7 @@ See the file COPYING.txt for details
             <item>Spanish as spoken in Latin America</item>
          </list>
       </p>
-      <p>The W3C Internationalization Activity has published a useful introduction to BCP 47, <ref target="http://www.w3.org/International/articles/language-tags/Overview.en.php">Language
+      <p>The W3C Internationalization Activity has published a useful introduction to BCP 47, <ref target="https://www.w3.org/International/articles/language-tags/Overview.en.php">Language
         tags in HTML and XML</ref>.</p>
   </remarks>
   <remarks xml:lang="ja" versionDate="2008-04-05">
@@ -180,7 +180,7 @@ See the file COPYING.txt for details
             <item>スペイン語，ラテンアメリカ</item>
          </list>
       </p>
-      <p> W3Cの国際化活動では，BCP 47の解説を以下に用意している． <ref target="http://www.w3.org/International/articles/language-tags/Overview.en.php">
+      <p> W3Cの国際化活動では，BCP 47の解説を以下に用意している． <ref target="https://www.w3.org/International/articles/language-tags/Overview.en.php">
         HTMLとXMLで使用される言語タグ</ref>. </p>
   </remarks>
   <remarks versionDate="2009-10-06" xml:lang="fr">
@@ -270,7 +270,7 @@ See the file COPYING.txt for details
             <item>Espagnol parlé en Amérique latine</item>
          </list>
       </p>
-      <p>La W3C Internationalization Activity a publié une introduction à la norme BCP 47 dont la lecture peut être utile : <ref target="http://www.w3.org/International/articles/language-tags/Overview.en.php">Language
+      <p>La W3C Internationalization Activity a publié une introduction à la norme BCP 47 dont la lecture peut être utile : <ref target="https://www.w3.org/International/articles/language-tags/Overview.en.php">Language
         tags in HTML and XML</ref>.</p>
       <!-- shuld be in bibliog -->
   </remarks>

--- a/P5/Source/Specs/teidata.name.xml
+++ b/P5/Source/Specs/teidata.name.xml
@@ -30,18 +30,18 @@ See the file COPYING.txt for details
   <remarks versionDate="2007-10-18"
             xml:lang="en">
       <p>Attributes using this datatype must contain a single word which follows the rules defining a
-      legal XML name (see <ptr target="http://www.w3.org/TR/REC-xml/#dt-name"/>): for example they
+      legal XML name (see <ptr target="https://www.w3.org/TR/REC-xml/#dt-name"/>): for example they
       cannot include whitespace or begin with digits. </p>
   </remarks>
   <remarks xml:lang="ja"
             versionDate="2008-04-05">
-      <p> 当該属性は，妥当なXML名前(詳細は <ptr target="http://www.w3.org/TR/REC-xml/#dt-name"/>を参照)である
+      <p> 当該属性は，妥当なXML名前(詳細は <ptr target="https://www.w3.org/TR/REC-xml/#dt-name"/>を参照)である
       ひとつの単語をとる．例えば，空白文字を含まず，数字が先頭文字にこな いもの． </p>
   </remarks>
   <remarks versionDate="2009-05-25"
             xml:lang="fr">
       <p>Les attributs utilisant ce type de données doivent contenir un seul mot, qui suit les règles
-      de définition d'un nom XML valide (voir <ptr target="http://www.w3.org/TR/REC-xml/#dt-name"/>) :
+      de définition d'un nom XML valide (voir <ptr target="https://www.w3.org/TR/REC-xml/#dt-name"/>) :
       par exemple ils ne peuvent contenir de blancs ou commencer par des chiffres. </p>
   </remarks>
 </dataSpec>

--- a/P5/Source/Specs/teidata.namespace.xml
+++ b/P5/Source/Specs/teidata.namespace.xml
@@ -9,16 +9,16 @@ See the file COPYING.txt for details
           ident="teidata.namespace">
   <desc versionDate="2007-10-14"
          xml:lang="en">defines the range of attribute values used to indicate XML namespaces as defined by the W3C
-    <ref target="http://www.w3.org/TR/1999/REC-xml-names-19990114/">Namespaces in XML</ref>
+    <ref target="https://www.w3.org/TR/1999/REC-xml-names-19990114/">Namespaces in XML</ref>
     Technical Recommendation.</desc>
   <desc versionDate="2007-12-20"
-         xml:lang="ko">W3C <ref target="http://www.w3.org/TR/1999/REC-xml-names-19990114/">Namespaces in XML</ref> 기술적 권고안에 의해
+         xml:lang="ko">W3C <ref target="https://www.w3.org/TR/1999/REC-xml-names-19990114/">Namespaces in XML</ref> 기술적 권고안에 의해
     정의된 XML 이름공간을 나타내는 속성 값 범위를 정의한다.</desc>
   <desc versionDate="2007-05-02"
          xml:lang="zh-TW">定義的屬性值範圍指出XML名稱空間，由XML technical
     recommendation中的W3C名稱空間所定義。</desc>
   <desc versionDate="2008-04-05"
-         xml:lang="ja">W3Cの<ref target="http://www.w3.org/TR/1999/REC-xml-names-19990114/">
+         xml:lang="ja">W3Cの<ref target="https://www.w3.org/TR/1999/REC-xml-names-19990114/">
     XML名前空間</ref>で定義されている名前空間を示す属性値の範囲を示す．</desc>
   <desc versionDate="2007-06-12"
          xml:lang="fr">définit la gamme des
@@ -28,12 +28,12 @@ See the file COPYING.txt for details
   <desc versionDate="2007-05-04"
          xml:lang="es">define la gama de valores de atributos usados para
     indicar los nombres de los espacios en XML como establecen las recomendaciones técnicas del W3C
-    para los <ptr target="http://www.w3.org/TR/1999/REC-xml-names-19990114/"/>
+    para los <ptr target="https://www.w3.org/TR/1999/REC-xml-names-19990114/"/>
    </desc>
   <desc versionDate="2007-01-21"
          xml:lang="it">definisce la gamma di valori di attributi usati per
     indicare i nomi degli spazi in XML come stabilito dalle raccomandazioni tecniche del W3C per gli
-    <ref target="http://www.w3.org/TR/1999/REC-xml-names-19990114/">spazi dei nomi in XML</ref>.</desc>
+    <ref target="https://www.w3.org/TR/1999/REC-xml-names-19990114/">spazi dei nomi in XML</ref>.</desc>
   <content>
       <dataRef name="anyURI"/>
    </content>

--- a/P5/Source/Specs/teidata.outputMeasurement.xml
+++ b/P5/Source/Specs/teidata.outputMeasurement.xml
@@ -56,12 +56,12 @@ See the file COPYING.txt for details
             xml:lang="en">
       <p> These values map directly onto the values used by XSL-FO and CSS. For definitions of the
       units see those specifications; at the time of this writing the most complete list is in the
-        <ref target="http://www.w3.org/TR/2005/WD-css3-values-20050726/#numbers0">CSS3 working
+        <ref target="https://www.w3.org/TR/2005/WD-css3-values-20050726/#numbers0">CSS3 working
       draft</ref>.</p>
   </remarks>
   <remarks xml:lang="ja"
             versionDate="2008-04-05">
-      <p> 当該値は，XSLFOやCSSで使用される値になる．詳細は各規格を参照のこと． 現時点で一番詳細なリストは， <ref target="http://www.w3.org/TR/2005/WD-css3-values-20050726/#numbers0"> CSS3 working
+      <p> 当該値は，XSLFOやCSSで使用される値になる．詳細は各規格を参照のこと． 現時点で一番詳細なリストは， <ref target="https://www.w3.org/TR/2005/WD-css3-values-20050726/#numbers0"> CSS3 working
       draft</ref>になる． </p>
   </remarks>
   <remarks versionDate="2009-05-25"
@@ -69,7 +69,7 @@ See the file COPYING.txt for details
       <p> Ces valeurs peuvent être reportées directement sur des valeurs utilisées par XSL-FO et CSS. Pour les
       définitions des unités, voir ces spécifications ; à ce jour la
       liste la plus complète est dans un
-        <ref target="http://www.w3.org/TR/2005/WD-css3-values-20050726/#numbers0">CSS3 working
+        <ref target="https://www.w3.org/TR/2005/WD-css3-values-20050726/#numbers0">CSS3 working
       draft</ref>.</p>
   </remarks>
   <!-- correct practice would be to add this item to the TEI


### PR DESCRIPTION
This PR just changes `http` to `https` for links to the _W3C_ and the `Unicode Technical Site` in the Guidelines and the Specs.
