### PR TITLE
Remove remaining RelaxNG namespace declarations

### DIFF
--- a/P5/Source/Specs/abstract.xml
+++ b/P5/Source/Specs/abstract.xml
@@ -18,7 +18,7 @@ $Id$
     <memberOf key="att.global"/>
     <memberOf key="model.profileDescPart"/>
   </classes>
-  <content xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <content>
     <alternate minOccurs="1" maxOccurs="unbounded">
       <classRef key="model.pLike"/>
       <classRef key="model.listLike"/>

--- a/P5/Source/Specs/add.xml
+++ b/P5/Source/Specs/add.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="core" ident="add">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="core" ident="add">
   <gloss versionDate="2005-01-14" xml:lang="en">addition</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">삽입, 첨가</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">插入</gloss>

--- a/P5/Source/Specs/altIdentifier.xml
+++ b/P5/Source/Specs/altIdentifier.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="msdescription" xml:id="ALTIDENTIFIER" ident="altIdentifier">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="msdescription" xml:id="ALTIDENTIFIER" ident="altIdentifier">
   <gloss versionDate="2005-01-14" xml:lang="en">alternative identifier</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">대체 확인소</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">替換識別符碼</gloss>

--- a/P5/Source/Specs/appInfo.xml
+++ b/P5/Source/Specs/appInfo.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="appInfo" module="header">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="appInfo" module="header">
   <gloss versionDate="2007-07-31" xml:lang="en">application information</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">애플리케이션 정보</gloss>
   <gloss versionDate="2008-04-06" xml:lang="es">información de la aplicación</gloss>

--- a/P5/Source/Specs/att.duration.iso.xml
+++ b/P5/Source/Specs/att.duration.iso.xml
@@ -15,7 +15,7 @@
   <desc versionDate="2008-12-09" xml:lang="fr">attributs pour l'enregistrement de durées temporelles normalisées.</desc>
   <desc versionDate="2007-11-06" xml:lang="it">attributi per registrare durate temporali normalizzate</desc>
   <desc versionDate="2007-05-04" xml:lang="es">atributos para registrar duraciones de tiempo normalizadas.</desc>
-  <attList xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <attList>
     <attDef ident="dur-iso" usage="opt">
       <gloss versionDate="2007-04-09" xml:lang="en">duration</gloss>
       <gloss versionDate="2007-12-20" xml:lang="ko">지속 기간</gloss>

--- a/P5/Source/Specs/att.duration.w3c.xml
+++ b/P5/Source/Specs/att.duration.w3c.xml
@@ -16,7 +16,7 @@ $Id$
       normalisées</desc>
   <desc versionDate="2007-11-06" xml:lang="it">attributi per la registrazione di durate temporali normalizzate</desc>
   <desc versionDate="2007-05-04" xml:lang="es">atributos para registrar un periodo temporal normalizado</desc>
-  <attList xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <attList>
     <attDef ident="dur" usage="opt">
       <gloss versionDate="2007-04-09" xml:lang="en">duration</gloss>
       <gloss versionDate="2007-12-20" xml:lang="ko">지속</gloss>

--- a/P5/Source/Specs/att.formula.xml
+++ b/P5/Source/Specs/att.formula.xml
@@ -9,7 +9,7 @@ $Id$
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" type="atts" ident="att.formula">
   <desc versionDate="2019-06-25" xml:lang="en">provides attributes for defining a mathematical formula.</desc>
-  <attList xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <attList>
     <attDef ident="formula" usage="opt">
       <desc versionDate="2019-06-25" xml:lang="en">A <att>formula</att> is provided to describe a mathematical calculation such as a conversion between measurement systems.</desc>
       <datatype><dataRef key="teidata.xpath"/></datatype>

--- a/P5/Source/Specs/att.identified.xml
+++ b/P5/Source/Specs/att.identified.xml
@@ -37,7 +37,7 @@ should correspond to an existing module, via a moduleSpec or
       </rule>
     </constraint>
   </constraintSpec>
-  <attList xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <attList>
     <attDef ident="ident" usage="req">
       <desc versionDate="2012-12-27" xml:lang="en">supplies the identifier by which this element may be referenced.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">이 요소가 참조된 확인소를 제공한다.</desc>

