### PR TITLE
guidelines.xsl generation update

### DIFF
--- a/P5/Makefile
+++ b/P5/Makefile
@@ -78,10 +78,7 @@ html-web.stamp:  check.stamp p5.xml  Utilities/guidelines.xsl.model
 	@# remove vestiges of previous run
 	rm -rf Guidelines-web
 	@# generate XSL stylesheet by modifying paths in our model stylesheet
-	perl -p -e \
-		"s+http://www.tei-c.org/release/xml/tei/stylesheet+${XSL}+; \
-		 s+/usr/share/xml/tei/stylesheet+${XSL}+;" \
-		Utilities/guidelines.xsl.model > Utilities/guidelines.xsl
+	java -jar Utilities/lib/${SAXONJAR} -s:Utilities/guidelines.xsl.model -xsl:Utilities/guidelines_model_2_executable.xslt -o:Utilities/guidelines.xsl
 	@# for each language, create a subdirectory and pre-populate it with CSS, source, and web navigation stuff
 	for i in $(ALLLANGUAGES) ;do \
 		mkdir -p Guidelines-web/$$i/html; \
@@ -142,10 +139,7 @@ fonttest:
 pdf-init: check.stamp p5.xml Utilities/guidelines-latex.xsl
 	@echo check if XeLaTeX exist
 	@command -v xelatex || exit 1
-	perl -p -e \
-		"s+http://www.tei-c.org/release/xml/tei/stylesheet+${XSL}+; \
-		 s+/usr/share/xml/tei/stylesheet+${XSL}+;" \
-		Utilities/guidelines-latex.xsl > Utilities/guidelines.xsl
+	java -jar Utilities/lib/${SAXONJAR} -s:Utilities/guidelines-latex.xsl -xsl:Utilities/guidelines_model_2_executable.xslt -o:Utilities/guidelines.xsl
 	@echo BUILD: build Lite version of Guidelines, then LaTeX version of Guidelines from Lite, then run to PDF using XeLaTeX
 	@echo Make sure you have Junicode and Noto CJK fonts installed
 	${ANT} -lib Utilities/lib/${SAXONJAR} -f antbuilder.xml -DXSL=${XSL} -DXELATEX=${XELATEX} pdfonce

--- a/P5/Utilities/guidelines-latex.xsl
+++ b/P5/Utilities/guidelines-latex.xsl
@@ -437,7 +437,7 @@
 <xsl:template name="latexEnd">
 <xsl:text>\include{Guidelines-index}
 </xsl:text>
-<xsl:result-document href="Guidelines-index.tex" method="text" encoding="utf8">
+<xsl:result-document href="Guidelines-index.tex" method="text" encoding="UTF-8">
 \cleardoublepage
 \pdfbookmark[0]{Index}{INDEX}
 \hypertarget{INDEX}{}
@@ -462,7 +462,7 @@
     <xsl:result-document 
         href="Guidelines-{@xml:id}.tex" 
         method="text" 
-        encoding="utf8">
+        encoding="UTF-8">
     <xsl:apply-templates/>
     </xsl:result-document>
   </xsl:template>
@@ -474,7 +474,7 @@
     <xsl:result-document 
         href="Guidelines-toc.tex" 
         method="text" 
-        encoding="utf8">
+        encoding="UTF-8">
       \tableofcontents
     </xsl:result-document>
   </xsl:template>
@@ -486,7 +486,7 @@
     <xsl:result-document 
         href="Guidelines-titlepage.tex" 
         method="text" 
-        encoding="utf8">
+        encoding="UTF-8">
   \begin{titlepage}
 \begin{center}
 \vfill

--- a/P5/Utilities/guidelines-latex.xsl
+++ b/P5/Utilities/guidelines-latex.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet
-  exclude-result-prefixes="xlink dbk rng tei teix xhtml a html xd xs xsl"
-  version="2.0"
+  version="3.0"
+  exclude-result-prefixes="#all"
   xmlns="http://www.w3.org/1999/xhtml"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:dbk="http://docbook.org/ns/docbook"
