### PR TITLE
Replaced castItem with role in the exemplum for `#2407`

### DIFF
--- a/P5/Source/Specs/att.ascribed.xml
+++ b/P5/Source/Specs/att.ascribed.xml
@@ -34,7 +34,7 @@ $Id$
       <datatype maxOccurs="unbounded"><dataRef key="teidata.pointer"/></datatype>
       <exemplum xml:lang="en">
         <p>In the following example from Hamlet, speeches (<gi>sp</gi>) in the body of the play 
-        are linked to <gi>castItem</gi> elements in the <gi>castList</gi> using the <att>who</att>
+        are linked to <gi>role</gi> elements in the <gi>castList</gi> using the <att>who</att>
         attribute.</p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="en" valid="feasible" source="#CODR-eg-293">
           <castItem type="role">


### PR DESCRIPTION
Updated the exemplum in att.ascribed.xml with @sydb to replace `<castItem>` with `<role>` because the `@who` attributes point to the `<role>` elements and not the `<castItem>` elements.