### PR TITLE
Address 2300 — no text inside `<facsimile>` (at least, not in `<line>` or `<zone>`) 

### DIFF
--- a/P5/Source/Specs/facsimile.xml
+++ b/P5/Source/Specs/facsimile.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="facsimile" module="transcr">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="facsimile" module="transcr" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <desc versionDate="2007-08-26" xml:lang="en">contains a representation of some written source in the form of
 a set of images rather than as transcribed or encoded text.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">전사 또는 부호화된 텍스트 형태보다는 이미지 집합의 형태로 기록 원본의 표상을 포함한다.</desc>
@@ -28,13 +28,35 @@ ou encodé.</desc>
     <sequence>
       <elementRef key="front" minOccurs="0"/>
       <alternate minOccurs="1" maxOccurs="unbounded">
-	<classRef key="model.graphicLike"/>
-	<elementRef key="surface"/>
-	<elementRef key="surfaceGrp"/>
+        <classRef key="model.graphicLike"/>
+        <elementRef key="surface"/>
+        <elementRef key="surfaceGrp"/>
       </alternate>
       <elementRef key="back" minOccurs="0"/>
     </sequence>
   </content>
+  <constraintSpec scheme="schematron" ident="no_facsimile_text_nodes">
+    <constraint>
+      <sch:rule context="tei:facsimile//tei:line | tei:facsimile//tei:zone">
+        <sch:report test="child::text()[ normalize-space(.) ne '']">
+  	  A facsimile element represents a text with images, thus
+	  transcribed text should not be present within it.
+	</sch:report>
+        <!-- 
+             What about:
+             * ellipses/supplied/text()
+             * writing
+             * label, formula, app, witDetail, metamark?
+             * notatedMusic?
+             * figure/[all-sorts-of-crazy-stuff-e.g.-entry]
+             * addSpan, damageSpan, delSpan
+             Or the fact that <front> and <back> (but not <body>) are
+             permitted inside <facsimile>, and thus *anything* can be
+             inside ther?
+        -->
+      </sch:rule>
+    </constraint>
+  </constraintSpec>
   <exemplum xml:lang="und">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#UND">
       <facsimile>

--- a/P5/Test/detest.xml
+++ b/P5/Test/detest.xml
@@ -29,6 +29,33 @@
       </editorialDecl>
     </encodingDesc>
   </teiHeader>
+  <facsimile>
+    <front>
+      <head>Test for <val>no_facsimile_text_nodes</val></head>
+      <p>Test that non-whitespace-only text nodes in
+      <code>facsimile//line</code> or <code>facsimile//zone</code> are
+      flagged as errors. Note that <name
+      type="file">testbasic.xml</name>, <name
+      type="file">testtranscr2.xml</name>, <name
+      type="file">testtranscr4.xml</name>, and <name
+      type="file">testtranscr.xml</name> test that a
+      <code>facsimile//zone</code> that does <emph>not</emph> have a
+      non-whitespace-only text node is <emph>not</emph> flagged as an
+      error.</p>
+    </front>
+    <surface>
+      <zone>I see the bad moon risin’</zone>
+      <zone>I see trouble on the way</zone>
+      <zone>I see earthquakes and lightnin’</zone>
+      <zone>I see bad times today</zone>
+    </surface>
+    <surface>
+      <line>In Penny Lane, there is a barber showing photographs</line>
+      <line>Of every head he's had the pleasure to know</line>
+      <line>And all the people that come and go</line>
+      <line>Stop and say hello</line>
+    </surface>
+  </facsimile>
   <text>
     <body>
       <p>This document is for testing validation.</p>

--- a/P5/Test/expected-results/detest_odd_schematron.log
+++ b/P5/Test/expected-results/detest_odd_schematron.log
@@ -1,11 +1,11 @@
-Buildfile: /tei/TEI/P5/Test/antruntest.xml
+Buildfile: /TEI/P5/Test/antruntest.xml
 
 validateodd:
      [echo] Validate detest.odd as ODD ...
      [echo]  ... against RelaxNG (../p5odds.rng) with jing ...
      [echo]  ... against Schematron (../p5odds.message.isosch.xsl) with Saaxon via trax
