### PR TITLE
Update encoding of examples

### DIFF
--- a/P5/Source/Specs/cl.xml
+++ b/P5/Source/Specs/cl.xml
@@ -31,18 +31,18 @@ $Id$
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <exemplum xml:lang="en">
+  <exemplum versionDate="2022-11-30" xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
-      <cl type="relative" function="clause_modifier">Which frightened
- both the heroes so,<cl>They quite forgot their quarrel.</cl>
-         </cl>
+      <l><cl type="relative" function="clause_modifier">Which frightened
+          both the heroes so,</cl></l>
+      <l><cl>They quite forgot their quarrel.</cl></l>
     </egXML>
   </exemplum>
-  <exemplum versionDate="2008-04-06" xml:lang="fr">
+  <exemplum versionDate="2022-11-30" xml:lang="fr">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
-      <cl type="relative" function="proposition_relative_déterminative"> Il nous rejoindra dans
-          les jours<cl>qui viennent.</cl>
-         </cl>
+      <l><cl type="relative" function="proposition_relative_déterminative">Il nous rejoindra dans
+          les jours</cl></l>
+      <l><cl>qui viennent.</cl></l>
     </egXML>
   </exemplum>
   <exemplum xml:lang="zh-TW">

--- a/P5/Source/Specs/cl.xml
+++ b/P5/Source/Specs/cl.xml
@@ -41,8 +41,9 @@ $Id$
   <exemplum versionDate="2022-11-30" xml:lang="fr">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <cl>Il nous rejoindra dans
-          les jours</cl>
+          les jours
       <cl type="relative" function="proposition_relative_déterminative">qui viennent.</cl>
+      </cl>
     </egXML>
   </exemplum>
   <exemplum xml:lang="zh-TW">

--- a/P5/Source/Specs/cl.xml
+++ b/P5/Source/Specs/cl.xml
@@ -40,9 +40,9 @@ $Id$
   </exemplum>
   <exemplum versionDate="2022-11-30" xml:lang="fr">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
-      <l><cl type="relative" function="proposition_relative_déterminative">Il nous rejoindra dans
-          les jours</cl></l>
-      <l><cl>qui viennent.</cl></l>
+      <cl>Il nous rejoindra dans
+          les jours</cl>
+      <cl type="relative" function="proposition_relative_déterminative">qui viennent.</cl>
     </egXML>
   </exemplum>
   <exemplum xml:lang="zh-TW">


### PR DESCRIPTION
Reorganized encoding of `cl` as the relative clause is only the first part of the sentence and not the whole sentence. This way, the encoding of `l` could also be added in the English example.
For the French example, reorganized encoding of `cl` as the relative clause and moved type and function attributes.
Could not check or update example in zh-TW due to lack of language skills.