### PR TITLE
changes the content model for msDesc, msPart, and msFrag in order to …

### DIFF
--- a/P5/Source/Specs/msDesc.xml
+++ b/P5/Source/Specs/msDesc.xml
@@ -36,7 +36,7 @@ $Id$
       <classRef key="model.headLike" minOccurs="0" maxOccurs="unbounded"/>
       <alternate>
         <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>
-        <sequence>
+        <alternate>
           <elementRef key="msContents" minOccurs="0"/>
           <elementRef key="physDesc" minOccurs="0"/>
           <elementRef key="history" minOccurs="0"/>
@@ -45,7 +45,7 @@ $Id$
             <elementRef key="msPart" minOccurs="0" maxOccurs="unbounded"/>
             <elementRef key="msFrag" minOccurs="0" maxOccurs="unbounded"/>
           </alternate>
-        </sequence>
+        </alternate>
       </alternate>
     </sequence>
   </content>

--- a/P5/Source/Specs/msFrag.xml
+++ b/P5/Source/Specs/msFrag.xml
@@ -20,7 +20,7 @@ $Id$
     <desc versionDate="2007-05-02" xml:lang="zh-TW"></desc>
     <desc versionDate="2008-04-05" xml:lang="ja"></desc>-->
     <desc versionDate="2015-10-26" xml:lang="fr">contient des informations sur un fragment d'un manuscrit dispersé, aujourd'hui conservé séparément ou incorporé dans un autre manuscrit.</desc>
-    <desc versionDate="2015-10-26" xml:lang="de">enthält Informationen zu einem Handschriftenfragment einer fragmentierten Handschrift, das heute als Einzeldokument oder eingebunden in eine Handschrift aufbewahrt wird.</desc>
+    <desc versionDate="2015-10-26" xml:lang="de">enthält Informationen zu einem Handschriftenfragment, beschrieben in Relation zu einem früheren Kontext, typischerweise als eine Beschreibung einer virtuellen Rekonstruktion einer Handschrift oder eines anderen Objekts, dessen fragmentarischen Teile separat beschrieben worden sind.</desc>
 <!--<desc versionDate="2007-05-04" xml:lang="es"></desc>-->
 <!--<desc versionDate="2007-01-21" xml:lang="it"></desc>-->
     <classes>
@@ -36,12 +36,12 @@ $Id$
             <classRef key="model.headLike" minOccurs="0" maxOccurs="unbounded"/>
             <alternate>
                 <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>
-                <sequence>
+                <alternate>
                     <elementRef key="msContents" minOccurs="0"/>
                     <elementRef key="physDesc" minOccurs="0"/>
                     <elementRef key="history" minOccurs="0"/>
                     <elementRef key="additional" minOccurs="0"/>
-                </sequence>
+                </alternate>
             </alternate>
         </sequence>
     </content>

--- a/P5/Source/Specs/msPart.xml
+++ b/P5/Source/Specs/msPart.xml
@@ -35,13 +35,13 @@ $Id$
       <classRef key="model.headLike" minOccurs="0" maxOccurs="unbounded"/>
       <alternate>
         <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>
-        <sequence>
+        <alternate>
           <elementRef key="msContents" minOccurs="0"/>
           <elementRef key="physDesc" minOccurs="0"/>
           <elementRef key="history" minOccurs="0"/>
           <elementRef key="additional" minOccurs="0"/>
           <elementRef key="msPart" minOccurs="0" maxOccurs="unbounded"/>
-        </sequence>
+        </alternate>
       </alternate>
     </sequence>
   </content>


### PR DESCRIPTION
…allow for any order of child elements, after msIdentifier and head

This pull request answers to issue #2214, allowing an even more flexible order of child elements of msDesc, msPart, and msFrag, as in the original issue. This turned out to be necessary within the Handschriftenportal, but as well was favoured by the MS-SIG in it's 2022 SIG meeting in Newcastle.