### PR TITLE
Added `@type` to `<calendar>` and added an example of `@type` to prose `#HD44` for #2396

### DIFF
--- a/P5/Source/Guidelines/en/HD-Header.xml
+++ b/P5/Source/Guidelines/en/HD-Header.xml
@@ -2339,8 +2339,8 @@ either the <att>calendar</att> attribute on <gi>date</gi> or the
   code for it as the value of its <att>xml:id</att> attribute.
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <calendarDesc>
-        <calendar xml:id="Gregorian"><p>Gregorian calendar</p></calendar>
-        <calendar xml:id="Stardate"><p>Fictional Stardate (from Star Trek series)</p></calendar>
+        <calendar xml:id="Gregorian" type="actual"><p>Gregorian calendar</p></calendar>
+        <calendar xml:id="Stardate" type="fictional"><p>Fictional Stardate (from Star Trek series)</p></calendar>
         <calendar xml:id="BP"><p>Calendar years before present (measured from 1950)</p></calendar>
       </calendarDesc>
     </egXML>

--- a/P5/Source/Guidelines/en/HD-Header.xml
+++ b/P5/Source/Guidelines/en/HD-Header.xml
@@ -118,13 +118,13 @@ looks like this:
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="und" source="#UND"><teiHeader>
     <fileDesc>
       <titleStmt>
-	<title><!-- title of the resource --></title>
+        <title><!-- title of the resource --></title>
       </titleStmt>
       <publicationStmt>
-	<p><!-- Information about distribution of the resource --></p>
+        <p><!-- Information about distribution of the resource --></p>
       </publicationStmt>
       <sourceDesc>
-	<p><!-- Information about source from which the resource derives --></p>
+        <p><!-- Information about source from which the resource derives --></p>
       </sourceDesc>
     </fileDesc>
   </teiHeader></egXML></p>
@@ -158,13 +158,13 @@ chapter). A corpus may thus take the form:
    </teiHeader>
    <TEI>
       <teiHeader>
-	<!-- metadata specific to this text here -->
+        <!-- metadata specific to this text here -->
       </teiHeader>
       <text><!-- ... --></text>
    </TEI>
    <TEI>
       <teiHeader>
-	<!-- metadata specific to this text here -->
+        <!-- metadata specific to this text here -->
       </teiHeader>
       <text><!-- ... --></text>
    </TEI>
@@ -303,15 +303,15 @@ might look like this:
     <fileDesc>
          <titleStmt> <title><!-- title of the resource --></title> </titleStmt>
          <editionStmt> <p> <!-- information about the edition of the
-				resource  --></p> </editionStmt>
+                                resource  --></p> </editionStmt>
          <extent> <!-- description of the size of the resource --></extent>
          <publicationStmt> <p><!-- information about the distribution
-				   of the resource --> </p></publicationStmt>
+                                   of the resource --> </p></publicationStmt>
          <seriesStmt> <p><!-- information about any series to which
-			      the resource belongs  --></p></seriesStmt>
+                              the resource belongs  --></p></seriesStmt>
          <notesStmt> <note><!-- notes on other aspects of the resource --> </note></notesStmt>
          <sourceDesc> <p> <!-- information about the source from which
-			       the resource was derived  --> </p></sourceDesc>
+                               the resource was derived  --> </p></sourceDesc>
     </fileDesc>
 </teiHeader></egXML>
 Of these  elements, only the <gi>titleStmt</gi>,
@@ -802,11 +802,11 @@ available. For example, the notes above might be encoded as follows:
         <respStmt>
           <persName>Mark Cohen</persName>
           <resp>historical commentary</resp>
-	</respStmt>
+        </respStmt>
         <respStmt>
           <orgName>University of Toronto</orgName>
           <resp>OCR scanning</resp>
-	</respStmt>
+        </respStmt>
       </titleStmt></egXML>
 <specGrp xml:id="D2226" n="The notes statement"><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/notesStmt.xml"/>
 </specGrp>
@@ -1047,8 +1047,8 @@ It should include information about such matters as
 <item>the object of the sampling procedure used</item></list>
 but is not restricted to these.
         <!-- should attributes be used for sample size, etc? -LB -->