@@ -14,100 +14,100 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
-<xsl:import href="/usr/share/xml/tei/stylesheet/latex/latex.xsl"/>
-<xsl:output method="text"/>
- <xsl:strip-space elements="tei:additional tei:address tei:adminInfo
-			    tei:altGrp tei:altIdentifier tei:analytic
-			    tei:app tei:appInfo tei:application
-			    tei:arc tei:argument tei:attDef
-			    tei:attList tei:availability tei:back
-			    tei:biblFull tei:biblStruct tei:bicond
-			    tei:binding tei:bindingDesc tei:body
-			    tei:broadcast tei:cRefPattern tei:calendar
-			    tei:calendarDesc tei:castGroup
-			    tei:castList tei:category tei:certainty
-			    tei:char tei:charDecl tei:charProp
-			    tei:choice tei:cit tei:classDecl
-			    tei:classSpec tei:classes tei:climate
-			    tei:cond tei:constraintSpec tei:correction
-			    tei:custodialHist tei:decoDesc
-			    tei:dimensions tei:div tei:div1 tei:div2
-			    tei:div3 tei:div4 tei:div5 tei:div6
-			    tei:div7 tei:divGen tei:docTitle tei:eLeaf
-			    tei:eTree tei:editionStmt
-			    tei:editorialDecl tei:elementSpec
-			    tei:encodingDesc tei:entry tei:epigraph
-			    tei:epilogue tei:equipment tei:event
-			    tei:exemplum tei:fDecl tei:fLib
-			    tei:facsimile tei:figure tei:fileDesc
-			    tei:floatingText tei:forest tei:front
-			    tei:fs tei:fsConstraints tei:fsDecl
-			    tei:fsdDecl tei:fvLib tei:gap tei:glyph
-			    tei:graph tei:graphic tei:group
-			    tei:handDesc tei:handNotes tei:history
-			    tei:hom tei:hyphenation tei:iNode tei:if
-			    tei:imprint tei:incident tei:index
-			    tei:interpGrp tei:interpretation tei:join
-			    tei:joinGrp tei:keywords tei:kinesic
-			    tei:langKnowledge tei:langUsage
-			    tei:layoutDesc tei:leaf tei:lg tei:linkGrp
-			    tei:list tei:listBibl tei:listChange
-			    tei:listEvent tei:listForest tei:listNym
-			    tei:listOrg tei:listPerson tei:listPlace
-			    tei:listRef tei:listRelation
-			    tei:listTranspose tei:listWit tei:location
-			    tei:locusGrp tei:macroSpec tei:metDecl
-			    tei:moduleRef tei:moduleSpec tei:monogr
-			    tei:msContents tei:msDesc tei:msIdentifier
-			    tei:msItem tei:msItemStruct tei:msPart
-			    tei:namespace tei:node tei:normalization
-			    tei:notatedMusic tei:notesStmt tei:nym
-			    tei:objectDesc tei:org tei:particDesc
-			    tei:performance tei:person tei:personGrp
-			    tei:physDesc tei:place tei:population
-			    tei:postscript tei:precision
-			    tei:profileDesc tei:projectDesc
-			    tei:prologue tei:publicationStmt
-			    tei:quotation tei:rdgGrp tei:recordHist
-			    tei:recording tei:recordingStmt
-			    tei:refsDecl tei:relatedItem tei:relation
-			    tei:relationGrp tei:remarks tei:respStmt
-			    tei:respons tei:revisionDesc tei:root
-			    tei:row tei:samplingDecl tei:schemaSpec
-			    tei:scriptDesc tei:scriptStmt tei:seal
-			    tei:sealDesc tei:segmentation
-			    tei:seriesStmt tei:set tei:setting
-			    tei:settingDesc tei:sourceDesc
-			    tei:sourceDoc tei:sp tei:spGrp tei:space
-			    tei:spanGrp tei:specGrp tei:specList
-			    tei:state tei:stdVals tei:subst
-			    tei:substJoin tei:superEntry
-			    tei:supportDesc tei:surface tei:surfaceGrp
-			    tei:table tei:tagsDecl tei:taxonomy
-			    tei:teiCorpus tei:teiHeader tei:terrain
-			    tei:text tei:textClass tei:textDesc
-			    tei:timeline tei:titlePage tei:titleStmt
-			    tei:trait tei:transpose tei:tree
-			    tei:triangle tei:typeDesc tei:vAlt
-			    tei:vColl tei:vDefault tei:vLabel
-			    tei:vMerge tei:vNot tei:vRange tei:valItem
-			    tei:valList tei:vocal"/>
-<xsl:param name="reencode">false</xsl:param>
-<xsl:param name="numberBackHeadings">true</xsl:param>
-<xsl:param name="numberFrontHeadings">true</xsl:param>
-<xsl:param name="spaceCharacter">\hspace*{1em}</xsl:param>
-<xsl:param name="classParameters">11pt,twoside</xsl:param>
-<xsl:param name="startNamespace"></xsl:param>
-<xsl:param name="tocNumberSuffix">.\ </xsl:param>
-<xsl:param name="numberSpacer">\ </xsl:param>
-<xsl:param name="specLinkDepth">1</xsl:param>
-<xsl:param name="exampleFont">DejaVu Sans Mono</xsl:param>
-<xsl:param name="typewriterFont">DejaVu Sans Mono</xsl:param>
-<xsl:param name="sansFont">DejaVu Sans Mono</xsl:param>
-<xsl:param name="romanFont">Linux Libertine O</xsl:param>
-<xsl:param name="chineseFont">Noto Sans CJK SC</xsl:param>
-<xsl:param name="koreanFont">Noto Sans CJK KR</xsl:param>
-<xsl:param name="japaneseFont">Noto Sans CJK JP</xsl:param>
+  <xsl:import href="/usr/share/xml/tei/stylesheet/latex/latex.xsl"/>
+  <xsl:output method="text"/>
+  <xsl:strip-space elements="tei:additional tei:address tei:adminInfo
+                             tei:altGrp tei:altIdentifier tei:analytic
+                             tei:app tei:appInfo tei:application
+                             tei:arc tei:argument tei:attDef
+                             tei:attList tei:availability tei:back
+                             tei:biblFull tei:biblStruct tei:bicond
+                             tei:binding tei:bindingDesc tei:body
+                             tei:broadcast tei:cRefPattern tei:calendar
+                             tei:calendarDesc tei:castGroup
+                             tei:castList tei:category tei:certainty
+                             tei:char tei:charDecl tei:charProp
+                             tei:choice tei:cit tei:classDecl
+                             tei:classSpec tei:classes tei:climate
+                             tei:cond tei:constraintSpec tei:correction
+                             tei:custodialHist tei:decoDesc
+                             tei:dimensions tei:div tei:div1 tei:div2
+                             tei:div3 tei:div4 tei:div5 tei:div6
+                             tei:div7 tei:divGen tei:docTitle tei:eLeaf
+                             tei:eTree tei:editionStmt
+                             tei:editorialDecl tei:elementSpec
+                             tei:encodingDesc tei:entry tei:epigraph
+                             tei:epilogue tei:equipment tei:event
+                             tei:exemplum tei:fDecl tei:fLib
+                             tei:facsimile tei:figure tei:fileDesc
+                             tei:floatingText tei:forest tei:front
+                             tei:fs tei:fsConstraints tei:fsDecl
+                             tei:fsdDecl tei:fvLib tei:gap tei:glyph
+                             tei:graph tei:graphic tei:group
+                             tei:handDesc tei:handNotes tei:history
+                             tei:hom tei:hyphenation tei:iNode tei:if
+                             tei:imprint tei:incident tei:index
+                             tei:interpGrp tei:interpretation tei:join
+                             tei:joinGrp tei:keywords tei:kinesic
+                             tei:langKnowledge tei:langUsage
+                             tei:layoutDesc tei:leaf tei:lg tei:linkGrp
+                             tei:list tei:listBibl tei:listChange
+                             tei:listEvent tei:listForest tei:listNym
+                             tei:listOrg tei:listPerson tei:listPlace
+                             tei:listRef tei:listRelation
+                             tei:listTranspose tei:listWit tei:location
+                             tei:locusGrp tei:macroSpec tei:metDecl
+                             tei:moduleRef tei:moduleSpec tei:monogr
+                             tei:msContents tei:msDesc tei:msIdentifier
+                             tei:msItem tei:msItemStruct tei:msPart
+                             tei:namespace tei:node tei:normalization
+                             tei:notatedMusic tei:notesStmt tei:nym
+                             tei:objectDesc tei:org tei:particDesc
+                             tei:performance tei:person tei:personGrp
+                             tei:physDesc tei:place tei:population
+                             tei:postscript tei:precision
+                             tei:profileDesc tei:projectDesc
+                             tei:prologue tei:publicationStmt
+                             tei:quotation tei:rdgGrp tei:recordHist
+                             tei:recording tei:recordingStmt
+                             tei:refsDecl tei:relatedItem tei:relation
+                             tei:relationGrp tei:remarks tei:respStmt
+                             tei:respons tei:revisionDesc tei:root
+                             tei:row tei:samplingDecl tei:schemaSpec
+                             tei:scriptDesc tei:scriptStmt tei:seal
+                             tei:sealDesc tei:segmentation
+                             tei:seriesStmt tei:set tei:setting
+                             tei:settingDesc tei:sourceDesc
+                             tei:sourceDoc tei:sp tei:spGrp tei:space
+                             tei:spanGrp tei:specGrp tei:specList
+                             tei:state tei:stdVals tei:subst
+                             tei:substJoin tei:superEntry
+                             tei:supportDesc tei:surface tei:surfaceGrp
+                             tei:table tei:tagsDecl tei:taxonomy
+                             tei:teiCorpus tei:teiHeader tei:terrain
+                             tei:text tei:textClass tei:textDesc
+                             tei:timeline tei:titlePage tei:titleStmt
+                             tei:trait tei:transpose tei:tree
+                             tei:triangle tei:typeDesc tei:vAlt
+                             tei:vColl tei:vDefault tei:vLabel
+                             tei:vMerge tei:vNot tei:vRange tei:valItem
+                             tei:valList tei:vocal"/>
+  <xsl:param name="reencode">false</xsl:param>
+  <xsl:param name="numberBackHeadings">true</xsl:param>
+  <xsl:param name="numberFrontHeadings">true</xsl:param>
+  <xsl:param name="spaceCharacter">\hspace*{1em}</xsl:param>
+  <xsl:param name="classParameters">11pt,twoside</xsl:param>
+  <xsl:param name="startNamespace"></xsl:param>
+  <xsl:param name="tocNumberSuffix">.\ </xsl:param>
+  <xsl:param name="numberSpacer">\ </xsl:param>
+  <xsl:param name="specLinkDepth">1</xsl:param>
+  <xsl:param name="exampleFont">DejaVu Sans Mono</xsl:param>
+  <xsl:param name="typewriterFont">DejaVu Sans Mono</xsl:param>
+  <xsl:param name="sansFont">DejaVu Sans Mono</xsl:param>
+  <xsl:param name="romanFont">Linux Libertine O</xsl:param>
+  <xsl:param name="chineseFont">Noto Sans CJK SC</xsl:param>
+  <xsl:param name="koreanFont">Noto Sans CJK KR</xsl:param>
+  <xsl:param name="japaneseFont">Noto Sans CJK JP</xsl:param>
 
 
   <xsl:variable name="docClass">book</xsl:variable>
