### PR TITLE
Updated `<revisionDesc>` content model

### DIFF
--- a/P5/Source/Specs/revisionDesc.xml
+++ b/P5/Source/Specs/revisionDesc.xml
@@ -30,11 +30,9 @@ $Id$
   </classes>
   <content>
     <alternate>
-      <elementRef key="list"/>
-      <elementRef key="listChange"/>
-      
-        <elementRef key="change" minOccurs="1" maxOccurs="unbounded"/>
-      
+      <elementRef key="list" minOccurs="1" maxOccurs="unbounded"/>
+      <elementRef key="listChange" minOccurs="1" maxOccurs="unbounded"/>
+      <elementRef key="change" minOccurs="1" maxOccurs="unbounded"/>
     </alternate>
   </content>
   <exemplum xml:lang="en">


### PR DESCRIPTION
Updated the content model of `<revisionDesc>` to the content model proposed by @sydb:

`element revisionDesc {
    ( list* | listChange* | change* )
    }`

Unable to build and test in Docker to see if it would break anything, so I've erred on the side of caution to create a pull request for this small change just in case.