--- a/P5/Source/Specs/att.internetMedia.xml
+++ b/P5/Source/Specs/att.internetMedia.xml
@@ -17,7 +17,7 @@ $Id$
 ressource informatique selon une taxinomie normalisée.</desc>
   <desc versionDate="2007-11-06" xml:lang="it">indica degli attributi che specificano il tipo di risorsa informatica utilizzando una tassonomia standard</desc>
   <desc versionDate="2007-05-04" xml:lang="es">atributos para registrar un periodo temporal normalizado</desc>
-  <attList xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <attList>
     <attDef ident="mimeType" usage="opt">
       <gloss versionDate="2007-07-02" xml:lang="en">MIME media type</gloss>
       <gloss versionDate="2007-12-20" xml:lang="ko">MIME 매체 유형</gloss>

--- a/P5/Source/Specs/att.measurement.xml
+++ b/P5/Source/Specs/att.measurement.xml
@@ -24,7 +24,7 @@ $Id$
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <attList xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <attList>
     <attDef ident="unit" usage="opt">
       <gloss xml:lang="en" versionDate="2009-05-28">unit</gloss>
       <gloss versionDate="2009-05-28" xml:lang="fr">unité</gloss>

--- a/P5/Source/Specs/att.media.xml
+++ b/P5/Source/Specs/att.media.xml
@@ -14,7 +14,7 @@ $Id$
   <classes>
     <memberOf key="att.internetMedia"/>
   </classes>
-  <attList xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <attList>
     <attDef ident="width" usage="opt">
       <desc versionDate="2013-01-10" xml:lang="en">Where the media are displayed, indicates the  display width</desc>
       <desc versionDate="2022-05-12" xml:lang="ja">メディアが表示されている場合、表示部分の幅を示す。</desc>

--- a/P5/Source/Specs/att.notated.xml
+++ b/P5/Source/Specs/att.notated.xml
@@ -11,7 +11,7 @@ $Id$
 <classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" type="atts" ident="att.notated">
   <desc versionDate="2021-08-22" xml:lang="en">provides attributes to indicate any specialised notation used for element content.</desc>
   
-  <attList xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <attList>
     <attDef ident="notation" usage="opt">
       <desc versionDate="2012-03-26" xml:lang="en">names the notation used for the content of the element.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">요소 내용으로 사용되어 앞서 정의된 표기법 이름을 제시한다.</desc>

--- a/P5/Source/Specs/att.resourced.xml
+++ b/P5/Source/Specs/att.resourced.xml
@@ -10,7 +10,7 @@ $Id$
 <classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" type="atts" ident="att.resourced">
   <desc versionDate="2013-01-11" xml:lang="en">provides attributes by which a resource (such as an externally
   held media file) may be located.</desc>
-  <attList xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <attList>
     <attDef ident="url" usage="req">
       <gloss versionDate="2013-01-11" xml:lang="en">uniform resource locator</gloss>
       <gloss versionDate="2007-12-20" xml:lang="ko">표준 원본 위치 지정소</gloss>

--- a/P5/Source/Specs/availability.xml
+++ b/P5/Source/Specs/availability.xml
@@ -31,7 +31,7 @@ $Id$
     <memberOf key="att.declarable"/>
     <memberOf key="model.biblPart"/>
   </classes>
-  <content xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <content>
     <alternate minOccurs="1" maxOccurs="unbounded">
       <classRef key="model.availabilityPart"/>
       <classRef key="model.pLike"/>

--- a/P5/Source/Specs/body.xml
+++ b/P5/Source/Specs/body.xml
@@ -31,7 +31,7 @@ $Id$
     <memberOf key="att.global"/>
     <memberOf key="att.declaring"/>
   </classes>
-  <content xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <content>
     <sequence>
       <!-- globals as usual -->      
       <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>

--- a/P5/Source/Specs/change.xml
+++ b/P5/Source/Specs/change.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="header" ident="change">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="header" ident="change">
   <gloss xml:lang="en" versionDate="2016-11-25">change</gloss>
   <gloss versionDate="2016-11-25" xml:lang="de">Änderung</gloss>
   <desc versionDate="2011-10-31" xml:lang="en">documents a change or set of changes made during the production