@@ -161,7 +161,7 @@
 \def\sectionmark#1{\markright { \ifnum \c@secnumdepth >\z@
           \thesection. \ %
         \fi
-	#1}}
+        #1}}
 \def\egxmlcite#1{\raisebox{12pt}[0pt][0pt]{\parbox{.95\textwidth}{\raggedleft #1}}}
 \def\oddindex#1{{\bfseries\hyperpage{#1}}}
 \def\exampleindex#1{{\itshape\hyperpage{#1}}}
@@ -299,7 +299,7 @@
     </xsl:when>
     <xsl:otherwise>
       <xsl:call-template name="makePreamble-complex">
-	<xsl:with-param name="r" select="$r"/>
+        <xsl:with-param name="r" select="$r"/>
       </xsl:call-template>
     </xsl:otherwise>
   </xsl:choose>
@@ -308,12 +308,12 @@
   <xsl:choose>
     <xsl:when test="tei:head and not(@rend='display')">
       <xsl:if test="not(ancestor::tei:table)">
-	<xsl:text>\endfirsthead </xsl:text>
-	<xsl:text>\multicolumn{</xsl:text>
-	<xsl:value-of select="count(tei:row[1]/tei:cell)"/>
-	<xsl:text>}{c}{</xsl:text>
-	<xsl:apply-templates mode="ok" select="tei:head"/>
-	<xsl:text>(cont.)}\\\hline \endhead </xsl:text>
+        <xsl:text>\endfirsthead </xsl:text>
+        <xsl:text>\multicolumn{</xsl:text>
+        <xsl:value-of select="count(tei:row[1]/tei:cell)"/>
+        <xsl:text>}{c}{</xsl:text>
+        <xsl:apply-templates mode="ok" select="tei:head"/>
+        <xsl:text>(cont.)}\\\hline \endhead </xsl:text>
       </xsl:if>
       <xsl:text>\caption{</xsl:text>
       <xsl:apply-templates mode="ok" select="tei:head"/>
@@ -338,20 +338,20 @@
     <xsl:text> \par</xsl:text>
     <xsl:choose>
       <xsl:when test="@rend='wovenodd' or @rend='attList' or
-		      @rend='valList' or @rend='attDef'"> 
-	<xsl:text>\begin{small}\begin{tabular}</xsl:text>
-	<xsl:call-template name="makeTable"/>
-	<xsl:text>\end{tabular}\end{small}\par</xsl:text>
+                      @rend='valList' or @rend='attDef'"> 
+        <xsl:text>\begin{small}\begin{tabular}</xsl:text>
+        <xsl:call-template name="makeTable"/>
+        <xsl:text>\end{tabular}\end{small}\par</xsl:text>
       </xsl:when>
       <xsl:when test="ancestor::tei:table"> 
-	<xsl:text>\begin{tabular}</xsl:text>
-	<xsl:call-template  name="makeTable"/> 
-	<xsl:text>\end{tabular}</xsl:text>
+        <xsl:text>\begin{tabular}</xsl:text>
+        <xsl:call-template  name="makeTable"/> 
+        <xsl:text>\end{tabular}</xsl:text>
       </xsl:when>
       <xsl:otherwise> 
-	<xsl:text>\begin{longtable}</xsl:text>
-	<xsl:call-template name="makeTable"/>
-	<xsl:text>\end{longtable} \par</xsl:text>
+        <xsl:text>\begin{longtable}</xsl:text>
+        <xsl:call-template name="makeTable"/>
+        <xsl:text>\end{longtable} \par</xsl:text>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -450,7 +450,7 @@
     <xsl:if test="count(ancestor::tei:div)&lt;3">
       <xsl:number count="tei:div" format="i.1.1" level="multiple"/>
       <xsl:if test="$minimal='false'">
-	<xsl:value-of select="$numberSpacer"/>
+        <xsl:value-of select="$numberSpacer"/>
       </xsl:if>
     </xsl:if>
   </xsl:template>
@@ -460,9 +460,9 @@
     <xsl:value-of select="@xml:id"/>
     <xsl:text>}&#10;</xsl:text>
     <xsl:result-document 
