### PR TITLE
“Deprecation” message: <content> gets 1 and only 1 child

### DIFF
--- a/P5/Source/Guidelines/en/USE.xml
+++ b/P5/Source/Guidelines/en/USE.xml
@@ -1650,11 +1650,13 @@ performance.attributes = att.global.attributes, empty]]></eg> Here, the attribut
           <elementSpec ident="sp">
             <!-- ... -->
             <content>
-              <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-              <sequence minOccurs="0" maxOccurs="1">
-                <elementRef key="speaker"/>
-                <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-              </sequence>
+	      <sequence minOccurs="1" maxOccurs="1">
+		<classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
+		<sequence minOccurs="0" maxOccurs="1">
+                  <elementRef key="speaker"/>
+                  <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+	      </sequence>
             </content>
             <!-- ... -->
           </elementSpec>
@@ -1666,8 +1668,10 @@ performance.attributes = att.global.attributes, empty]]></eg> Here, the attribut
           <elementSpec ident="sp">
             <!-- ... -->
             <content>
-              <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-              <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
+	      <sequence minOccurs="1" maxOccurs="1">
+		<classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
+                <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
+	      </sequence>
             </content>
             <!-- ... -->
           </elementSpec>
@@ -1675,8 +1679,8 @@ performance.attributes = att.global.attributes, empty]]></eg> Here, the attribut
           <ident type="class">model.global</ident> it is impossible to be sure which rule is being
         used. This situation is not detected when RELAX NG is used, since the language is able to
         cope with non-deterministic content models of this kind and does not require that only a
-        single rule be used. </p>
-      <!-- not sure if this works : needs testing : original source clearly wrong though -->
+        single rule be used.</p>
+	<!-- not sure if this works : needs testing : original source clearly wrong though -->
 
       <p>Finally, an application will need to have some method of associating the schema with
         document instances that use it. The TEI does not mandate any particular method of doing

--- a/P5/Source/Specs/TEI.xml
+++ b/P5/Source/Specs/TEI.xml
@@ -53,12 +53,13 @@ $Id$
   <constraintSpec ident="c1" scheme="schematron">
     <constraint>
       <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
-      <sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+      <sch:ns prefix="xs"  uri="http://www.w3.org/2001/XMLSchema"/>
     </constraint>
   </constraintSpec>
   <constraintSpec ident="c2" scheme="schematron">
     <constraint>
       <sch:ns prefix="rng" uri="http://relaxng.org/ns/structure/1.0"/>
+      <sch:ns prefix="rna" uri="http://relaxng.org/ns/compatibility/annotations/1.0"/>
     </constraint>
   </constraintSpec>
   <attList>

--- a/P5/Source/Specs/content.xml
+++ b/P5/Source/Specs/content.xml
@@ -54,13 +54,13 @@ $Id$
       <sch:let name="msg_part09" value="../@ident | ../@key | ../@url"/>
       <sch:let name="msg_part10" value="concat('&quot; and has ', $tot_kids, ' children,')"/>
       <sch:let name="msgs_1to10" value="concat( $msg_part01, $msg_part02, $msg_part03, $msg_part04, $msg_part05, $msg_part06, $msg_part07, $msg_part08, $msg_part09, $msg_part10 )"></sch:let>
-      <sch:report test="$tei_kids eq $tot_kids">
+      <sch:report test="$tei_kids eq $tot_kids" role="warning">
         <sch:value-of select="$msgs_1to10"/> which could be wrapped in a &lt;sequence> element.
       </sch:report>
-      <sch:report test="$rng_kids eq $tot_kids">
+      <sch:report test="$rng_kids eq $tot_kids" role="warning">
         <sch:value-of select="$msgs_1to10"/> which could be wrapped in an &lt;rng:div> element.
       </sch:report>
-      <sch:assert test="$tei_kids eq $tot_kids  or  $rng_kids eq $tot_kids">
+      <sch:assert test="$tei_kids eq $tot_kids  or  $rng_kids eq $tot_kids"   role="warning">
         <sch:value-of select="$msgs_1to10"/> but those children are neither all TEI elements nor
         all RELAX NG elements, and thus this &lt;content> is invalid and can not be easily rectified.
       </sch:assert>

--- a/P5/Source/Specs/content.xml
+++ b/P5/Source/Specs/content.xml
@@ -34,6 +34,39 @@ $Id$
       <anyElement minOccurs="1" maxOccurs="unbounded" require="http://relaxng.org/ns/compatibility/annotations/1.0 http://relaxng.org/ns/structure/1.0"/>
     </alternate>
   </content>
