### PR TITLE
Update allowed units in outputMeasurement

### DIFF
--- a/P5/Source/Specs/teidata.outputMeasurement.xml
+++ b/P5/Source/Specs/teidata.outputMeasurement.xml
@@ -18,7 +18,7 @@ See the file COPYING.txt for details
   <desc versionDate="2007-01-21" xml:lang="it">definisce una gamma di valori da impiegare nello
     specificare le dimensioni di un oggetto da inserire in rete</desc>
   <content>
-      <dataRef name="token" restriction="[\-+]?\d+(\.\d+)?(%|cm|mm|in|pt|pc|px|em|ex|gd|rem|vw|vh|vm)"/>
+      <dataRef name="token" restriction="[\-+]?\d+(\.\d+)?(%|cm|mm|in|pt|pc|px|em|ex|ch|rem|vw|vh|vmin|vmax)"/>
    </content>
   <exemplum xml:lang="en">
       <egXML xmlns="http://www.tei-c.org/ns/Examples">
@@ -39,22 +39,20 @@ See the file COPYING.txt for details
          </figure>
       </egXML>
   </exemplum>
-  <remarks versionDate="2008-01-05" xml:lang="en">
+  <remarks versionDate="2022-09-27" xml:lang="en">
       <p> These values map directly onto the values used by XSL-FO and CSS. For definitions of the
       units see those specifications; at the time of this writing the most complete list is in the
-        <ref target="https://www.w3.org/TR/2005/WD-css3-values-20050726/#numbers0">CSS3 working
-      draft</ref>.</p>
+        <ref target="https://www.w3.org/TR/css-values-3/">CSS3 working draft</ref>.</p>
   </remarks>
-  <remarks xml:lang="ja" versionDate="2008-04-05">
-      <p> 当該値は、XSLFOやCSSで使用される値になる。詳細は各規格を参照のこと。 現時点で一番詳細なリストは、 <ref target="https://www.w3.org/TR/2005/WD-css3-values-20050726/#numbers0"> CSS3 working
+  <remarks versionDate="2022-09-27" xml:lang="ja">
+      <p> 当該値は、XSLFOやCSSで使用される値になる。詳細は各規格を参照のこと。 現時点で一番詳細なリストは、 <ref target="https://www.w3.org/TR/css-values-3/"> CSS3 working
       draft</ref>になる。 </p>
   </remarks>
-  <remarks versionDate="2009-05-25" xml:lang="fr">
+  <remarks versionDate="2022-09-27" xml:lang="fr">
       <p> Ces valeurs peuvent être reportées directement sur des valeurs utilisées par XSL-FO et CSS. Pour les
       définitions des unités, voir ces spécifications ; à ce jour la
       liste la plus complète est dans un
-        <ref target="https://www.w3.org/TR/2005/WD-css3-values-20050726/#numbers0">CSS3 working
-      draft</ref>.</p>
+        <ref target="https://www.w3.org/TR/css-values-3/">CSS3 working draft</ref>.</p>
   </remarks>
   <!-- correct practice would be to add this item to the TEI
 bibliography and link to that (LB 2013-03-13) -->


### PR DESCRIPTION
This updates `teidata.outputMeasurement` to the allowed units from latest CSS3 Candidate Recommendation and also updating the embedded link. 

* 'gd' has been dropped and replaced by 'ch' ([W3C Working Draft 6 September 2011](https://www.w3.org/TR/2011/WD-css3-values-20110906/))
* 'vm' has been updated to 'vmin' ([W3C Working Draft 8 March 2012](https://www.w3.org/TR/2012/WD-css3-values-20120308/))
* 'vmax' has been added ([W3C Candidate Recommendation 28 August 2012](https://www.w3.org/TR/2012/CR-css3-values-20120828/))