-	<!-- if it would help automatic processing yes.  but i   -->
-	<!-- doubt it.  so no.  -msm                             -->
+        <!-- if it would help automatic processing yes.  but i   -->
+        <!-- doubt it.  so no.  -msm                             -->
 <egXML xmlns="http://www.tei-c.org/ns/Examples"><samplingDecl>
    <p>Samples of 2000 words taken from the beginning of the text.</p>
 </samplingDecl></egXML></p>
@@ -1225,7 +1225,7 @@ text.  Instead, the <att>decls</att> attribute of each text (or
 subdivision of the text) to which it applies may
 be used to supply a cross-reference to it, as further described in
 section <ptr target="#CCAS"/>.
-	</p></div>
+        </p></div>
 
 <div type="div3" xml:id="HD57"><head>The Tagging Declaration</head>
 <p>The <gi>tagsDecl</gi> element is used to record
@@ -1354,7 +1354,7 @@ follows:
         <titlePart rendition="#xx-space"><lb/> VOLUME I.
         <lb/><hi rendition="#red #x-large">POEMS AND BALLADS</hi>
         <lb/><hi rendition="#x-space">FIRST SERIES</hi>
-	</titlePart>
+        </titlePart>
     </docTitle>
     <docImprint rendition="#center">
         <lb/><pubPlace rendition="#xx-space">LONDON</pubPlace>
@@ -1493,7 +1493,7 @@ the convenience of the encoder and the likely efficiency of the
 particular software applications envisaged, in this context as in many
 others. For a more detailed discussion of referencing
 systems supported by these Guidelines, see section <ptr target="#CORS"/> below.
-	</p>
+        </p>
 <p>A referencing scheme may be described in one of four ways using this
 element:
 <list rend="bulleted">
@@ -1608,8 +1608,8 @@ and line numbers change. Note that no value has been specified for the
 that its value at each state change is monotonically increased.
 For more detail on the use of milestone tags,
 see section <ptr target="#CORS5"/>.<!-- was:  target='P2.232ms'> -->
-	<!-- was:  target='CORSYS5' > -->
-	<!-- following algorithm should also be moved to CREF --></p>
+        <!-- was:  target='CORSYS5' > -->
+        <!-- following algorithm should also be moved to CREF --></p>
 <p>The milestone referencing scheme, though conceptually simple, is not
 supported by a generic XML parser.  Its use places a
 correspondingly greater burden of verification and accuracy on the
@@ -1941,11 +1941,11 @@ which was last saved on June 6 2006. The parts concerned are
 accessible at the URLs given as target for the two <gi>ptr</gi>
 elements.     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <appInfo>
-	<application version="1.5" ident="ImageMarkupTool" notAfter="2006-06-01">
-	  <label>Image Markup Tool</label>
-	  <ptr target="#P1"/>
-	  <ptr target="#P2"/>
-	</application>
+        <application version="1.5" ident="ImageMarkupTool" notAfter="2006-06-01">
+          <label>Image Markup Tool</label>
+          <ptr target="#P1"/>
+          <ptr target="#P2"/>
+        </application>
       </appInfo>
     </egXML>
    </p><specGrp xml:id="DHDAPP"><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/appInfo.xml"/><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/application.xml"/><!--&model.applicationLike;-->
@@ -2181,9 +2181,9 @@ the <att>scheme</att> attribute will point to the local definition, which will
 typically be held in a <gi>taxonomy</gi> element within the
 <gi>classDecl</gi> part of the encoding description (see section <ptr target="#HD55"/>).
 <!-- LC subject tracings on R Potter, ed., Literary           -->
-	<!-- Computing and Literary Criticism:  Theoretical and       -->
-	<!-- Practical Essays on Theme and Rhetoric (Philadelphia,    -->
-	<!-- U Penn, 1989), from CIP data on title overleaf.
+        <!-- Computing and Literary Criticism:  Theoretical and       -->
+        <!-- Practical Essays on Theme and Rhetoric (Philadelphia,    -->
+        <!-- U Penn, 1989), from CIP data on title overleaf.
  source="#HD43-eg-123" but I think we dont need to cite source          --></p>
 <p>The <gi>classCode</gi> element also categorizes an individual text,
 by supplying a numerical or other code rather than descriptive