--- a/P5/Source/Specs/classRef.xml
+++ b/P5/Source/Specs/classRef.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="classRef">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="classRef">
   <desc versionDate="2010-07-06" xml:lang="en">points to the specification for an attribute or model class which is to be included in a schema</desc>
   <classes>
     <memberOf key="att.global"/>

--- a/P5/Source/Specs/climate.xml
+++ b/P5/Source/Specs/climate.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="climate" module="namesdates">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="climate" module="namesdates">
   <gloss xml:lang="en" versionDate="2008-12-09">climate</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">climat</gloss>
   <desc versionDate="2007-06-14" xml:lang="en">contains information about the physical climate of a place.</desc>

--- a/P5/Source/Specs/constraint.xml
+++ b/P5/Source/Specs/constraint.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="tagdocs" ident="constraint">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="tagdocs" ident="constraint">
   <gloss versionDate="2009-06-10" xml:lang="en">constraint rules</gloss>
   <desc versionDate="2009-06-10" xml:lang="en">the formal rules of a constraint</desc>
   <classes>

--- a/P5/Source/Specs/constraintSpec.xml
+++ b/P5/Source/Specs/constraintSpec.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="constraintSpec">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="constraintSpec">
   <gloss versionDate="2009-06-10" xml:lang="en">constraint on schema</gloss>
   <desc versionDate="2017-06-24" xml:lang="en">contains a formal constraint, typically expressed in a rule-based schema language, to which a construct must conform in order to be considered valid<!--ebb: old description of 2009-06-10 was: "contains  a constraint, expressed in some formal syntax,
   which cannot be expressed in the structural content model"--></desc>

--- a/P5/Source/Specs/creation.xml
+++ b/P5/Source/Specs/creation.xml
@@ -26,7 +26,7 @@ $Id$
     <memberOf key="att.datable"/>
     <memberOf key="model.profileDescPart"/>
   </classes>
-  <content xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <content>
     
       <alternate minOccurs="0" maxOccurs="unbounded">
         <textNode/>

--- a/P5/Source/Specs/dataFacet.xml
+++ b/P5/Source/Specs/dataFacet.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="dataFacet">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="dataFacet">
   <desc versionDate="2016-11-21" xml:lang="en">Restricts the value of the strings used to represent values of a datatype, 
     according to <ref target="#XSD2">XML Schemas: Part 2: Datatypes</ref>. 
  </desc>

--- a/P5/Source/Specs/dataRef.xml
+++ b/P5/Source/Specs/dataRef.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="dataRef">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="dataRef">
   <desc versionDate="2010-05-14" xml:lang="en">identifies the datatype of an attribute value, either by referencing an item in an externally defined datatype library, or by
     pointing to a TEI-defined data specification</desc>
   <classes>

--- a/P5/Source/Specs/egXML.xml
+++ b/P5/Source/Specs/egXML.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="tagdocs" ns="http://www.tei-c.org/ns/Examples" ident="egXML">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="tagdocs" ns="http://www.tei-c.org/ns/Examples" ident="egXML">
   <gloss versionDate="2007-07-04" xml:lang="en">example of XML</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">XML의 예</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW"/>

--- a/P5/Source/Specs/elementRef.xml
+++ b/P5/Source/Specs/elementRef.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="elementRef">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="elementRef">
   <desc versionDate="2010-05-11" xml:lang="en">points to the specification for some element which is to be included in a schema</desc>
   <classes>
     <memberOf key="att.global"/>

--- a/P5/Source/Specs/empty.xml
+++ b/P5/Source/Specs/empty.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="tagdocs" ident="empty">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="tagdocs" ident="empty">
   <desc versionDate="2014-07-01" xml:lang="en">indicates the presence of an empty node within a
     content model</desc>
   <classes>

--- a/P5/Source/Specs/facsimile.xml
+++ b/P5/Source/Specs/facsimile.xml
@@ -24,7 +24,7 @@ ou encodé.</desc>
     <memberOf key="model.resource"/>
     <memberOf key="att.declaring"/>
   </classes>
-  <content xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <content>
     <sequence>
       <elementRef key="front" minOccurs="0"/>
       <alternate minOccurs="1" maxOccurs="unbounded">