-	href="Guidelines-{@xml:id}.tex" 
-	method="text" 
-	encoding="utf8">
+        href="Guidelines-{@xml:id}.tex" 
+        method="text" 
+        encoding="utf8">
     <xsl:apply-templates/>
     </xsl:result-document>
   </xsl:template>
@@ -472,9 +472,9 @@
 \include{Guidelines-toc} 
 </xsl:text>
     <xsl:result-document 
-	href="Guidelines-toc.tex" 
-	method="text" 
-	encoding="utf8">
+        href="Guidelines-toc.tex" 
+        method="text" 
+        encoding="utf8">
       \tableofcontents
     </xsl:result-document>
   </xsl:template>
@@ -484,9 +484,9 @@
 \include{Guidelines-titlepage} 
 </xsl:text>
     <xsl:result-document 
-	href="Guidelines-titlepage.tex" 
-	method="text" 
-	encoding="utf8">
+        href="Guidelines-titlepage.tex" 
+        method="text" 
+        encoding="utf8">
   \begin{titlepage}
 \begin{center}
 \vfill
@@ -537,5 +537,3 @@
 
 
 </xsl:stylesheet>
-
-

--- a/P5/Utilities/guidelines-print.xsl
+++ b/P5/Utilities/guidelines-print.xsl
@@ -19,7 +19,7 @@
   <xsl:output method="xml"
               doctype-public="//W3C//DTD XHTML 1.1//EN"
               doctype-system="http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"
