### PR TITLE
Fix examples of IETF language tags

### DIFF
--- a/P5/Source/Guidelines/en/MS-ManuscriptDescription.xml
+++ b/P5/Source/Guidelines/en/MS-ManuscriptDescription.xml
@@ -1355,7 +1355,7 @@ attribute may be used. This attribute takes the same range of values as the
 global <att>xml:lang</att> attribute, on which see further <ptr target="#CHSH"/>. In the following example a manuscript written chiefly in Old Church Slavonic
 is described:
 <egXML xmlns="http://www.tei-c.org/ns/Examples">
-<textLang mainLang="chu">Old Church Slavonic</textLang>
+<textLang mainLang="cu">Old Church Slavonic</textLang>
 </egXML>
 </p>
 <!-- here I would like to add the these two attributes are also available on msContents -->
@@ -1364,7 +1364,7 @@ The <att>mainLang</att> attribute should be used only for the chief language.
 Other languages used may be specified using the <att>otherLangs</att> attribute
 as in the following example:
 <egXML xmlns="http://www.tei-c.org/ns/Examples">
-<textLang mainLang="chu" otherLangs="RUS HEL">Mostly Old Church Slavonic, with
+<textLang mainLang="cu" otherLangs="ru grc">Mostly Old Church Slavonic, with
 some Russian and Greek material</textLang>
 </egXML>
 </p>
@@ -1372,7 +1372,7 @@ some Russian and Greek material</textLang>
 scripts, and even occasionally in both within the same manuscript, it might be
 preferable to use a more explicit identifier:
 <egXML xmlns="http://www.tei-c.org/ns/Examples">
-<textLang mainLang="chu-Cyrs">Old Church Slavonic in Cyrillic script</textLang>
+<textLang mainLang="cu-Cyrs">Old Church Slavonic in Cyrillic script</textLang>
 </egXML>
 </p>
 <p>The form and scope of language identifiers recommended by these Guidelines is

--- a/P5/Source/Specs/msPart.xml
+++ b/P5/Source/Specs/msPart.xml
@@ -77,7 +77,7 @@ $Id$
           <msName>Maurdramnus Bible</msName>
         </msIdentifier>
         <msContents><summary xml:lang="la">Miscellany of various texts; Prudentius, Psychomachia; Physiologus de natura animantium</summary>
-          <textLang mainLang="lat">Latin</textLang>
+          <textLang mainLang="la">Latin</textLang>
         </msContents>
         <physDesc>
           <objectDesc form="composite_manuscript"/>
@@ -86,7 +86,7 @@ $Id$
           <msIdentifier><idno>ms. 10066-77 ff. 140r-156v</idno>
           </msIdentifier>
           <msContents><summary xml:lang="la">Physiologus</summary>
-            <textLang mainLang="lat">Latin</textLang>
+            <textLang mainLang="la">Latin</textLang>
           </msContents>
         </msPart>        
         <msPart>


### PR DESCRIPTION
The text specifies that tags in `<textLang>` should follow IETF BCP 47, but several of these examples did not use codes from the IETF registry.

See <https://r12a.github.io/app-subtags/> for an enhanced version of the subtag registry.