--- a/P5/Source/Specs/fileDesc.xml
+++ b/P5/Source/Specs/fileDesc.xml
@@ -28,7 +28,7 @@ $Id$
   <classes>
     <memberOf key="att.global"/>
   </classes>
-  <content xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <content>
     <sequence>
       <sequence>
         <elementRef key="titleStmt"/>

--- a/P5/Source/Specs/idno.xml
+++ b/P5/Source/Specs/idno.xml
@@ -43,7 +43,7 @@ $Id$
     <memberOf key="model.publicationStmtPart.detail"/>
     <memberOf key="model.personPart"/>
   </classes>
-  <content xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <content>
 
     <alternate minOccurs="0" maxOccurs="unbounded">
       <textNode/>

--- a/P5/Source/Specs/line.xml
+++ b/P5/Source/Specs/line.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="line" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="line" module="transcr">
   <desc versionDate="2011-11-02" xml:lang="en">contains the transcription of a topographic line in the source
    document</desc>
   <classes>

--- a/P5/Source/Specs/listChange.xml
+++ b/P5/Source/Specs/listChange.xml
@@ -16,7 +16,7 @@ with either the creation of a source text or the revision of an encoded text.</d
     <memberOf key="att.sortable"/>
     <memberOf key="att.typed"/>
   </classes>
-  <content xmlns:rng="http://relaxng.org/ns/structure/1.0">  
+  <content>  
     <sequence>
       <elementRef key="desc" minOccurs="0" maxOccurs="unbounded"/> 
       <alternate minOccurs="1" maxOccurs="unbounded">

--- a/P5/Source/Specs/listOrg.xml
+++ b/P5/Source/Specs/listOrg.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="listOrg">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="listOrg">
   <gloss versionDate="2007-07-04" xml:lang="en">list of organizations</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">조직 목록</gloss>
   <gloss versionDate="2008-04-06" xml:lang="es">lista de organizaciones</gloss>

--- a/P5/Source/Specs/listPlace.xml
+++ b/P5/Source/Specs/listPlace.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="listPlace">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="listPlace">
   <gloss versionDate="2007-07-04" xml:lang="en">list of places</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">장소 목록</gloss>
   <gloss versionDate="2008-04-06" xml:lang="es">lista de lugares</gloss>

--- a/P5/Source/Specs/listTranspose.xml
+++ b/P5/Source/Specs/listTranspose.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="listTranspose" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="listTranspose" module="transcr">
   <desc versionDate="2013-04-14" xml:lang="en">supplies a list of transpositions, each of which is  indicated at some point in
    a document typically by means of metamarks.</desc>
   <classes>

--- a/P5/Source/Specs/location.xml
+++ b/P5/Source/Specs/location.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="location" module="namesdates">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="location" module="namesdates">
   <gloss xml:lang="en" versionDate="2008-12-09">location</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">localisation</gloss>
   <desc versionDate="2012-02-14" xml:lang="en">defines the location of a place as a set of geographical coordinates, in terms of other named geo-political entities, or as an

--- a/P5/Source/Specs/macroRef.xml
+++ b/P5/Source/Specs/macroRef.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="macroRef">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="macroRef">
   <desc versionDate="2010-05-14" xml:lang="en">points to the specification for some pattern which is to be included in a schema</desc>
   <classes>
     <memberOf key="att.global"/>

--- a/P5/Source/Specs/metamark.xml
+++ b/P5/Source/Specs/metamark.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="metamark" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="metamark" module="transcr">
   <desc versionDate="2013-04-16" xml:lang="en">contains or describes any kind of graphic or written signal
    within a document the function of which is to determine how it
    should be read rather than forming part of the actual content of

--- a/P5/Source/Specs/mod.xml
+++ b/P5/Source/Specs/mod.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="mod" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="mod" module="transcr">
   <desc versionDate="2013-04-16" xml:lang="en">represents any kind of modification identified within a single document.</desc>
   <classes>
     <memberOf key="model.pPart.transcriptional"/>

