### PR TITLE
Address #2426 — do not allow elements or classes inside a datatype

### DIFF
--- a/P5/Source/Guidelines/en/TD-DocumentationElements.xml
+++ b/P5/Source/Guidelines/en/TD-DocumentationElements.xml
@@ -995,17 +995,19 @@ to mark any technical term, thus:
         <p>The <soCalled>datatype</soCalled> (i.e. the kind of value) for an attribute may be specified using
           the elements <gi>datatype</gi> and <gi>dataRef</gi>. A datatype may be defined in any of the
           following three ways: <list>
-            <item>by reference to an existing TEI datatype definition; </item>
-            <item>by use of its name in the widely used schema datatype library maintained by the W3C as part
-              of the definition of its schema language; </item>
+            <item>by reference to an existing TEI datatype definition, itself defined by a <gi>dataSpec</gi>;</item>
+            <item>by use of its name in <ref target="#XSD2">XML Schema
+            Part 2: Datatypes Second Edition</ref>, the widely used
+            datatype library maintained by the W3C as part of
+            the definition of its schema language;</item>
             <item>by referencing its URI within some other datatype library.</item>
-          </list>The TEI defines a number of datatypes, each with an identifier beginning
+          </list> The TEI defines a number of datatypes, each with an identifier beginning
             <code>teidata.</code>, which are used in preference to the datatypes available natively from a
           target schema such as RELAX NG or W3C Schema since the facilities provided by different schema
           languages vary so widely. The TEI datatypes available are described in section <ptr target="#DTYPES"
           /> above. Note that each is, of necessity, mapped eventually to an externally defined datatype such
           as W3C Schema's <ident>text</ident> or <ident>name</ident>, possibly combined to give more
-          expressivity, or constrained to a particular defined usage. </p>
+          expressivity, or constrained to a particular defined usage.</p>
         <p>It is possible to reference a W3C schema datatype directly using <att>name</att>. In this case, 
           the child <gi>dataFacet</gi> can be used instead of <att>restriction</att> to set W3C schema compliant 
           restrictions on the datatype. A <gi>dataFacet</gi> is particularly useful for restrictions that can be difficult to impose and to read as a 
@@ -1015,17 +1017,32 @@ to mark any technical term, thus:
             <dataFacet name="minInclusive" value="-360.0"/>
             </dataRef></egXML>   
         Note that restrictions are either expressed with <att>restriction</att> or <gi>dataFacet</gi>, never both.</p>
-        <p>Attributes <att>minOccurs</att> and <att>maxOccurs</att> are available for the case where an
-          attribute may take more than one value of the type specified. For example, the <att>target</att>
-          attribute provided by the <ident type="class">att.pointing</ident> class has the following
-          declaration:
-          <egXML xmlns="http://www.tei-c.org/ns/Examples"><attDef ident="target">
-              <desc versionDate="2010-05-02" xml:lang="en">specifies the destination of the reference by
-                supplying one or more URI References</desc>
-              <datatype minOccurs="1" maxOccurs="unbounded">
-                <dataRef key="teidata.pointer"/>
-              </datatype>
-            </attDef></egXML>
+	<p>A datatype may be used to constrain the textual content of
+	an element, rather than the value of an attribute. But because
+	they are intended for use in defining ranges of attribute
+	values, datatypes may not contain elements or attributes.</p>
+        <p>The attributes <att>minOccurs</att> and
+        <att>maxOccurs</att> are available for the case where an
+        attribute may take more than one value of the type
+        specified. For example, the <att>columns</att> attribute of
+        the <gi>layout</gi> element can have one or two non-negative
+        integers as its value:
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+	    <attDef ident="columns">
+	      <gloss xml:lang="en" versionDate="2007-06-12">columns</gloss>
+	      <desc versionDate="2005-01-14" xml:lang="en">specifies the number of columns per page</desc>
+	      <datatype minOccurs="1" maxOccurs="2">
+		<dataRef key="teidata.count"/>
+	      </datatype>
+	      <remarks xml:lang="en" versionDate="2017-07-09">
+		<p>If a single number is given, all pages referenced
+		have this number of columns. If two numbers are given,
+		the number of columns per page varies between the
+		values supplied. Where <att>columns</att> is omitted
+		the number is assumed to be <val>1</val>.</p>
+	      </remarks>
+	    </attDef>
+	  </egXML>
            indicating that the <att>target</att> attribute may take any number of values, each being of the
           same datatype, namely the TEI data specification <ident>teidata.pointer</ident>. As is usual in XML,
           multiple values for a single attribute are separated by one or more white space characters. Hence,

--- a/P5/Source/Specs/dataFacet.xml
+++ b/P5/Source/Specs/dataFacet.xml
@@ -9,7 +9,7 @@
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="dataFacet">
   <desc versionDate="2016-11-21" xml:lang="en">Restricts the value of the strings used to represent values of a datatype, 
-    according to <ref target="#XSD2">XML Schemas: Part 2: Datatypes</ref>. 
+    according to <ref target="#XSD2">XML Schema Part 2: Datatypes Second Edition</ref>.
  </desc>
   <classes>
     <memberOf key="att.global"/>
@@ -64,7 +64,7 @@
   </exemplum>
   <remarks versionDate="2016-11-21" xml:lang="en">
     <p>This element is only allowed when the parent <gi>dataRef</gi> refers with
-        <att>name</att> to a datatype from the specification <ref target="#XSD2">XML Schemas: Part 2: Datatypes</ref>. 
+        <att>name</att> to a datatype from the specification <ref target="#XSD2">XML Schema Part 2: Datatypes Second Edition</ref>. 
     </p>
   </remarks>
   <listRef>

