### PR TITLE
Add missing ISO references in BIB

### DIFF
--- a/P5/Source/Guidelines/en/BIB-Bibliography.xml
+++ b/P5/Source/Guidelines/en/BIB-Bibliography.xml
@@ -3341,6 +3341,25 @@ $Id$
           </imprint>
         </monogr>
       </biblStruct>
+      <biblStruct xml:id="ISO-5218">
+        <monogr>
+          <author>International Organization for Standardization</author>
+          <title>ISO/IEC 5218:2004: Information technology — Codes for the representation of human sexes</title>
+          <imprint>
+            <date>2004</date>
+          </imprint>
+        </monogr>
+      </biblStruct>
+      <biblStruct xml:id="ISO-8601">
+        <monogr>
+          <author>International Organization for Standardization</author>
+          <title>ISO 8601:2004: Data elements and interchange formats — Information interchange — 
+            Representation of dates and times</title>
+          <imprint>
+            <date>2004</date>
+          </imprint>
+        </monogr>
+      </biblStruct>
       <biblStruct xml:id="ISO-12620">
         <monogr>
           <author>International Organization for Standardization</author>
@@ -3353,10 +3372,19 @@ $Id$
           </imprint>
         </monogr>
       </biblStruct>
+      <biblStruct xml:id="ISO-19136">
+        <monogr>
+          <author>International Organization for Standardization</author>
+          <title>ISO 19136:2007: Geographic information — Geography Markup Language (GML)</title>
+          <imprint>
+            <date>2006</date>
+          </imprint>
+        </monogr>
+      </biblStruct>
       <biblStruct xml:id="ISO-19757-3">
         <monogr>
           <author>International Organization for Standardization</author>
-          <title>ISO 19757-3:2006: Information technology – Document Schema Definition Languages
+          <title>ISO/IEC 19757-3:2006: Information technology — Document Schema Definition Languages
             (DSDL) – Part 3: Rule-based validation – Schematron</title>
           <imprint>
             <date>2006</date>

--- a/P5/Source/Guidelines/en/ND-NamesDates.xml
+++ b/P5/Source/Guidelines/en/ND-NamesDates.xml
@@ -1660,7 +1660,7 @@ exemplifying here too? -->
             <item> the OpenGIS Geography Markup Language (GML) being defined by the OGC<note place="bottom">The OGC is an
                 international voluntary consensus standards organization whose members maintain the Geography Markup Language
                 standard. The OGC coordinates with the ISO TC 211 standards organization to maintain consistency between OGC and
-                ISO standards work. GML is also an ISO standard (ISO 19136:2007).</note>
+                ISO standards work. GML is also an ISO standard (<ref target="#ISO-19136">ISO 19136:2007</ref>).</note>
             </item>
             <item> the Keyhole Markup Language (KML) used by Google Maps<note place="bottom">See <ptr
                   target="https://developers.google.com/kml/documentation/"/></note>

--- a/P5/Source/Specs/personGrp.xml
+++ b/P5/Source/Specs/personGrp.xml
@@ -72,8 +72,7 @@ specification.</p></remarks>
         <p>Values for this attribute may be locally defined by a project, or may refer to an external standard, such as
           vCard's sex property <ptr target="http://microformats.org/wiki/gender-formats"/>
           (in which <val>M</val> indicates male, <val>F</val> female, <val>O</val> other, <val>N</val> none or not applicable, <val>U</val> unknown),
-          or the often used ISO 5218:2004 <title>Representation of Human Sexes</title>
-               <ptr target="http://standards.iso.org/ittf/PubliclyAvailableStandards/c036266_ISO_IEC_5218_2004(E_F).zip"/> (in which <val>0</val>
+          or the often used <ref target="#ISO-5218">ISO 5218:2004</ref> (in which <val>0</val>
           indicates unknown; <val>1</val> male; <val>2</val> female; and <val>9</val> not applicable,
           although the ISO standard is widely considered inadequate);
           cf. CETH's <title>Recommendations for Inclusive Data Collection of Trans People</title>

--- a/P5/Source/Specs/personGrp.xml
+++ b/P5/Source/Specs/personGrp.xml
@@ -70,7 +70,7 @@ specification.</p></remarks>
       <datatype minOccurs="1" maxOccurs="unbounded"><dataRef key="teidata.sex"/></datatype>
       <remarks versionDate="2013-04-14" xml:lang="en">
         <p>Values for this attribute may be locally defined by a project, or may refer to an external standard, such as
-          vCard's sex property <ptr target="http://microformats.org/wiki/gender-formats"/>
+          vCard's sex property <ptr target="https://microformats.org/wiki/gender-formats"/>
           (in which <val>M</val> indicates male, <val>F</val> female, <val>O</val> other, <val>N</val> none or not applicable, <val>U</val> unknown),
           or the often used <ref target="#ISO-5218">ISO 5218:2004</ref> (in which <val>0</val>
           indicates unknown; <val>1</val> male; <val>2</val> female; and <val>9</val> not applicable,


### PR DESCRIPTION
This PR adds missing entries in the bibliography for cited ISO standards in the Guidelines. 
Also it removes an outdated link in `personGrp.xml`.
Relates to [#2340](https://github.com/TEIC/TEI/issues/2340#issuecomment-1246540706)