@@ -2324,32 +2324,39 @@ classification system.</p>
 
 <div type="div3" xml:id="HD44"><head>Calendar Description</head>
   <p>The <gi>calendarDesc</gi> element is used within the
-  <gi>profileDesc</gi> element to document objects referenced by means of
-either the <att>calendar</att> attribute on <gi>date</gi> or the
-<att>datingMethod</att> attribute on any member of the <ident type="class">att.datable</ident> class.
+  <gi>profileDesc</gi> element to document objects referenced by means
+  of either the <att>calendar</att> attribute on <gi>date</gi> or the
+  <att>datingMethod</att> attribute on any member of the <ident
+  type="class">att.datable</ident> class.
     <specList>
       <specDesc key="calendarDesc"/>
-    </specList></p>
+    </specList>
+  </p>
   <p>This element may contain one or more <gi>calendar</gi> elements:
     <specList>
       <specDesc key="calendar"/>
-    </specList></p>
+    </specList>
+  </p>
   <p>Each such element contains one or more paragraphs of description
   for the calendar system concerned, and also supplies an identifying
-  code for it as the value of its <att>xml:id</att> attribute.
+  code for it as the value of its <att>xml:id</att> attribute. A
+  <gi>calendar</gi> element may also have a <att>type</att> (and
+  <att>subtype</att>) attribute in order to categorize the calendar in
+  any convenient way. In the following example, <att>type</att> is
+  used to differentiate real calendar systems in actual use from those
+  used in a fictional environment.
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <calendarDesc>
         <calendar xml:id="Gregorian" type="actual"><p>Gregorian calendar</p></calendar>
         <calendar xml:id="Stardate" type="fictional"><p>Fictional Stardate (from Star Trek series)</p></calendar>
-        <calendar xml:id="BP"><p>Calendar years before present (measured from 1950)</p></calendar>
+        <calendar xml:id="BP" type="actual"><p>Calendar years before present (measured from 1950)</p></calendar>
       </calendarDesc>
     </egXML>
   </p>
-<p>This identifying code may then be referenced from any element
-supplying  a date
-expressed using that calendar system:
+  <p>This identifying code may then be referenced from any element
+  supplying a date expressed using that calendar system:
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
-<p>Captain's log <date calendar="#stardate">stardate 23.9 rounded off
+      <p>Captain's log <date calendar="#stardate">stardate 23.9 rounded off
     to the nearest decimal point</date>...</p></egXML>
 
   See <ptr target="#NDDATECUSTOM"/> for details of the usage of dating attributes in conjunction
@@ -2608,9 +2615,9 @@ most recent first.</p>
     <change n="RCS:1.39" when="2007-08-08" who="#jwernimo.lrv">Changed <val>drama.verse</val>
     <gi>lg</gi>s to <gi>p</gi>s. <note>we have opened a discussion about the need for a new
           value for <att>type</att> of <gi>lg</gi>, <val>drama.free.verse</val>, in order to address
-	  the verse of Behn which is not in regular iambic pentameter. For the time being these
-	  instances are marked with a comment note until we are able to fully consider the best way
-	  to encode these instances.</note>
+          the verse of Behn which is not in regular iambic pentameter. For the time being these
+          instances are marked with a comment note until we are able to fully consider the best way
+          to encode these instances.</note>
     </change>
     <change n="RCS:1.33" when="2007-06-28" who="#pcaton.xzc">Added <att>key</att> and <att>reg</att>
     to <gi>name</gi>s.</change>
@@ -2623,20 +2630,20 @@ In the above example, the <att>who</att> attributes point to
 <gi>titleStmt</gi> of the same header:
 <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <titleStmt>
