### PR TITLE
Fixing permissions in actions (should fix #2399) 

### DIFF
--- a/.github/workflows/generate-spec-lists.yml
+++ b/.github/workflows/generate-spec-lists.yml
@@ -10,9 +10,17 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/generate-spec-lists
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Checkout TEI Repository
+        uses: actions/checkout@v3
+        
+      - name: Fix permissions   
+        run: git config --global --add safe.directory /__w/TEI/TEI
+        
+      - name: Generate JSON Spec list        
+        uses: ./.github/actions/generate-spec-lists
+        
+      - name: Auto-commit Spec list  
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_user_name: ${{ github.actor }}
           commit_message: Re-generated spec lists.

--- a/.github/workflows/generate-spec-lists.yml
+++ b/.github/workflows/generate-spec-lists.yml
@@ -12,13 +12,10 @@ jobs:
     steps:
       - name: Checkout TEI Repository
         uses: actions/checkout@v3
-        
-      - name: Fix permissions   
-        run: git config --global --add safe.directory /__w/TEI/TEI
-        
+
       - name: Generate JSON Spec list        
         uses: ./.github/actions/generate-spec-lists
-        
+
       - name: Auto-commit Spec list  
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
      
      # Temporary fix to deal with #2399     
       - name: Fix Git permissions
-        run: git config --system --add safe.directory /github/workspace
+        run: git config --global --add safe.directory /__w/TEI/TEI
 
       - name: Run tests from the Test directory
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ jobs:
           repository: TEIC/Stylesheets
           ref: dev
           path: Stylesheets
+     
+     # Temporary fix to deal with #2399     
+      - name: Fix Git permissions
+        run: git config --system --add safe.directory /github/workspace
 
       - name: Run tests from the Test directory
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,10 @@ jobs:
           ref: dev
           path: Stylesheets
      
-     # Temporary fix to deal with #2399     
+      # Update permissions in GITHUB_WORSPACE (e.g. /__w/TEI/TEI)
+      # to resolve "dubious permissions" in git (see TEI/TEIC#2399)  
       - name: Fix Git permissions
-        run: git config --global --add safe.directory /__w/TEI/TEI
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Run tests from the Test directory
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           ref: dev
           path: Stylesheets
      
-      # Update permissions in GITHUB_WORSPACE (e.g. /__w/TEI/TEI)
+      # Update permissions in GITHUB_WORKSPACE (e.g. /__w/TEI/TEI)
       # to resolve "dubious permissions" in git (see TEI/TEIC#2399)  
       - name: Fix Git permissions
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"


### PR DESCRIPTION
* test.yml:
    * Add permissions config step to resolve 'dubious permissions' error
* generate-spec-lists.yml:
    * Upgrade action/checkout to v3
    * Add names and ws to the yaml (to align with test.yml)
 
Note that I haven't added the permissions step to generate-spec-lists.yml, as I don't think it will be necessary—however, I haven't been able to figure out a way to test for the dubious permissions error locally (or at least reliably), since I can't replicate the error (running the steps in a Docker container doesn't yield the error and neither does running the action using [`act`](https://github.com/nektos/act)). 