--- a/P5/Source/Specs/msFrag.xml
+++ b/P5/Source/Specs/msFrag.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="msdescription" xml:id="MSFRAG" ident="msFrag">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="msdescription" xml:id="MSFRAG" ident="msFrag">
     <gloss versionDate="2015-10-26" xml:lang="en">manuscript fragment</gloss>
 <!--<gloss versionDate="2015-10-26" xml:lang="ko"></gloss>-->
 <!--<gloss versionDate="2015-10-26" xml:lang="zh-TW"/>-->

--- a/P5/Source/Specs/msPart.xml
+++ b/P5/Source/Specs/msPart.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="msdescription" xml:id="MSPART" ident="msPart">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="msdescription" xml:id="MSPART" ident="msPart">
   <gloss versionDate="2007-07-04" xml:lang="en">manuscript part</gloss>
   <gloss versionDate="2015-10-26" xml:lang="de">Handschriftenteil (kodikologische Einheit)</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">원고 부분</gloss>

--- a/P5/Source/Specs/org.xml
+++ b/P5/Source/Specs/org.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="namesdates" ident="org">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="namesdates" ident="org">
   <gloss versionDate="2007-07-04" xml:lang="en">organization</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">조직</gloss>
   <gloss versionDate="2008-04-06" xml:lang="es">organización</gloss>

--- a/P5/Source/Specs/path.xml
+++ b/P5/Source/Specs/path.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="path" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="path" module="transcr">
   <gloss xml:lang="en" versionDate="2018-07-13">path</gloss>
   <desc versionDate="2018-03-28" xml:lang="en">defines any line passing through two or more points within a <gi>surface</gi>
 element.</desc>

--- a/P5/Source/Specs/pc.xml
+++ b/P5/Source/Specs/pc.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="analysis" ident="pc">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="analysis" ident="pc">
   <gloss versionDate="2009-06-10" xml:lang="en">punctuation character</gloss>
   <gloss versionDate="2017-06-19" xml:lang="de">Interpunktionszeichen</gloss>
   <desc versionDate="2012-12-27" xml:lang="en">contains a character or string of characters regarded as constituting a

--- a/P5/Source/Specs/physDesc.xml
+++ b/P5/Source/Specs/physDesc.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="msdescription" xml:id="PHYSDESC" ident="physDesc">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="msdescription" xml:id="PHYSDESC" ident="physDesc">
   <gloss versionDate="2007-07-04" xml:lang="en">physical description</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">물리적 기술</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW"/>

--- a/P5/Source/Specs/place.xml
+++ b/P5/Source/Specs/place.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="place" module="namesdates">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="place" module="namesdates">
   <gloss xml:lang="en" versionDate="2008-12-09">place</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">lieu</gloss>
   <desc versionDate="2007-06-14" xml:lang="en">contains data about a geographic location</desc>

--- a/P5/Source/Specs/population.xml
+++ b/P5/Source/Specs/population.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="population" module="namesdates">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="population" module="namesdates">
   <gloss xml:lang="en" versionDate="2008-12-09">population</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">population</gloss>
   <desc versionDate="2007-10-18" xml:lang="en">contains information about the population of a place.</desc>

--- a/P5/Source/Specs/precision.xml
+++ b/P5/Source/Specs/precision.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="certainty" ident="precision">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="certainty" ident="precision">
   <desc versionDate="2009-06-05" xml:lang="en">indicates the numerical accuracy or precision  associated
   with some aspect of the text markup.</desc>
   <classes>

--- a/P5/Source/Specs/prefixDef.xml
+++ b/P5/Source/Specs/prefixDef.xml
@@ -18,7 +18,7 @@ $Id$
   <content>
       <classRef key="model.pLike" minOccurs="0" maxOccurs="unbounded"/>
   </content>
-  <attList xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <attList>
     <attDef ident="ident" usage="req">
       <desc versionDate="2012-11-22" xml:lang="en">supplies a name which functions as the prefix for an abbreviated
           pointing scheme such as a private URI scheme. The prefix constitutes the 

--- a/P5/Source/Specs/redo.xml
+++ b/P5/Source/Specs/redo.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="redo" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="redo" module="transcr">
   <desc versionDate="2013-04-16" xml:lang="en">indicates one or more cancelled interventions in a
 		  document which have subsequently been
 		  marked as reaffirmed or repeated.</desc>