-     [xslt] Processing /tei/TEI/P5/Test/detest.odd to /dev/null
-     [xslt] Loading stylesheet /tei/TEI/P5/p5odds.message.isosch.xsl
+     [xslt] Processing /TEI/P5/Test/detest.odd to /dev/null
+     [xslt] Loading stylesheet /TEI/P5/p5odds.message.isosch.xsl
      [xslt] 
      [xslt]                   Error: both the versionDate and xml:lang attributes on "remarks" are required when it is a child of "elementSpec".
      [xslt]                  (not( @xml:lang and @versionDate ))
@@ -43,4 +43,4 @@ validateodd:
      [xslt]         values (string(tei:defaultVal) = tei:valList/tei:valItem/@ident)
 
 BUILD SUCCESSFUL
-Total time: 3 seconds
+Total time: 2 seconds

--- a/P5/Test/expected-results/detest_xml_relaxng.log
+++ b/P5/Test/expected-results/detest_xml_relaxng.log
@@ -1,27 +1,27 @@
 detest.xml
-detest.xml:42:13: error: unfinished content of element http://www.tei-c.org/ns/1.0^lg
+detest.xml:69:13: error: unfinished content of element http://www.tei-c.org/ns/1.0^lg
 required:
 	element http://www.tei-c.org/ns/1.0^l
 	element http://www.tei-c.org/ns/1.0^stage
 	element http://www.tei-c.org/ns/1.0^desc
 	element http://www.tei-c.org/ns/1.0^label
 	element http://www.tei-c.org/ns/1.0^lg
-detest.xml:118:10: error: attribute ^truth with invalid value "no"
+detest.xml:145:10: error: attribute ^truth with invalid value "no"
 required:
 	data http://www.w3.org/2001/XMLSchema-datatypes^boolean
-detest.xml:120:10: error: attribute http://www.w3.org/XML/1998/namespace^lang not allowed
+detest.xml:147:10: error: attribute http://www.w3.org/XML/1998/namespace^lang not allowed
 required:
 	after
-detest.xml:123:10: error: attribute ^enumerated with invalid value " dog  breath"
+detest.xml:150:10: error: attribute ^enumerated with invalid value " dog  breath"
 required:
 	data http://www.w3.org/2001/XMLSchema-datatypes^token
-detest.xml:128:10: error: attribute ^name with invalid value "123"
+detest.xml:155:10: error: attribute ^name with invalid value "123"
 required:
 	data http://www.w3.org/2001/XMLSchema-datatypes^Name
-detest.xml:137:10: error: unfinished content of element http://www.tei-c.org/ns/1.0^lg
+detest.xml:164:10: error: unfinished content of element http://www.tei-c.org/ns/1.0^lg
 required:
 	element http://www.tei-c.org/ns/1.0^l
-detest.xml:162:37: error: invalid data or text not allowed
+detest.xml:189:37: error: invalid data or text not allowed
 required:
 	element http://www.tei-c.org/ns/1.0^add
 	element http://www.tei-c.org/ns/1.0^surplus
@@ -33,34 +33,34 @@ required:
 	element http://www.tei-c.org/ns/1.0^cb
 	element http://www.tei-c.org/ns/1.0^fw
 	element http://www.tei-c.org/ns/1.0^anchor
-detest.xml:180:11: error: attribute ^target with invalid value "#spanTest"
+detest.xml:207:11: error: attribute ^target with invalid value "#spanTest"
 required:
 	data http://www.w3.org/2001/XMLSchema-datatypes^anyURI
-detest.xml:186:11: error: missing attributes of http://www.tei-c.org/ns/1.0^media
+detest.xml:213:11: error: missing attributes of http://www.tei-c.org/ns/1.0^media
 required:
 	attribute ^url
-detest.xml:187:11: error: missing attributes of http://www.tei-c.org/ns/1.0^media
+detest.xml:214:11: error: missing attributes of http://www.tei-c.org/ns/1.0^media
 required:
 	attribute ^mimeType