--- a/P5/Source/Specs/dataRef.xml
+++ b/P5/Source/Specs/dataRef.xml
@@ -22,7 +22,7 @@
     <constraint>
       <sch:rule context="tei:dataRef[tei:dataFacet]">
         <sch:assert test="@name" role="nonfatal">Data facets can only be specified for references to datatypes specified by
-          XML Schemas: Part 2: Datatypes — that is, for there to be a 'dataFacet' child there must be a @name attribute.</sch:assert>
+          XML Schema Part 2: Datatypes Second Edition — that is, for there to be a 'dataFacet' child there must be a @name attribute.</sch:assert>
         <sch:report test="@restriction" role="nonfatal">Data facets and restrictions cannot both be expressed on the same data reference — that is, the @restriction attribute cannot be used when a 'dataFacet' element is present.</sch:report>
       </sch:rule>
     </constraint>
@@ -31,7 +31,7 @@
     <constraint>
       <sch:rule context="tei:dataRef[@restriction]">
         <sch:assert test="@name" role="nonfatal">Restrictions can only be specified for references to datatypes specified by
-          XML Schemas: Part 2: Datatypes — that is, for there to be a @restriction attribute there must be a @name attribute, too.</sch:assert>
+          XML Schema Part 2: Datatypes Second Edition — that is, for there to be a @restriction attribute there must be a @name attribute, too.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>
@@ -43,7 +43,7 @@
       </attDef>
       <attDef ident="name">
         <desc versionDate="2010-05-14" xml:lang="en">the name of a datatype in the list provided by 
-        <ref target="#XSD2">XML Schemas: Part 2: Datatypes</ref> </desc>
+        <ref target="#XSD2">XML Schema Part 2: Datatypes Second Edition</ref> </desc>
         <datatype><dataRef key="teidata.xmlName"/></datatype>
       </attDef>
       <attDef ident="ref">
@@ -85,7 +85,7 @@
     
   <remarks versionDate="2010-05-14" xml:lang="en">
     <p>Only one of the attributes <att>key</att>, <att>name</att>, and <att>ref</att> may be used on any given instance of <gi>dataRef</gi>.</p>
-    <p>Neither a <att>restriction</att> attribute not a <gi>dataFacet</gi> child element may be used unless the <gi>dataRef</gi> refers to a datatype from the specification <ref target="#XSD2">XML Schemas: Part 2: Datatypes</ref> with a <att>name</att> attribute.</p>
+    <p>Neither a <att>restriction</att> attribute not a <gi>dataFacet</gi> child element may be used unless the <gi>dataRef</gi> refers to a datatype from the specification <ref target="#XSD2">XML Schema Part 2: Datatypes Second Edition</ref> with a <att>name</att> attribute.</p>
   </remarks>
   <listRef>
     <ptr target="#TD-datatypes"/>

--- a/P5/Source/Specs/dataRef.xml
+++ b/P5/Source/Specs/dataRef.xml
@@ -85,7 +85,7 @@
     
   <remarks versionDate="2010-05-14" xml:lang="en">
     <p>Only one of the attributes <att>key</att>, <att>name</att>, and <att>ref</att> may be used on any given instance of <gi>dataRef</gi>.</p>
-    <p>Neither a <att>restriction</att> attribute not a <gi>dataFacet</gi> child element may be used unless the <gi>dataRef</gi> refers to a datatype from the specification <ref target="#XSD2">XML Schema Part 2: Datatypes Second Edition</ref> with a <att>name</att> attribute.</p>
+    <p>Neither a <att>restriction</att> attribute nor a <gi>dataFacet</gi> child element may be used unless the <gi>dataRef</gi> refers to a datatype from the specification <ref target="#XSD2">XML Schema Part 2: Datatypes Second Edition</ref> with a <att>name</att> attribute.</p>
   </remarks>
   <listRef>
     <ptr target="#TD-datatypes"/>

--- a/P5/Source/Specs/dataSpec.xml
+++ b/P5/Source/Specs/dataSpec.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="tagdocs" ident="dataSpec">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="dataSpec">
   <gloss versionDate="2007-07-04" xml:lang="en">datatype specification</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">documents a datatype.</desc>
   <classes>
@@ -31,6 +31,15 @@ $Id$
       <elementRef key="listRef" minOccurs="0" maxOccurs="unbounded"/>
     </sequence>
   </content>
+  <constraintSpec scheme="schematron" ident="no_elements_in_data_content">
+    <constraint>
+      <sch:rule role="warn" context="tei:dataSpec/tei:content">
+        <sch:report test=".//tei:anyElement | .//tei:classRef | .//tei:elementRef">
+          A datatype specification should not refer to an element or a class.
+        </sch:report>
+      </sch:rule>
+    </constraint>
+  </constraintSpec>
   <exemplum xml:lang="und">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <dataSpec ident="teidata.pointer">


### PR DESCRIPTION
 What I did:
 * Added para to "TD-datatypes" (22.5.3.1) asserting that, while they may be used in a content model, because datatypes are for attr vals, cannot have element or attr.
 * Changed example that shows defining “more than one” occurrence of a datatype from `@target` of att.pointing to `@columns` of `<layout>`. I did this because I think the URI example is particularly problematic, as someone who does not carefully read a modern version of teidata.pointer but knows how xs:anyURI is defined could be quite confused.
 * Made clear in list of ways a `<dataRef>` refers to a dataype that TEI datatypes are defined by the `<dataSpec>` element.
 * Added a `role="warn"` constraint to `<dataSpec>`.
 * Corrected half a dozen references to XML Schema Part 2: Datatypes Second Edition in dataRef and dataFacet tagdocs.

Note that I used an `@role` of "warn" on the constraint itself, on the theory that we should provide a sort of deprecation period. Feel free to disagree. (Either way — no deprecation needed, remove "warn", or re-word warning to make it a real deprecation.)