--- a/P5/Source/Specs/relatedItem.xml
+++ b/P5/Source/Specs/relatedItem.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="relatedItem" module="core">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="relatedItem" module="core">
   <desc versionDate="2007-03-19" xml:lang="en">contains or references some other bibliographic item which is related to the present one in
     some specified manner, for example as a constituent or alternative version of it.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">구성물이나 대체 버전과 같이 현 항목과 특정 방식으로 관련된 다른 서지 항목을 명시적 방식에 따라

--- a/P5/Source/Specs/retrace.xml
+++ b/P5/Source/Specs/retrace.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="retrace" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="retrace" module="transcr">
   <desc versionDate="2013-04-16" xml:lang="en">contains a sequence of writing which has been retraced, for
       example by over-inking, to clarify or fix it.</desc>
   <classes>

--- a/P5/Source/Specs/schemaSpec.xml
+++ b/P5/Source/Specs/schemaSpec.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:teix="http://www.tei-c.org/ns/Examples" module="tagdocs" xml:id="SCHEMASPEC" ident="schemaSpec">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:teix="http://www.tei-c.org/ns/Examples" module="tagdocs" xml:id="SCHEMASPEC" ident="schemaSpec">
   <gloss versionDate="2007-07-04" xml:lang="en">schema specification</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">스키마 명시</gloss>
   <gloss versionDate="2008-04-06" xml:lang="es">especificación de esquema</gloss>

--- a/P5/Source/Specs/scriptDesc.xml
+++ b/P5/Source/Specs/scriptDesc.xml
@@ -37,7 +37,7 @@ $Id$
     </egXML>
   </exemplum>
   <exemplum xml:lang="en">
-    <egXML xmlns="http://www.tei-c.org/ns/Examples" xmlns:rng="http://relaxng.org/ns/structure/1.0">
+    <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <scriptDesc>
         <summary>Contains two distinct styles of scripts </summary>
         <scriptNote xml:id="style-1">.</scriptNote>

--- a/P5/Source/Specs/scriptNote.xml
+++ b/P5/Source/Specs/scriptNote.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="header" ident="scriptNote">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="header" ident="scriptNote">
   <desc versionDate="2010-09-24" xml:lang="en">describes a particular script distinguished within
     the description of a manuscript or similar resource.</desc>
   <classes>

--- a/P5/Source/Specs/spGrp.xml
+++ b/P5/Source/Specs/spGrp.xml
@@ -18,7 +18,7 @@
     <memberOf key="model.divPart"/>
     <memberOf key="att.ascribed.directed"/>
   </classes>
-  <content xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <content>
     <sequence>
       
         <classRef key="model.headLike" minOccurs="0" maxOccurs="unbounded"/>

--- a/P5/Source/Specs/subst.xml
+++ b/P5/Source/Specs/subst.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="transcr" ident="subst">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="transcr" ident="subst">
   <gloss versionDate="2007-09-02" xml:lang="en">substitution</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">대체</gloss>
   <gloss versionDate="2008-04-06" xml:lang="es">substitución</gloss>

--- a/P5/Source/Specs/supportDesc.xml
+++ b/P5/Source/Specs/supportDesc.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="msdescription" xml:id="SUPPORTDESC" ident="supportDesc">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="msdescription" xml:id="SUPPORTDESC" ident="supportDesc">
   <gloss versionDate="2007-07-04" xml:lang="en">support description</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">보충 기술</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW"/>

--- a/P5/Source/Specs/surface.xml
+++ b/P5/Source/Specs/surface.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="surface" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="surface" module="transcr">
   <desc versionDate="2011-11-20" xml:lang="en">defines a written surface as a two-dimensional 
 coordinate space, optionally grouping one or more graphic representations of
 that space, zones of interest within that space, and transcriptions of the

--- a/P5/Source/Specs/surfaceGrp.xml
+++ b/P5/Source/Specs/surfaceGrp.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="surfaceGrp" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="surfaceGrp" module="transcr">
   <gloss versionDate="2022-06-09" xml:lang="en">surface group</gloss>
   <desc versionDate="2011-11-11" xml:lang="en">defines any kind of useful grouping of written surfaces, for
   example the recto and verso of a single leaf, which the encoder

