### PR TITLE
abide by “`<content>` has 1 and only 1 child” rule, step 1

### DIFF
--- a/P5/Exemplars/tei_its.odd
+++ b/P5/Exemplars/tei_its.odd
@@ -69,12 +69,14 @@
       <moduleRef key="textstructure"/>
       <moduleRef url="https://www.tei-c.org/release/xml/tei/Exemplars/its.rng">
       	<content>
-	  <rng:define name="tei_model.teiHeaderPart" combine="choice">
-	    <rng:ref name="its_rules"/>
-	  </rng:define>
-	  <rng:define name="tei_model.inter" combine="choice">
-	    <rng:ref name="its_span"/>
-	  </rng:define>
+	  <rng:div>
+	    <rng:define name="tei_model.teiHeaderPart" combine="choice">
+	      <rng:ref name="its_rules"/>
+	    </rng:define>
+	    <rng:define name="tei_model.inter" combine="choice">
+	      <rng:ref name="its_span"/>
+	    </rng:define>
+	  </rng:div>
 	</content>
       </moduleRef>
       <classSpec ident="att.global" type="atts" mode="change">

--- a/P5/Test/testplus.odd
+++ b/P5/Test/testplus.odd
@@ -7,7 +7,7 @@
         <author>Sebastian Rahtz</author>
       </titleStmt>
       <publicationStmt>
-	<publisher>TEI Consortium</publisher>
+        <publisher>TEI Consortium</publisher>
         <availability status="free">
           <p>This template file is freely available and you are hereby
             authorised to copy, modify, and redistribute it in any way without
@@ -72,12 +72,14 @@
 
         <moduleRef url="its.rng">
           <content>
-            <rng:define name="tei_model.teiHeaderPart" combine="choice">
-              <rng:ref name="its_rules"/>
-            </rng:define>
-            <rng:define name="tei_model.inter" combine="choice">
-              <rng:ref name="its_span"/>
-            </rng:define>
+            <rng:div>
+              <rng:define name="tei_model.teiHeaderPart" combine="choice">
+                <rng:ref name="its_rules"/>
+              </rng:define>
+              <rng:define name="tei_model.inter" combine="choice">
+                <rng:ref name="its_span"/>
+              </rng:define>
+            </rng:div>
           </content>
         </moduleRef>
         <classSpec ident="att.global" type="atts" mode="change">
@@ -113,78 +115,78 @@
           </content>
         </elementSpec>
       <elementSpec 
-	  xmlns:rng="http://relaxng.org/ns/structure/1.0"
-	  ident="include" 
-	  ns="http://www.w3.org/2001/XInclude" 
-	  mode="add">
-	<desc xml:lang="en" versionDate="2014-01-12">The W3C XInclude element</desc>
-	<classes>
-	  <memberOf key="model.common"/>
-	  <memberOf key="model.teiHeaderPart"/>
-	  <memberOf key="model.graphicLike"/>
-	</classes>
-	<content>
-	  <rng:optional>
-	    <rng:ref name="fallback"/>
-	  </rng:optional>
-	</content>
-	<attList>
-	  <attDef ident="href">
-	    <desc xml:lang="en" versionDate="2014-01-12">pointer to the resource being included</desc>
-	    <datatype>
-	      <rng:ref name="data.pointer"/>
-	    </datatype>
-	  </attDef>
-	  
-	  <attDef ident="parse"  usage="opt">
-	    <defaultVal>xml</defaultVal>
-	    <valList type="closed">
-	      <valItem ident="xml"/>
-	      <valItem ident="text"/>
-	    </valList>
-	  </attDef>
-	  
-	  <attDef ident="xpointer" usage="opt">
-	    <datatype>
-	      <rng:text/>
-	    </datatype>
-	  </attDef>
-	  
-	  <attDef ident="encoding"  usage="opt">
-	    <datatype>
-	      <rng:text/>
-	    </datatype>
-	  </attDef>
-	  
-	  <attDef ident="accept" usage="opt">
-	    <datatype>
-	      <rng:text/>
-	    </datatype>
-	  </attDef>
-	  
-	  <attDef ident="accept-charset"  usage="opt">
-	    <datatype>
-	      <rng:text/>
-	    </datatype>
-	  </attDef>
-	  
-	  <attDef ident="accept-language"  usage="opt">
-	    <datatype>
-	      <rng:text/>
-	    </datatype>
-	  </attDef>
-	</attList>
+          xmlns:rng="http://relaxng.org/ns/structure/1.0"
+          ident="include" 
+          ns="http://www.w3.org/2001/XInclude" 
+          mode="add">
+        <desc xml:lang="en" versionDate="2014-01-12">The W3C XInclude element</desc>
+        <classes>
+          <memberOf key="model.common"/>
+          <memberOf key="model.teiHeaderPart"/>
+          <memberOf key="model.graphicLike"/>
+        </classes>
+        <content>
+          <rng:optional>
+            <rng:ref name="fallback"/>
+          </rng:optional>
+        </content>
+        <attList>
+          <attDef ident="href">
+            <desc xml:lang="en" versionDate="2014-01-12">pointer to the resource being included</desc>
+            <datatype>
+              <rng:ref name="data.pointer"/>
+            </datatype>
+          </attDef>
+          
+          <attDef ident="parse"  usage="opt">
+            <defaultVal>xml</defaultVal>
+            <valList type="closed">
+              <valItem ident="xml"/>
+              <valItem ident="text"/>
+            </valList>
+          </attDef>
+          
+          <attDef ident="xpointer" usage="opt">
+            <datatype>
+              <rng:text/>
+            </datatype>
+          </attDef>
+          
+          <attDef ident="encoding"  usage="opt">
+            <datatype>
+              <rng:text/>
+            </datatype>
+          </attDef>
+          
+          <attDef ident="accept" usage="opt">
+            <datatype>
+              <rng:text/>
+            </datatype>
+          </attDef>
+          
+          <attDef ident="accept-charset"  usage="opt">
+            <datatype>
+              <rng:text/>
+            </datatype>
+          </attDef>
+          
+          <attDef ident="accept-language"  usage="opt">
+            <datatype>
+              <rng:text/>
+            </datatype>
+          </attDef>
+        </attList>
       </elementSpec>
       
       <elementSpec 
