### PR TITLE
change type of attr to match its target

### DIFF
--- a/P5/Source/Specs/attRef.xml
+++ b/P5/Source/Specs/attRef.xml
@@ -29,7 +29,7 @@ $Id$
   <attList>
     <attDef ident="class">
       <desc versionDate="2013-11-16" xml:lang="en">the name of the attribute class</desc>
-      <datatype><dataRef key="teidata.word"/></datatype>
+      <datatype><dataRef key="teidata.name"/></datatype>
     </attDef>
     <attDef ident="name">
       <desc versionDate="2013-11-16" xml:lang="en">the name of the attribute</desc>


### PR DESCRIPTION
This fixes #2276 by changing defintion of `attRef/@class` to be teidata.name (instead of teidata.word), because that is what `classSpec/@ident` is defined as.