-              encoding="utf-8"
+              encoding="UTF-8"
               />  
   
   <xsl:param name="autoToc">true</xsl:param>

--- a/P5/Utilities/guidelines-print.xsl
+++ b/P5/Utilities/guidelines-print.xsl
@@ -1,47 +1,45 @@
 <xsl:stylesheet
-  exclude-result-prefixes="xlink dbk rng tei teix xhtml a html xd xs xsl"
-  version="2.0"
-  xmlns="http://www.w3.org/1999/xhtml"
-  xmlns:xlink="http://www.w3.org/1999/xlink"
-  xmlns:dbk="http://docbook.org/ns/docbook"
-  xmlns:rng="http://relaxng.org/ns/structure/1.0"
-  xmlns:tei="http://www.tei-c.org/ns/1.0"
-  xmlns:teix="http://www.tei-c.org/ns/Examples"
-  xmlns:xhtml="http://www.w3.org/1999/xhtml"
-  xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-  xmlns:html="http://www.w3.org/1999/xhtml"
-  xmlns:xd="http://www.pnp-software.com/XSLTdoc"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    version="3.0"
+    exclude-result-prefixes="#all"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:dbk="http://docbook.org/ns/docbook"
+    xmlns:rng="http://relaxng.org/ns/structure/1.0"
+    xmlns:tei="http://www.tei-c.org/ns/1.0"
+    xmlns:teix="http://www.tei-c.org/ns/Examples"
+    xmlns:xhtml="http://www.w3.org/1999/xhtml"
+    xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+    xmlns:html="http://www.w3.org/1999/xhtml"
+    xmlns:xd="http://www.pnp-software.com/XSLTdoc"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-<xsl:import href="guidelines.xsl"/>
+  <xsl:import href="guidelines.xsl"/>
+  
+  <xsl:output method="xml"
+              doctype-public="//W3C//DTD XHTML 1.1//EN"
+              doctype-system="http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"
+              encoding="utf-8"
+              />  
+  
+  <xsl:param name="autoToc">true</xsl:param>
+  <xsl:param name="splitLevel">-1</xsl:param>
+  <xsl:param name="footnoteFile">false</xsl:param>
+  <xsl:param name="pageLayout">Simple</xsl:param>
+  <xsl:param name="cssFile">guidelines.css</xsl:param>
+  <xsl:param name="parentWords">Text Encoding Initiative Consortium</xsl:param>
+  <xsl:param name="topNavigationPanel">true</xsl:param>
+  
+  <xsl:template name="generateSubTitle"/>
 
-<xsl:output method="xml"
-	      doctype-public="//W3C//DTD XHTML 1.1//EN"
-	      doctype-system="http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"
-	      encoding="utf-8"
-	      />  
- 
-<xsl:param name="autoToc">true</xsl:param>
-<xsl:param name="splitLevel">-1</xsl:param>
-<xsl:param name="footnoteFile">false</xsl:param>
-<xsl:param name="pageLayout">Simple</xsl:param>
-<xsl:param name="cssFile">guidelines.css</xsl:param>
-<xsl:param name="parentWords">Text Encoding Initiative Consortium</xsl:param>
-<xsl:param name="topNavigationPanel">true</xsl:param>
-
-<xsl:template name="generateSubTitle"/>
-
-<xsl:template name="includeCSS">
+  <xsl:template name="includeCSS">
     <link href="{$cssFile}" rel="stylesheet" type="text/css"/>
     <xsl:if test="not($cssPrintFile='')">
       <link rel="stylesheet" media="print" type="text/css" href="{$cssPrintFile}"/>
     </xsl:if>
-</xsl:template>
+  </xsl:template>
 
-<xsl:template name="printLink"/>
-
-
+  <xsl:template name="printLink"/>
 
 </xsl:stylesheet>
 

--- a/P5/Utilities/guidelines.xsl.model
+++ b/P5/Utilities/guidelines.xsl.model
@@ -1,6 +1,6 @@
 <xsl:stylesheet
-  exclude-result-prefixes="xlink dbk rng teix xhtml a html xd  xs xsl fo tei"
   version="3.0"
+  exclude-result-prefixes="#all"
   xmlns="http://www.w3.org/1999/xhtml"
   xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
   xmlns:dbk="http://docbook.org/ns/docbook"
