### PR TITLE
Address #2314

### DIFF
--- a/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
+++ b/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
@@ -3035,12 +3035,12 @@ example, in the following entry from a dictionary already in
 electronic form, it is necessary to include a <gi>pron</gi> element
 within a <gi>def</gi>. This is not permitted in the content model for
 <gi>entry</gi>, but it poses no problem in the <gi>entryFree</gi>
-element. <egXML xmlns="http://www.tei-c.org/ns/Examples">&lt;ent
-h="demigod"&gt; &lt;hwd&gt;demi|god&lt;/hwd&gt; &lt;pr&gt; &lt;ph&gt;"demIgQd&lt;/ph&gt; &lt;/pr&gt; &lt;hps
-ps="n"&gt; &lt;hsn&gt; &lt;def&gt;one who is partly divine and partly human&lt;/def&gt;
-&lt;def&gt;(in Gk myth, etc) the son of a god and a mortal woman,
-eg&lt;cf&gt;Hercules&lt;/cf&gt; &lt;pr&gt; &lt;ph&gt;"h3:kjUli:z&lt;/ph&gt; &lt;/pr&gt; &lt;/def&gt; &lt;/hsn&gt;
-&lt;/hps&gt; &lt;/ent&gt; </egXML>(<ref target="#DIC-OALD">OALD</ref>)
+element. <eg source="#DIC-OALD"><![CDATA[<entb
+h="demigod"> <hwd>demi|god</hwd> <pr> <ph>"demIgQd</ph> </pr> <hps
+ps="n"> <hsn> <def>one who is partly divine and partly human</def>
+<def>(in Gk myth, etc) the son of a god and a mortal woman,
+eg<cf>Hercules</cf> <pr> <ph>"h3:kjUli:z</ph> </pr> </def> </hsn>
+</hps> </ent>]]></eg>
 <egXML xmlns="http://www.tei-c.org/ns/Examples">
 <entryFree>
 <form>


### PR DESCRIPTION
Per my suggestion on the [ticket](https://github.com/TEIC/TEI/issues/2314), changed example of non-XML encoding from `<egXML>` to `<eg>`, and moved citation to its `@source` attr.

Note: The little anchor that shows up for the “link-to-me” feature is the wrong character (i.e., is different than the one used for `<egXML>`s); and the “bibliography” link is not showing up. Both of these are Stylesheets problems, and neither one should prevent us from incorporating this change, IMHO.