-	  xmlns:rng="http://relaxng.org/ns/structure/1.0"
-	  ident="fallback" 
-	  ns="http://www.w3.org/2001/XInclude" 
-	  mode="add">
-	<desc xml:lang="en" versionDate="2014-01-12">Wrapper for fallback elements if an XInclude fails</desc>
-	<content>
-	  <rng:ref name="anyThing"/>
-	</content>
+          xmlns:rng="http://relaxng.org/ns/structure/1.0"
+          ident="fallback" 
+          ns="http://www.w3.org/2001/XInclude" 
+          mode="add">
+        <desc xml:lang="en" versionDate="2014-01-12">Wrapper for fallback elements if an XInclude fails</desc>
+        <content>
+          <rng:ref name="anyThing"/>
+        </content>
       </elementSpec>
         <macroSpec ident="anyThing" mode="add">
           <content>

--- a/P5/Utilities/TEI-to-tei_customization.xslt
+++ b/P5/Utilities/TEI-to-tei_customization.xslt
@@ -53,6 +53,11 @@
 
   <xsl:variable name="revisionDesc">
     <revisionDesc>
+      <change who="#sbauman.emt" when="2023-04-04">
+	We will soon not allow more than 1 child of <gi>content</gi>,
+	so updated the content model of <gi>schemaSpec</gi> to have
+	only 1 child (in this case, <gi>sequence</gi>).
+      </change>
       <change who="#sbauman.emt" when="2022-06-25">
         Since <ref
         target="https://github.com/TEIC/TEI/issues/1735">TEI ticket
@@ -721,12 +726,14 @@
 
               <elementSpec module="tagdocs" ident="schemaSpec" mode="change">
                 <content>
-                  <elementRef key="gloss" minOccurs="0" maxOccurs="1"/>
-                  <elementRef key="desc"  minOccurs="1" maxOccurs="1"/>
-                  <alternate minOccurs="0" maxOccurs="unbounded">
-                    <classRef key="model.oddRef"/>
-                    <classRef key="model.oddDecl"/>
-                  </alternate>
+		  <sequence>
+                    <elementRef key="gloss" minOccurs="0" maxOccurs="1"/>
+                    <elementRef key="desc"  minOccurs="1" maxOccurs="1"/>
+                    <alternate minOccurs="0" maxOccurs="unbounded">
+                      <classRef key="model.oddRef"/>
+                      <classRef key="model.oddDecl"/>
+                    </alternate>
+		  </sequence>
                 </content>
                 <constraintSpec scheme="schematron" ident="required-modules">
                   <gloss>required modules</gloss>


### PR DESCRIPTION
This PR addresses #2411 by wrapping the content of `<content>` elements that have 2+ child elements in either `<rng:div>` or `<sequence>` in Exemplars and a Test/ file that is used by `make test`.

NOTE:
There are still 7 files in Test/ that have 1 or more `<content>` elements that have 2 or more child elements:
~~~
 Test/test-newodd.xml: 10
 Test/testdocbook3.odd: 1
 Test/testdocbook2.odd: 1
 Test/testnym.odd: 1
 Test/testdocbook1.odd: 1
 Test/testdocbook5.odd: 1
 Test/testdocbook4.odd: 3
~~~
However, it seems these are not executed by `make test`, and thus will not affect the build. Thus, **for now** I have not changed them. If & when this PR is merged & closed _the ticket should remain open_ so that those other files can be repaired. 