-detest.xml:193:51: error: invalid data or text not allowed
+detest.xml:220:51: error: invalid data or text not allowed
 required:
 	after
-detest.xml:194:41: error: invalid data or text not allowed
+detest.xml:221:41: error: invalid data or text not allowed
 required:
 	after
-detest.xml:195:61: error: invalid data or text not allowed
+detest.xml:222:61: error: invalid data or text not allowed
 required:
 	after
-detest.xml:196:25: error: invalid data or text not allowed
+detest.xml:223:25: error: invalid data or text not allowed
 required:
 	after
-detest.xml:219:12: error: element http://www.tei-c.org/ns/1.0^altIdentifier not allowed
+detest.xml:246:12: error: element http://www.tei-c.org/ns/1.0^altIdentifier not allowed
 required:
 	element http://www.tei-c.org/ns/1.0^msIdentifier
-detest.xml:222:10: error: unfinished content of element http://www.tei-c.org/ns/1.0^msPart
+detest.xml:249:10: error: unfinished content of element http://www.tei-c.org/ns/1.0^msPart
 required:
 	element http://www.tei-c.org/ns/1.0^msIdentifier
-detest.xml:251:10: error: element http://www.tei-c.org/ns/1.0^idno not allowed
+detest.xml:278:10: error: element http://www.tei-c.org/ns/1.0^idno not allowed
 required:
 	after
 allowed:
@@ -73,7 +73,7 @@ allowed:
 	element http://www.tei-c.org/ns/1.0^listRef
 	element http://www.tei-c.org/ns/1.0^relatedItem
 	element http://www.tei-c.org/ns/1.0^citedRange
-detest.xml:321:12: error: attribute ^target with invalid value ""
+detest.xml:348:12: error: attribute ^target with invalid value ""
 required:
 	data http://www.w3.org/2001/XMLSchema-datatypes^anyURI
 error: some documents are invalid

--- a/P5/Test/expected-results/detest_xml_schematron.log
+++ b/P5/Test/expected-results/detest_xml_schematron.log
@@ -41,6 +41,38 @@ If @to is supplied on span, @from must be supplied as well (@to and not(@from))
 
               The @location value "external" is inconsistent with the
               parallel-segmentation method of apparatus markup. (@location eq 'external' and @method eq 'parallel-segmentation')
+
+  	  A facsimile element represents a text with images, thus
+	  transcribed text should not be present within it.
+	 (child::text()[ normalize-space(.) ne ''])
+
+  	  A facsimile element represents a text with images, thus
+	  transcribed text should not be present within it.
+	 (child::text()[ normalize-space(.) ne ''])
+
+  	  A facsimile element represents a text with images, thus
+	  transcribed text should not be present within it.
+	 (child::text()[ normalize-space(.) ne ''])
+
+  	  A facsimile element represents a text with images, thus
+	  transcribed text should not be present within it.
+	 (child::text()[ normalize-space(.) ne ''])
+
+  	  A facsimile element represents a text with images, thus
+	  transcribed text should not be present within it.
+	 (child::text()[ normalize-space(.) ne ''])
+
+  	  A facsimile element represents a text with images, thus
+	  transcribed text should not be present within it.
+	 (child::text()[ normalize-space(.) ne ''])
+
+  	  A facsimile element represents a text with images, thus
+	  transcribed text should not be present within it.
+	 (child::text()[ normalize-space(.) ne ''])
+
+  	  A facsimile element represents a text with images, thus
+	  transcribed text should not be present within it.
+	 (child::text()[ normalize-space(.) ne ''])
 The @spanTo attribute of delSpan is required. (@spanTo)
 The @spanTo attribute of delSpan is required. (@spanTo)
 subst must have at least one child add and at least one child del or surplus (child::tei:add and (child::tei:del or child::tei:surplus))


### PR DESCRIPTION
 * Add a constraint (in Schematron) to require that there NOT be text content (other than whitespace-only text nodes, of course) inside 'zone' or 'line' elements that are themselves inside a 'facsimile' element.
 * Add a test that should fail that rule to detest.xml.
 * Change the expected results to match new outputs.