### PR TITLE
Update ISO 8601 to specific implementation

### DIFF
--- a/P5/Source/Specs/att.datable.iso.xml
+++ b/P5/Source/Specs/att.datable.iso.xml
@@ -8,16 +8,16 @@
 -->
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <classSpec xmlns="http://www.tei-c.org/ns/1.0" module="namesdates" xml:id="DATABLEISO" type="atts" predeclare="true" ident="att.datable.iso">
-  <desc versionDate="2007-04-09" xml:lang="en">provides attributes for normalization of elements that contain datable events using the ISO 8601 standard.</desc>
-  <desc versionDate="2007-12-20" xml:lang="ko">ISO 8601 표준을 사용해서 날짜를 추정할 수 있는 사건을 포함하는 요소의 규격화를 위한 속성을 제공한다.</desc>
-  <desc versionDate="2007-05-02" xml:lang="zh-TW">用於紀錄規格化時間的屬性，該規格使用ISO 8601標準</desc>
-  <desc versionDate="2008-04-05" xml:lang="ja">ISO8601に従い，時間事象の正規的方法を示す属性を示す．</desc>
-  <desc versionDate="2009-03-19" xml:lang="fr">fournit des attributs pour la normalisation, selon la norme ISO 8601, d'éléments contenant des évènements
+  <desc versionDate="2007-04-09" xml:lang="en">provides attributes for normalization of elements that contain datable events using the ISO 8601:2004 standard.</desc>
+  <desc versionDate="2007-12-20" xml:lang="ko">ISO 8601:2004 표준을 사용해서 날짜를 추정할 수 있는 사건을 포함하는 요소의 규격화를 위한 속성을 제공한다.</desc>
+  <desc versionDate="2007-05-02" xml:lang="zh-TW">用於紀錄規格化時間的屬性，該規格使用ISO 8601:2004標準</desc>
+  <desc versionDate="2008-04-05" xml:lang="ja">ISO8601:2004に従い，時間事象の正規的方法を示す属性を示す．</desc>
+  <desc versionDate="2009-03-19" xml:lang="fr">fournit des attributs pour la normalisation, selon la norme ISO 8601:2004, d'éléments contenant des évènements
         datables.</desc>
-  <desc versionDate="2007-11-06" xml:lang="it">indica attributi per la normalizzazione tramite lo standard ISO 8601 di elementi che contengono eventi
+  <desc versionDate="2007-11-06" xml:lang="it">indica attributi per la normalizzazione tramite lo standard ISO 8601:2004 di elementi che contengono eventi
         databili</desc>
   <desc versionDate="2007-05-04" xml:lang="es">proporciona atributos para la normalización de elementos que contienen eventos datables usando el
-        estándard ISO 8601.</desc>
+        estándard ISO 8601:2004.</desc>
   <attList>
     <!-- org="choice">-->
     <attDef ident="when-iso" usage="opt">
@@ -25,7 +25,7 @@
       <desc versionDate="2007-12-20" xml:lang="ko">표준형의 날짜 또는 시간 값을 제시한다.</desc>
       <desc versionDate="2008-04-06" xml:lang="es">proporciona el valor de fecha o de tiempo en una forma estándar.</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">日付や時間を，標準形式で示す．</desc>
-      <desc versionDate="2008-12-09" xml:lang="fr">précise une date exacte pour l'évènement selon la forme normalisée ISO 8601, c'est-à-dire
+      <desc versionDate="2008-12-09" xml:lang="fr">précise une date exacte pour l'évènement selon la forme normalisée ISO 8601:2004, c'est-à-dire
                 aaaa-mm-jj.</desc>
       <desc versionDate="2007-11-06" xml:lang="it">indica il valore di una data o di un orario in un formato standard</desc>
       <datatype><dataRef key="teidata.temporal.iso"/></datatype>
@@ -125,7 +125,7 @@
   <remarks versionDate="2008-07-23" xml:lang="en">
     <p>The value of these attributes should be a normalized
     representation of the date, time, or combined date &amp; time
-    intended, in any of the standard formats specified by ISO 8601,
+    intended, in any of the standard formats specified by ISO 8601:2004,
     using the Gregorian calendar.</p>
     <p>If both <att>when-iso</att> and <att>dur-iso</att> are specified, the values should be interpreted as indicating a span of time by its
       starting time (or date) and duration. That is, <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#UND"><date when-iso="2007-06-01" dur-iso="P8D"/></egXML> indicates the same time period as <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#UND"><date when-iso="2007-06-01/P8D"/></egXML>
@@ -133,9 +133,9 @@
     <p>In providing a <soCalled>regularized</soCalled> form, no claim is made that the form in the source text is incorrect; the regularized form
       is simply that chosen as the main form for purposes of unifying variant forms under a single heading.</p>
   </remarks>
-  <remarks versionDate="2019-03-29" xml:lang="ja"><p>この属性の値は，グレゴリオ暦を用い、ISO8601で定義されるいずれかの標準形式で正規化された日付や時刻，あるいはその組み合わせである。</p>
+  <remarks versionDate="2019-03-29" xml:lang="ja"><p>この属性の値は，グレゴリオ暦を用い、ISO8601:2004で定義されるいずれかの標準形式で正規化された日付や時刻，あるいはその組み合わせである。</p>
     
