### PR TITLE
Updated description of language attributes and corrected language code for #2447

### DIFF
--- a/P5/Source/Specs/language.xml
+++ b/P5/Source/Specs/language.xml
@@ -37,7 +37,7 @@ $Id$
         <gloss versionDate="2016-11-17" xml:lang="de">Identifikator</gloss>
 <!--  NOTE (MDH 2016-04-24): This @versionDate is clearly wrong; we updated from ISO 3066 to BCP 47 around 2010 or 2011.  -->
       <desc versionDate="2007-07-08" xml:lang="en">Supplies a language code constructed as defined in <ref target="https://tools.ietf.org/html/bcp47">BCP 47</ref> which is used to identify the
-        language documented by this element, and which is referenced by the global
+        language documented by this element, and which may be referenced by the global
         <att>xml:lang</att> attribute.</desc>
       <desc versionDate="2009-01-05" xml:lang="fr">fournit un code de langue issu de la recommandation
         <ref target="https://tools.ietf.org/html/bcp47">BCP 47</ref> (ou son
@@ -63,7 +63,7 @@ $Id$
       <datatype><dataRef key="teidata.language"/></datatype>
     </attDef>
     <attDef ident="usage" usage="opt">
-      <desc versionDate="2005-01-14" xml:lang="en">specifies the approximate percentage (by volume) of the text which uses this language.</desc>
+      <desc versionDate="2005-01-14" xml:lang="en">specifies the approximate percentage of the text which uses this language.</desc>
       <desc versionDate="2009-01-05" xml:lang="fr">précise approximativement le pourcentage du volume de
         texte utilisant cette langue.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">이 언어를 사용하는 텍스트의 대략적 백분율(분량)을 명시한다.</desc>
@@ -81,7 +81,7 @@ $Id$
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="en">
       <langUsage>
         <language ident="en-US" usage="75">modern American English</language>
-        <language ident="i-az-Arab" usage="20">Azerbaijani in Arabic script</language>
+        <language ident="az-Arab" usage="20">Azerbaijani in Arabic script</language>
         <language ident="x-lap" usage="05">Pig Latin</language>
       </langUsage>
     </egXML>
@@ -90,7 +90,7 @@ $Id$
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <langUsage>
         <language ident="en-US" usage="75">Anglais américain moderne</language>
-        <language ident="i-az-Arab" usage="20">Azerbaijanais en caractères arabes</language>
+        <language ident="az-Arab" usage="20">Azerbaijanais en caractères arabes</language>
         <language ident="x-verlan" usage="05">verlan</language>
       </langUsage>
     </egXML>
@@ -99,7 +99,7 @@ $Id$
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <langUsage>
         <language ident="en-US" usage="75">現代美語</language>
-        <language ident="i-az-Arab" usage="20">阿拉伯文手寫的亞塞拜然語</language>
+        <language ident="az-Arab" usage="20">阿拉伯文手寫的亞塞拜然語</language>
         <language ident="x-lap" usage="05">一種行話，將字頭的子音調至字尾，再多加一個音節</language>
       </langUsage>
     </egXML>


### PR DESCRIPTION
Updated description of `ident` and `usage` attributes and corrected language code for #2447. 