@@ -15,95 +15,87 @@
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-  <xsl:import
-      href="http://www.tei-c.org/release/xml/tei/stylesheet/odds/odd2html.xsl"/>
-  <xsl:import
-      href="http://www.tei-c.org/release/xml/tei/stylesheet/odds/guidelines.xsl"/>
-        <xsl:output method="xhtml" html-version="5"/>
-        <!--
-            Note:
-            Above <xsl:output> changed 2021-09-03 by SDB & MDH, but change does not seem
-            to have any effect on the Guidelines (HTML output), which still have
-            an innappropriate "about:legacy-compat" as the SYSTEM identifier. See line
-            ~139, below. Hopefully HBS will be fixing this in Stylesheets PR 499.
-        -->
 
- <xsl:strip-space elements="tei:additional tei:address tei:adminInfo
-                            tei:altGrp tei:altIdentifier tei:analytic
-                            tei:app tei:appInfo tei:application
-                            tei:arc tei:argument tei:attDef
-                            tei:attList tei:availability tei:back
-                            tei:biblFull tei:biblStruct tei:bicond
-                            tei:binding tei:bindingDesc tei:body
-                            tei:broadcast tei:cRefPattern tei:calendar
-                            tei:calendarDesc tei:castGroup
-                            tei:castList tei:category tei:certainty
-                            tei:char tei:charDecl tei:charProp
-                            tei:choice tei:cit tei:classDecl
-                            tei:classSpec tei:classes tei:climate
-                            tei:cond tei:constraintSpec tei:correction
-                            tei:custodialHist tei:decoDesc
-                            tei:dimensions tei:div tei:div1 tei:div2
-                            tei:div3 tei:div4 tei:div5 tei:div6
-                            tei:div7 tei:divGen tei:docTitle tei:eLeaf
-                            tei:eTree tei:editionStmt
-                            tei:editorialDecl tei:elementSpec
-                            tei:encodingDesc tei:entry tei:epigraph
-                            tei:epilogue tei:equipment tei:event
-                            tei:exemplum tei:fDecl tei:fLib
-                            tei:facsimile tei:figure tei:fileDesc
-                            tei:floatingText tei:forest tei:front
-                            tei:fs tei:fsConstraints tei:fsDecl
-                            tei:fsdDecl tei:fvLib tei:gap tei:glyph
-                            tei:graph tei:graphic tei:group
-                            tei:handDesc tei:handNotes tei:history
-                            tei:hom tei:hyphenation tei:iNode tei:if
-                            tei:imprint tei:incident tei:index
-                            tei:interpGrp tei:interpretation tei:join
-                            tei:joinGrp tei:keywords tei:kinesic
-                            tei:langKnowledge tei:langUsage
-                            tei:layoutDesc tei:leaf tei:lg tei:linkGrp
-                            tei:list tei:listBibl tei:listChange
-                            tei:listEvent tei:listForest tei:listNym
-                            tei:listOrg tei:listPerson tei:listPlace
-                            tei:listRef tei:listRelation
-                            tei:listTranspose tei:listWit tei:location
-                            tei:locusGrp tei:macroSpec tei:metDecl
-                            tei:moduleRef tei:moduleSpec tei:monogr
-                            tei:msContents tei:msDesc tei:msIdentifier
-                            tei:msItem tei:msItemStruct tei:msPart
-                            tei:namespace tei:node tei:normalization
-                            tei:notatedMusic tei:notesStmt tei:nym
-                            tei:objectDesc tei:org tei:particDesc
-                            tei:performance tei:person tei:personGrp
-                            tei:physDesc tei:place tei:population
-                            tei:postscript tei:precision
-                            tei:profileDesc tei:projectDesc
-                            tei:prologue tei:publicationStmt
-                            tei:quotation tei:rdgGrp tei:recordHist
-                            tei:recording tei:recordingStmt
-                            tei:refsDecl tei:relatedItem tei:relation
-                            tei:relationGrp tei:remarks tei:respStmt
-                            tei:respons tei:revisionDesc tei:root
-                            tei:row tei:samplingDecl tei:schemaSpec
-                            tei:scriptDesc tei:scriptStmt tei:seal
-                            tei:sealDesc tei:segmentation
-                            tei:seriesStmt tei:set tei:setting
-                            tei:settingDesc tei:sourceDesc
-                            tei:sourceDoc tei:sp tei:spGrp tei:space
-                            tei:spanGrp tei:specGrp tei:specList
-                            tei:state tei:stdVals tei:subst
-                            tei:substJoin tei:superEntry
-                            tei:supportDesc tei:surface tei:surfaceGrp
-                            tei:table tei:tagsDecl tei:taxonomy
-                            tei:teiCorpus tei:teiHeader tei:terrain
-                            tei:text tei:textClass tei:textDesc
-                            tei:timeline tei:titlePage tei:titleStmt
-                            tei:trait tei:transpose tei:tree
-                            tei:triangle tei:typeDesc tei:vAlt
-                            tei:vColl tei:vDefault tei:vLabel
-                            tei:vMerge tei:vNot tei:vRange tei:valItem
-                            tei:valList tei:vocal"/>
+  <xsl:import href="http://www.tei-c.org/release/xml/tei/stylesheet/odds/odd2html.xsl"/>
+  <xsl:import href="http://www.tei-c.org/release/xml/tei/stylesheet/odds/guidelines.xsl"/>
+  <xsl:output method="xhtml" html-version="5"/>
+
+  <xsl:strip-space elements="tei:additional tei:address tei:adminInfo
+                             tei:altGrp tei:altIdentifier tei:analytic
+                             tei:app tei:appInfo tei:application
+                             tei:arc tei:argument tei:attDef
+                             tei:attList tei:availability tei:back
+                             tei:biblFull tei:biblStruct tei:bicond
+                             tei:binding tei:bindingDesc tei:body
+                             tei:broadcast tei:cRefPattern tei:calendar
+                             tei:calendarDesc tei:castGroup
+                             tei:castList tei:category tei:certainty
+                             tei:char tei:charDecl tei:charProp
+                             tei:choice tei:cit tei:classDecl
+                             tei:classSpec tei:classes tei:climate
+                             tei:cond tei:constraintSpec tei:correction
+                             tei:custodialHist tei:decoDesc
+                             tei:dimensions tei:div tei:div1 tei:div2
+                             tei:div3 tei:div4 tei:div5 tei:div6
+                             tei:div7 tei:divGen tei:docTitle tei:eLeaf
+                             tei:eTree tei:editionStmt
+                             tei:editorialDecl tei:elementSpec
+                             tei:encodingDesc tei:entry tei:epigraph
+                             tei:epilogue tei:equipment tei:event
+                             tei:exemplum tei:fDecl tei:fLib
+                             tei:facsimile tei:figure tei:fileDesc
+                             tei:floatingText tei:forest tei:front
+                             tei:fs tei:fsConstraints tei:fsDecl
+                             tei:fsdDecl tei:fvLib tei:gap tei:glyph
+                             tei:graph tei:graphic tei:group
+                             tei:handDesc tei:handNotes tei:history
+                             tei:hom tei:hyphenation tei:iNode tei:if
+                             tei:imprint tei:incident tei:index
+                             tei:interpGrp tei:interpretation tei:join
+                             tei:joinGrp tei:keywords tei:kinesic
+                             tei:langKnowledge tei:langUsage
+                             tei:layoutDesc tei:leaf tei:lg tei:linkGrp
+                             tei:list tei:listBibl tei:listChange
+                             tei:listEvent tei:listForest tei:listNym
+                             tei:listOrg tei:listPerson tei:listPlace
+                             tei:listRef tei:listRelation
+                             tei:listTranspose tei:listWit tei:location
+                             tei:locusGrp tei:macroSpec tei:metDecl
+                             tei:moduleRef tei:moduleSpec tei:monogr
+                             tei:msContents tei:msDesc tei:msIdentifier
+                             tei:msItem tei:msItemStruct tei:msPart
+                             tei:namespace tei:node tei:normalization
+                             tei:notatedMusic tei:notesStmt tei:nym
+                             tei:objectDesc tei:org tei:particDesc
+                             tei:performance tei:person tei:personGrp
+                             tei:physDesc tei:place tei:population
+                             tei:postscript tei:precision
+                             tei:profileDesc tei:projectDesc
+                             tei:prologue tei:publicationStmt
+                             tei:quotation tei:rdgGrp tei:recordHist
+                             tei:recording tei:recordingStmt
+                             tei:refsDecl tei:relatedItem tei:relation
+                             tei:relationGrp tei:remarks tei:respStmt
+                             tei:respons tei:revisionDesc tei:root
+                             tei:row tei:samplingDecl tei:schemaSpec
+                             tei:scriptDesc tei:scriptStmt tei:seal
+                             tei:sealDesc tei:segmentation
+                             tei:seriesStmt tei:set tei:setting
+                             tei:settingDesc tei:sourceDesc
+                             tei:sourceDoc tei:sp tei:spGrp tei:space
+                             tei:spanGrp tei:specGrp tei:specList
+                             tei:state tei:stdVals tei:subst
+                             tei:substJoin tei:superEntry
+                             tei:supportDesc tei:surface tei:surfaceGrp
+                             tei:table tei:tagsDecl tei:taxonomy
+                             tei:teiCorpus tei:teiHeader tei:terrain
+                             tei:text tei:textClass tei:textDesc
+                             tei:timeline tei:titlePage tei:titleStmt
+                             tei:trait tei:transpose tei:tree
+                             tei:triangle tei:typeDesc tei:vAlt
+                             tei:vColl tei:vDefault tei:vLabel
+                             tei:vMerge tei:vNot tei:vRange tei:valItem
+                             tei:valList tei:vocal"/>
 
   <xsl:key name="IDS" match="*[@xml:id]" use="@xml:id"/>
   <xsl:param name="googleAnalytics"></xsl:param>