-    <p> 属性<att>when-iso</att>の値は，ISO8601に従った，日付や時間，ま たはその組み合わせになる．属性<att>calendar</att>がある場合に は，要素内容の歴システムが示される．属<att>calendar</att>は，
+    <p> 属性<att>when-iso</att>の値は，ISO8601:2004に従った，日付や時間，ま たはその組み合わせになる．属性<att>calendar</att>がある場合に は，要素内容の歴システムが示される．属<att>calendar</att>は，
       属性<att>when</att>
       <att>when-iso</att>の歴システムを示すもので はない．これは普通はグレゴリオ暦になる． </p>
     <p> 属性<att>when-iso</att>と<att>dur-iso</att>が付与されている場合， 当該属性値は時間幅を示し，それぞれ始点と幅を示すものになる． 例えば，以下のような場合， <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#UND"><date when-iso="2007-06-01" dur-iso="P8D"/></egXML> この記述は，以下のようにも書くことができる． <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#UND"><date when-iso="2007-06-01/P8D"/></egXML>
@@ -144,7 +144,7 @@
   </remarks>
   <remarks versionDate="2009-03-19" xml:lang="fr">
     <p>La valeur de <att>when-iso</att> doit être une représentation normalisée de la date, de la durée ou d'une combinaison de date et de
-    durée, dans l'un des formats spécifiés dans ISO 8601, selon le calendrier grégorien.</p>
+    durée, dans l'un des formats spécifiés dans ISO 8601:2004, selon le calendrier grégorien.</p>
     <p>Si les attributs <att>when-iso</att> et <att>dur-iso</att> sont tous les deux spécifiés, les valeurs doivent être interprétées comme
       indiquant un intervalle de temps au moyen de son point de départ (ou date) et de sa durée. C'est à dire, <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#UND"><date when-iso="2007-06-01" dur-iso="P8D"/></egXML> indique la même période temporelle que <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#UND"><date when-iso="2007-06-01/P8D"/></egXML>
     </p>

--- a/P5/Source/Specs/att.datable.iso.xml
+++ b/P5/Source/Specs/att.datable.iso.xml
@@ -8,15 +8,15 @@
 -->
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <classSpec xmlns="http://www.tei-c.org/ns/1.0" module="namesdates" xml:id="DATABLEISO" type="atts" predeclare="true" ident="att.datable.iso">
-  <desc versionDate="2007-04-09" xml:lang="en">provides attributes for normalization of elements that contain datable events using the ISO 8601:2004 standard.</desc>
-  <desc versionDate="2007-12-20" xml:lang="ko">ISO 8601:2004 표준을 사용해서 날짜를 추정할 수 있는 사건을 포함하는 요소의 규격화를 위한 속성을 제공한다.</desc>
-  <desc versionDate="2007-05-02" xml:lang="zh-TW">用於紀錄規格化時間的屬性，該規格使用ISO 8601:2004標準</desc>
-  <desc versionDate="2008-04-05" xml:lang="ja">ISO8601:2004に従い，時間事象の正規的方法を示す属性を示す．</desc>
-  <desc versionDate="2009-03-19" xml:lang="fr">fournit des attributs pour la normalisation, selon la norme ISO 8601:2004, d'éléments contenant des évènements
+  <desc versionDate="2022-03-23" xml:lang="en">provides attributes for normalization of elements that contain datable events using the ISO 8601:2004 standard.</desc>
+  <desc versionDate="2022-03-23" xml:lang="ko">ISO 8601:2004 표준을 사용해서 날짜를 추정할 수 있는 사건을 포함하는 요소의 규격화를 위한 속성을 제공한다.</desc>
+  <desc versionDate="2022-03-23" xml:lang="zh-TW">用於紀錄規格化時間的屬性，該規格使用ISO 8601:2004標準</desc>
+  <desc versionDate="2022-03-23" xml:lang="ja">ISO8601:2004に従い，時間事象の正規的方法を示す属性を示す．</desc>
+  <desc versionDate="2022-03-23" xml:lang="fr">fournit des attributs pour la normalisation, selon la norme ISO 8601:2004, d'éléments contenant des évènements
         datables.</desc>
-  <desc versionDate="2007-11-06" xml:lang="it">indica attributi per la normalizzazione tramite lo standard ISO 8601:2004 di elementi che contengono eventi
+  <desc versionDate="2022-03-23" xml:lang="it">indica attributi per la normalizzazione tramite lo standard ISO 8601:2004 di elementi che contengono eventi
         databili</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">proporciona atributos para la normalización de elementos que contienen eventos datables usando el
+  <desc versionDate="2022-03-23" xml:lang="es">proporciona atributos para la normalización de elementos que contienen eventos datables usando el
         estándard ISO 8601:2004.</desc>
   <attList>
     <!-- org="choice">-->

--- a/P5/Source/Specs/teidata.temporal.iso.xml
+++ b/P5/Source/Specs/teidata.temporal.iso.xml
@@ -46,7 +46,7 @@ See the file COPYING.txt for details
          <dataRef name="token" restriction="[0-9.,DHMPRSTWYZ/:+\-]+"/>
       </alternate>
    </content>