-	<title>The Amorous Prince, or, the Curious Husband, 1671</title>
-	<author><persName ref="#abehn.aeh">Behn, Aphra</persName></author>
-	<respStmt xml:id="pcaton.xzc">
-	  <persName>Caton, Paul</persName>
-	  <resp>electronic publication editor</resp>
-	</respStmt>
-	<respStmt xml:id="wgui.ner">
-	  <persName>Gui, Weihsin</persName>
-	  <resp>encoder</resp>
-	</respStmt>
-	<respStmt xml:id="jwernimo.lrv">
+        <title>The Amorous Prince, or, the Curious Husband, 1671</title>
+        <author><persName ref="#abehn.aeh">Behn, Aphra</persName></author>
+        <respStmt xml:id="pcaton.xzc">
+          <persName>Caton, Paul</persName>
+          <resp>electronic publication editor</resp>
+        </respStmt>
+        <respStmt xml:id="wgui.ner">
+          <persName>Gui, Weihsin</persName>
+          <resp>encoder</resp>
+        </respStmt>
+        <respStmt xml:id="jwernimo.lrv">
           <persName>Wernimont, Jacqueline</persName>
-	  <resp>encoder</resp>
-	</respStmt>
+          <resp>encoder</resp>
+        </respStmt>
       </titleStmt>
 </egXML>
 There is however no requirement that the <gi>respStmt</gi> be used for
@@ -2697,7 +2704,7 @@ example:
     </publicationStmt>
     <sourceDesc>
       <bibl>The complete writings of Thomas Paine, collected and edited
-	    by Phillip S. Foner (New York, Citadel Press, 1945)</bibl>
+            by Phillip S. Foner (New York, Citadel Press, 1945)</bibl>
     </sourceDesc>
   </fileDesc>
 </teiHeader></egXML></p><p>The only mandatory component of the TEI header is the
@@ -2720,9 +2727,9 @@ encoding principles used in this (imaginary) encoding, about the
 text itself (in the form of Library of Congress subject headings),
 and about the revision of the file.
 <!-- Bibliographic reference to a real OTA text.              -->
-	<!-- EncodingDesc mostly from description of                  -->
-	<!-- that text, but improvised in part.                       -->
-	<!-- Revision desc is imaginary                               -->
+        <!-- EncodingDesc mostly from description of                  -->
+        <!-- that text, but improvised in part.                       -->
+        <!-- Revision desc is imaginary                               -->
 <egXML xmlns="http://www.tei-c.org/ns/Examples"><teiHeader>
    <fileDesc>
       <titleStmt>
@@ -2845,13 +2852,13 @@ and about the revision of the file.
    </revisionDesc>
 </teiHeader></egXML>
 <!-- this is what Rich suggested: me, I think the  -->
-	<!-- contents of the supplementary file should be  -->
-	<!-- decanted into the encodingDesc  (LB)          -->
-	<!-- Do we agree that this really is an acceptable -->
-	<!-- minimal recommendation?                       -->
-	<!-- Not at all:  it ought to have encodingDesc,   -->
-	<!-- profileDesc, and revisionDesc too.            -->
-	<!-- Which I have now added.  -msm                 -->
+        <!-- contents of the supplementary file should be  -->
+        <!-- decanted into the encodingDesc  (LB)          -->
+        <!-- Do we agree that this really is an acceptable -->
+        <!-- minimal recommendation?                       -->
+        <!-- Not at all:  it ought to have encodingDesc,   -->
+        <!-- profileDesc, and revisionDesc too.            -->
+        <!-- Which I have now added.  -msm                 -->
  </p>
 <p>Many other examples of recommended usage for the elements discussed
 in this chapter are provided here, in the reference index and in the

--- a/P5/Source/Specs/calendar.xml
+++ b/P5/Source/Specs/calendar.xml
@@ -17,6 +17,7 @@ $Id$
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.pointing"/>
+    <memberOf key="att.typed"/>
   </classes>
   <content>    
       <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>


### PR DESCRIPTION
Added `@type` to `<calendar>` to specify between real or actual and fictional calendar as per the example currently listed in the prose description for `<calendar>` in the Header (`#HD44'). Also added `@type` to the '<calendar>` example in the prose description in the Header `#HD44` for #2396. 

Needs to be reviewed by Council because this issue has not been discussed in detail prior to pushing this pull request. @jamescummings and @martindholmes any thoughts on adding `@type` to `<calendar>`?