@@ -132,10 +124,9 @@
   <xsl:param name="divOffset">2</xsl:param>
   <xsl:param name="verboseSpecDesc">false</xsl:param>
 
-
   <xsl:template match="/">
     <xsl:result-document doctype-public="{$doctypePublic}"
-                         omit-xml-declaration = "yes"                     
+                         omit-xml-declaration="yes"                     
                          doctype-system="{$doctypeSystem}" 
                          encoding="{$outputEncoding}"
                          href="{$outputDir}/index-toc.html" 
@@ -344,7 +335,7 @@
                     number($pos)=2)">
         <hr/>
         <p>
-	  <xsl:variable name="exemplumLang" select="tei:checkLang(ancestor::exemplum/@xml:lang)"/>
+          <xsl:variable name="exemplumLang" select="tei:checkLang(ancestor::exemplum/@xml:lang)"/>
           <xsl:choose>
             <xsl:when test="ancestor::elementSpec">
               <a
@@ -354,9 +345,9 @@
                     select="ancestor::elementSpec/@ident"/>
                 <xsl:text>&gt;</xsl:text>
               </a>
-	      <xsl:if test="$exemplumLang ne $doclang">
-		<xsl:sequence select="'&#x20;('||$exemplumLang||')'"/>
-	      </xsl:if>
+              <xsl:if test="$exemplumLang ne $doclang">
+                <xsl:sequence select="'&#x20;('||$exemplumLang||')'"/>
+              </xsl:if>
             </xsl:when>
             <xsl:when test="ancestor::classSpec">
               <a