-  <remarks versionDate="2007-04-13"
+  <remarks versionDate="2022-03-23"
             xml:lang="en">
       <p>If it is likely that the value used is to be compared with another, then a time zone
       indicator should always be included, and only the dateTime representation should be used.</p>
@@ -61,7 +61,7 @@ See the file COPYING.txt for details
     23:59:60. --></p>
   </remarks>
   <remarks xml:lang="ja"
-            versionDate="2008-04-05">
+            versionDate="2022-03-23">
       <p> 当該属性値が他の値と比較される場合，時間帯は必ず示されるべきである． またはdateTimeを使うべきである(訳注：この文は修正されるかもしれな い)． </p>
       <p> ISO 8601:2004には<term>基本形式</term>と<term>拡張形式</term>がある． 本ガイドラインでは拡張形式を使うことを推奨する． </p>
       <p> ISO 8601:2004では，深夜の12時を示す方法として， <code>00:00</code>と<code>24:00</code>の両方を認めているが，
@@ -73,7 +73,7 @@ See the file COPYING.txt for details
     </p>
   </remarks>
   <remarks xml:lang="fr"
-            versionDate="2007-06-12">
+            versionDate="2022-03-23">
       <p> S'il est vraisemblable que la valeur utilisée soit destinée à être comparer à d’autres
       valeurs, alors une indication du fuseau horaire devrait toujours être incluse, et seule la
       représentation <term>dateTime</term> devrait être employée.</p>

--- a/P5/Source/Specs/teidata.temporal.iso.xml
+++ b/P5/Source/Specs/teidata.temporal.iso.xml
@@ -50,9 +50,9 @@ See the file COPYING.txt for details
             xml:lang="en">
       <p>If it is likely that the value used is to be compared with another, then a time zone
       indicator should always be included, and only the dateTime representation should be used.</p>
-      <p>For all representations for which ISO 8601 describes both a <term>basic</term> and an
+      <p>For all representations for which ISO 8601:2004 describes both a <term>basic</term> and an
         <term>extended</term> format, these Guidelines recommend use of the extended format.</p>
-      <p>While ISO 8601 permits the use of both <code>00:00</code> and <code>24:00</code> to represent
+      <p>While ISO 8601:2004 permits the use of both <code>00:00</code> and <code>24:00</code> to represent
       midnight, these Guidelines strongly recommend against the use of <code>24:00</code>.
       <!-- As
     there are only 24 hours in a day, numbered "00" through "23", use
@@ -63,8 +63,8 @@ See the file COPYING.txt for details
   <remarks xml:lang="ja"
             versionDate="2008-04-05">
       <p> 当該属性値が他の値と比較される場合，時間帯は必ず示されるべきである． またはdateTimeを使うべきである(訳注：この文は修正されるかもしれな い)． </p>
-      <p> ISO 8601には<term>基本形式</term>と<term>拡張形式</term>がある． 本ガイドラインでは拡張形式を使うことを推奨する． </p>
-      <p> ISO 8601では，深夜の12時を示す方法として， <code>00:00</code>と<code>24:00</code>の両方を認めているが，
+      <p> ISO 8601:2004には<term>基本形式</term>と<term>拡張形式</term>がある． 本ガイドラインでは拡張形式を使うことを推奨する． </p>
+      <p> ISO 8601:2004では，深夜の12時を示す方法として， <code>00:00</code>と<code>24:00</code>の両方を認めているが，
         本ガイドラインでは，<code>24:00</code>とは表記しないことを強く推奨 している．
       <!-- As there are only 24 hours in a day, numbered "00" through "23",
     use of "24:00" implies a 25th hour, and some software may be
@@ -77,10 +77,10 @@ See the file COPYING.txt for details
       <p> S'il est vraisemblable que la valeur utilisée soit destinée à être comparer à d’autres
       valeurs, alors une indication du fuseau horaire devrait toujours être incluse, et seule la
       représentation <term>dateTime</term> devrait être employée.</p>
-      <p>Pour toutes les représentations pour lesquelles l’ISO 8601 décrit à la fois un format
+      <p>Pour toutes les représentations pour lesquelles l’ISO 8601:2004 décrit à la fois un format
         <term>basique</term> et un format<term> étendu </term>, ce guide d’encodage recommandande
       l’emploi du format <term> étendu </term>.</p>
-      <p> Même si l’ ISO 8601 permet d’écrire à la fois <code>00:00</code> et <code>24:00</code> pour
+      <p> Même si l’ ISO 8601:2004 permet d’écrire à la fois <code>00:00</code> et <code>24:00</code> pour
       minuit, ce guide d’encodage déconseille vivement d’écrire <code>24:00</code>.
       <!-- As
         there are only 24 hours in a day, numbered "00" through "23", use


### PR DESCRIPTION
This specifies the ISO 8601 standard named in `att.datable.iso.xml` and `teidata.temporal.iso.xml` to be the one from the standard published in 2004 (i.e. _not_ the latest standard). 

connected to #2249