--- a/P5/Source/Specs/tagsDecl.xml
+++ b/P5/Source/Specs/tagsDecl.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="header" ident="tagsDecl">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="header" ident="tagsDecl">
   <gloss versionDate="2005-01-14" xml:lang="en">tagging declaration</gloss>
   <gloss versionDate="2009-01-05" xml:lang="fr">déclaration de balisage</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">태깅 선언</gloss>

--- a/P5/Source/Specs/terrain.xml
+++ b/P5/Source/Specs/terrain.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="terrain" module="namesdates">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="terrain" module="namesdates">
   <gloss xml:lang="en" versionDate="2009-03-19">terrain</gloss>
   <gloss versionDate="2009-03-19" xml:lang="fr">terrain</gloss>
   <desc versionDate="2007-10-18" xml:lang="en">contains information about the physical terrain of a place.</desc>

--- a/P5/Source/Specs/textNode.xml
+++ b/P5/Source/Specs/textNode.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="tagdocs" ident="textNode">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="tagdocs" ident="textNode">
    <desc versionDate="2014-07-01" xml:lang="en">indicates the presence
    of a text node in a content model</desc>
    <classes>     

--- a/P5/Source/Specs/transpose.xml
+++ b/P5/Source/Specs/transpose.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="transpose" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="transpose" module="transcr">
   <desc versionDate="2013-04-16" xml:lang="en"> describes a single textual transposition as an ordered list
    of at least two pointers specifying the order in which the elements
    indicated should be re-combined.</desc>

--- a/P5/Source/Specs/typeDesc.xml
+++ b/P5/Source/Specs/typeDesc.xml
@@ -33,7 +33,7 @@ $Id$
     </alternate>
   </content>
   <exemplum xml:lang="en">
-    <egXML xmlns="http://www.tei-c.org/ns/Examples" xmlns:rng="http://relaxng.org/ns/structure/1.0">
+    <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <typeDesc>
         <p>Uses an unidentified black letter font, probably from the
 	15th century</p>
@@ -41,7 +41,7 @@ $Id$
     </egXML>
   </exemplum>
   <exemplum xml:lang="en">
-    <egXML xmlns="http://www.tei-c.org/ns/Examples" xmlns:rng="http://relaxng.org/ns/structure/1.0">
+    <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <typeDesc>
         <summary>Contains a mixture of blackletter and Roman (antiqua) typefaces</summary>
         <typeNote xml:id="Frak1">Blackletter face, showing

--- a/P5/Source/Specs/typeNote.xml
+++ b/P5/Source/Specs/typeNote.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" module="msdescription" ident="typeNote">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="msdescription" ident="typeNote">
   <gloss xml:lang="en" versionDate="2020-12-20">typographic note</gloss>
   <gloss versionDate="2009-01-05" xml:lang="fr">note sur les caractères typographiques.</gloss>
   <desc versionDate="2008-09-02" xml:lang="en">describes a particular font or other significant typographic feature distinguished within

--- a/P5/Source/Specs/undo.xml
+++ b/P5/Source/Specs/undo.xml
@@ -7,7 +7,7 @@
     $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="undo" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="undo" module="transcr">
   <desc versionDate="2013-04-16" xml:lang="en">indicates one or more marked-up interventions in a document
    which have subsequently been marked for cancellation.</desc>
   <classes>

--- a/P5/Source/Specs/xenoData.xml
+++ b/P5/Source/Specs/xenoData.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="xenoData">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="xenoData">
   <gloss versionDate="2015-05-30" xml:lang="en">non-TEI metadata</gloss>
   <desc versionDate="2015-05-30" xml:lang="en">provides a container
   element into which metadata in non-TEI formats may be

--- a/P5/Source/Specs/zone.xml
+++ b/P5/Source/Specs/zone.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" ident="zone" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="zone" module="transcr">
   <desc versionDate="2011-11-20" xml:lang="en">defines any two-dimensional area within a <gi>surface</gi>
 element.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko"><gi>surface</gi> 요소 내에 포함된 직사각형 영역을 정의한다.</desc>


### PR DESCRIPTION
This PR removes the now obsolete rng namespaces from the schema. 