+  <constraintSpec ident="only_1_child_of_content" scheme="schematron">
+    <desc>A temporary constraint to give users a warning that in the
+    future the content of <gi>content</gi> will be restricted to 1 and
+    only 1 child element.</desc>
+    <constraint>
+    <sch:rule context="tei:content[ *[2] ]">
+      <sch:let name="tot_kids" value="count( * )"/>
+      <sch:let name="tei_kids" value="count( tei:* )"/>
+      <sch:let name="rng_kids" value="count( rng:* | rna:* )"/>
+      <sch:let name="msg_part01" value="'In the near future the &lt;content> element will be limited to 1 and only 1 child element. '"/>
+      <sch:let name="msg_part02" value="'This &lt;content> element is in '"/>
+      <sch:let name="msg_part03" value="if ( local-name(..) eq 'elementSpec' ) then 'an ' else 'a '"/>
+      <sch:let name="msg_part04" value="concat( local-name(..), ' with ' )"/>
+      <sch:let name="msg_part05" value="if ( parent::tei:moduleRef/@key ) then 'a @key'    else ''"/>
+      <sch:let name="msg_part06" value="if ( parent::tei:moduleRef/@url ) then 'a @url'    else ''"/>
+      <sch:let name="msg_part07" value="if ( parent::tei:*/@ident )       then 'an @ident' else ''"/>
+      <sch:let name="msg_part08" value="' of &quot;'"/>
+      <sch:let name="msg_part09" value="../@ident | ../@key | ../@url"/>
+      <sch:let name="msg_part10" value="concat('&quot; and has ', $tot_kids, ' children,')"/>
+      <sch:let name="msgs_1to10" value="concat( $msg_part01, $msg_part02, $msg_part03, $msg_part04, $msg_part05, $msg_part06, $msg_part07, $msg_part08, $msg_part09, $msg_part10 )"></sch:let>
+      <sch:report test="$tei_kids eq $tot_kids">
+        <sch:value-of select="$msgs_1to10"/> which could be wrapped in a &lt;sequence> element.
+      </sch:report>
+      <sch:report test="$rng_kids eq $tot_kids">
+        <sch:value-of select="$msgs_1to10"/> which could be wrapped in an &lt;rng:div> element.
+      </sch:report>
+      <sch:assert test="$tei_kids eq $tot_kids  or  $rng_kids eq $tot_kids">
+        <sch:value-of select="$msgs_1to10"/> but those children are neither all TEI elements nor
+        all RELAX NG elements, and thus this &lt;content> is invalid and can not be easily rectified.
+      </sch:assert>
+    </sch:rule>
+    </constraint>
+  </constraintSpec>
   <attList>
     <attDef ident="autoPrefix">
       <desc versionDate="2010-05-13" xml:lang="en">controls whether or

--- a/P5/Source/Specs/sp.xml
+++ b/P5/Source/Specs/sp.xml
@@ -36,14 +36,10 @@
   </classes>
   <content>
     <sequence>
-      
-        <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-      
+      <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
       <sequence minOccurs="0">
         <elementRef key="speaker"/>
-        
-          <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-        
+        <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
       </sequence>
       <sequence minOccurs="1" maxOccurs="unbounded">
         <alternate>


### PR DESCRIPTION
Here is what I did:

- Created Schematron constraint, as a separate file for easy testing
- Ran it on all .xml, .tei, .odd, and .plodd files in the ATOP repository (there are a lot of ODD files there to be used as tests)
- Found that it seemed to work perfectly — it found lots of cases of 2+ children of `<content>` that were either all TEI elements or all RELAX NG elements; also found 2 cases in which there was a mix. I spot-checked 2–3 of each of the former cases and the 2 mixes, too.
- Moved the Schematron into P5/Sourece/Specs/content.xml in `<constraintSpec ident="only_1_child_of_content">`.
- That constraint needs the RELAX NG annotation namespace to be declared, so added an `<sch:ns>` to TEI.xml (in "c2"), binding the namespace to the prefix “rna:”.
- Built the _Guidelines_ with `make clean validate html-web test exemplars` in the Docker environment.
- Found 1 failure — 2 examples in USE had 2+ children of `<content>`.
- Fixed those errors. (Also tweaked some whitespace in sp.xml while I was at it.)
- Built again, no errors.

Here is what the warning messages look like (whitespace altered for readability) …

2+ TEI children:
~~~
In the near future the <content> element will be limited to 1 and
only 1 child element. This <content> element is in an elementSpec
with an @ident of "constraintSpec" and has 2 children, which
could be wrapped in a <sequence> element.
~~~
 
2+ RELAX NG children:
~~~
In the near future the <content> element will be limited to 1 and
only 1 child element. This <content> element is in a moduleRef
with a @url of "http://www.w3.org/Math/RelaxNG/mathml3/mathml3.rng"
and has 2 children, which could be wrapped in an <rng:div> element.
~~~

2+ children, not all TEI, not all RELAX NG:
~~~
In the near future the <content> element will be limited to 1 and
only 1 child element. This <content> element is in an elementSpec
with an @ident of "publicationStmt" and has 3 children, but those
children are neither all TEI elements nor all RELAX NG elements,
and thus this <content> is invalid and can not be easily rectified.
~~~

What I did *not* do was use role="warning" on the `<sch:assert>` and `<sch:report>` elements. I probably should have, and may well fix that and commit shortly.