@@ -364,9 +355,9 @@
                 <xsl:value-of
                     select="ancestor::classSpec/@ident"/>
               </a>
-	      <xsl:if test="$exemplumLang ne $doclang">
-		<xsl:sequence select="'&#x20;('||$exemplumLang||')'"/>
-	      </xsl:if>
+              <xsl:if test="$exemplumLang ne $doclang">
+                <xsl:sequence select="'&#x20;('||$exemplumLang||')'"/>
+              </xsl:if>
             </xsl:when>
             <xsl:otherwise>
               <xsl:for-each select="ancestor::div[@xml:id and head][1]">
@@ -737,8 +728,6 @@
       </p>
   </div>
 </xsl:template>
-
-
 
   <xsl:template name="calculateFigureNumber">
     <xsl:choose>

--- a/P5/Utilities/guidelines_model_2_executable.xslt
+++ b/P5/Utilities/guidelines_model_2_executable.xslt
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="3.0"
-		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="3.0" >
 
   <xsl:param name="input" select="tokenize( base-uri(/), '/')[last()]"/>
   <xsl:output method="xml" indent="yes" omit-xml-declaration="no"/>
@@ -10,9 +9,9 @@
   <xsl:template match="xsl:import/@href">
     <xsl:attribute name="href" select="
                    replace( .,
-		 	    'http://www.tei-c.org/release/xml/tei/stylesheet/',
-			    '/usr/share/xml/tei/stylesheet/'
-			  ) "/>
+                            'http://www.tei-c.org/release/xml/tei/stylesheet/',
+                            '/usr/share/xml/tei/stylesheet/'
+                          ) "/>
   </xsl:template>
 
   <xsl:template match="/xsl:stylesheet | /*/xsl:strip-space | /*/xsl:template | /*/xsl:function" expand-text="yes">

--- a/P5/Utilities/guidelines_model_2_executable.xslt
+++ b/P5/Utilities/guidelines_model_2_executable.xslt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0"
+		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+		>
+
+  <xsl:param name="input" select="tokenize( base-uri(/), '/')[last()]"/>
+  <xsl:output method="xml" indent="yes" omit-xml-declaration="no"/>
+  <xsl:mode on-no-match="shallow-copy"/>
+
+  <xsl:template match="xsl:import/@href">
+    <xsl:attribute name="href" select="
+                   replace( .,
+		 	    'http://www.tei-c.org/release/xml/tei/stylesheet/',
+			    '/usr/share/xml/tei/stylesheet/'
+			  ) "/>
+  </xsl:template>
+
+  <xsl:template match="/xsl:stylesheet | /*/xsl:strip-space | /*/xsl:template | /*/xsl:function" expand-text="yes">
+    <xsl:text>&#x0A;</xsl:text>
+    <xsl:comment> ***************************************************************** </xsl:comment>
+    <xsl:comment> WARNING: This is a derived file. You probably do not want to edit </xsl:comment>
+    <xsl:comment>          this file, but rather ./{$input} instead.    </xsl:comment>
+    <xsl:comment> ***************************************************************** </xsl:comment>
+    <xsl:text>&#x0A;</xsl:text>
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="@elements | @test">
+    <xsl:attribute name="{name(.)}">
+      <xsl:sequence select="normalize-space(.)"/>
+    </xsl:attribute>
+  </xsl:template>    
+
+</xsl:stylesheet>


### PR DESCRIPTION
I got caught once again by the fact that P5/Utilities/guidelines.xsl is a generated file. (And in front of my mentee, making it even more embarrassing.) So the main point of this PR is to make sure there is a very very obvious warning in that file that says it is a derived file. But while I was at it, I converted the generation mechanism to XSLT.

Various changes include:
 * Use new XSLT pgm guidelines_model_2_executable.xslt instead of using Perl (to change paths to imported files)
 * Add XML declaration to output
 * Allow XSLT processor to indent output (but not for guidelines-latex, as I do not know enough LaTeX to know that is OK)
 * Use XSLT 3
 * Add warning comments in derived output
 * Correct lots of mistyped "UTF-8"s