### PR TITLE
deleted mode="add" everywhere except in egXML elements

### DIFF
--- a/P5/Source/Specs/abbr.xml
+++ b/P5/Source/Specs/abbr.xml
@@ -50,7 +50,7 @@
                 l'abbreviazione secondo una tipologia funzionale.</desc>
       <desc versionDate="2016-11-25" xml:lang="de">erlaubt es, die Abkürzung nach einer geeigneten Typologie zu klassifizieren.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="suspension">
           <gloss xml:lang="en" versionDate="2017-06-25">suspension</gloss>
           <gloss versionDate="2017-06-25" xml:lang="de">Suspension</gloss>

--- a/P5/Source/Specs/affiliation.xml
+++ b/P5/Source/Specs/affiliation.xml
@@ -71,7 +71,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
 	<valItem ident="sponsor"/>
 	<valItem ident="recommend"/>
 	<valItem ident="discredit"/>

--- a/P5/Source/Specs/age.xml
+++ b/P5/Source/Specs/age.xml
@@ -63,7 +63,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
 	<valItem ident="western"/>
 	<valItem ident="sui"/>
 	<valItem ident="subjective"/>

--- a/P5/Source/Specs/annotation.xml
+++ b/P5/Source/Specs/annotation.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="annotation" mode="add" module="linking"
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="annotation" module="linking"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <desc versionDate="2020-07-31" xml:lang="en">represents an annotation following the <ref target="#WADM">Web
       Annotation Data Model</ref>.</desc>

--- a/P5/Source/Specs/att.entryLike.xml
+++ b/P5/Source/Specs/att.entryLike.xml
@@ -25,7 +25,7 @@ $Id$
   #370. Note that same problems is present in att.textCritical. -->
   <attList>
     <attRef class="att.typed" name="subtype"/>
-    <attDef ident="type" usage="opt" mode="add">
+    <attDef ident="type" usage="opt">
       <desc versionDate="2005-10-10" xml:lang="en">indicates type of entry, in dictionaries with multiple types.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">다중 유형을 포함하는 사전에서, 표제 항목 유형을 나타낸다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">指出複合類型字典中的辭條類型。</desc>

--- a/P5/Source/Specs/att.textCritical.xml
+++ b/P5/Source/Specs/att.textCritical.xml
@@ -29,7 +29,7 @@ $Id$
   Also see TEI ticket #1867. -->
   <attList>
     <attRef class="att.typed" name="subtype"/>
-    <attDef ident="type" usage="opt" mode="add">
+    <attDef ident="type" usage="opt">
       <desc versionDate="2005-10-10" xml:lang="en">classifies the reading according to some useful typology.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">유용한 유형에 따라 독법을 분류한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">用合宜的分類法將對應本分類。</desc>

--- a/P5/Source/Specs/birth.xml
+++ b/P5/Source/Specs/birth.xml
@@ -67,7 +67,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
 	<valItem ident="caesarean">
 	  <gloss xml:lang="en" versionDate="2017-06-23">caesarean section</gloss>
 	  <gloss xml:lang="ja" versionDate="2023-09-27">帝王切開</gloss>

--- a/P5/Source/Specs/castItem.xml
+++ b/P5/Source/Specs/castItem.xml
@@ -48,7 +48,7 @@ either a single role or a list of non-speaking roles.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">indica la voce della lista dei personaggi</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <defaultVal>role</defaultVal>
-      <valList type="closed" mode="add">
+      <valList type="closed">
         <valItem ident="role">
           <desc versionDate="2007-06-27" xml:lang="en">the item describes a single role.</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">항목이 하나의 배역을 기술한다.</desc>

--- a/P5/Source/Specs/certainty.xml
+++ b/P5/Source/Specs/certainty.xml
@@ -34,7 +34,7 @@ $Id$
     <attDef ident="type" usage="opt" mode="change">
       <desc versionDate="2021-01-28" xml:lang="en">characterizes the element in some sense, using any convenient
          classification scheme or typology; sample categorization of annotations of uncertainty might use following values:</desc>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="ignorance"/>
         <valItem ident="incompleteness"/>
         <valItem ident="credibility"/>

--- a/P5/Source/Specs/classSpec.xml
+++ b/P5/Source/Specs/classSpec.xml
@@ -58,7 +58,7 @@ that is a group of
       <desc versionDate="2007-05-04" xml:lang="es">indica si se trata de una clase de modelos o de atributos.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">indica se si tratta di una classe di modelli o di attributi</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="closed" mode="add">
+      <valList type="closed">
         <valItem ident="model">
           <gloss versionDate="2007-07-04" xml:lang="en">content model</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">내용 모델</gloss>

--- a/P5/Source/Specs/constitution.xml
+++ b/P5/Source/Specs/constitution.xml
@@ -38,7 +38,7 @@ as fragmentary, complete, etc.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica come era costituito il testo.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <defaultVal>single</defaultVal>
-      <valList type="closed" mode="add">
+      <valList type="closed">
         <valItem ident="single">
           <desc versionDate="2007-06-27" xml:lang="en">a single complete text</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">단일 완전 텍스트</desc>

--- a/P5/Source/Specs/constraintSpec.xml
+++ b/P5/Source/Specs/constraintSpec.xml
@@ -126,7 +126,7 @@ $Id$
       when a <gi>constraintSpec</gi> warns about a deprecated
       construct.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="deprecationWarning">
           <desc xml:lang="en" versionDate="2018-09-17">Indicates that
           this constraint specification warns that some other

--- a/P5/Source/Specs/conversion.xml
+++ b/P5/Source/Specs/conversion.xml
@@ -47,13 +47,13 @@ $Id$
     </attDef>
 
   
-      <attDef ident="fromUnit" mode="add" usage="req">
+      <attDef ident="fromUnit" usage="req">
       <desc versionDate="2019-06-26" xml:lang="en">indicates a source unit of measure that is to be converted into another unit indicated in <att>toUnit</att>.</desc>
       <datatype>
         <dataRef key="teidata.pointer"/>
       </datatype>
     </attDef>
-    <attDef ident="toUnit" mode="add" usage="req">
+    <attDef ident="toUnit" usage="req">
       <desc versionDate="2019-06-26" xml:lang="en">the target unit of measurement for a conversion from a source unit referenced in <att>fromUnit</att>.</desc>
       <datatype>
         <dataRef key="teidata.pointer"/>

--- a/P5/Source/Specs/correspAction.xml
+++ b/P5/Source/Specs/correspAction.xml
@@ -36,7 +36,7 @@
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="sent">
           <desc versionDate="2015-02-09" xml:lang="en">information concerning the sending or dispatch of a message.</desc>
 		<desc versionDate="2022-06-02" xml:lang="ja">メッセージの送信や発送に関する情報。

--- a/P5/Source/Specs/death.xml
+++ b/P5/Source/Specs/death.xml
@@ -64,7 +64,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
 	<valItem ident="proclaimed"/>
 	<valItem ident="assumed"/>
 	<valItem ident="verified"/>

--- a/P5/Source/Specs/derivation.xml
+++ b/P5/Source/Specs/derivation.xml
@@ -36,7 +36,7 @@ $Id$
       <desc versionDate="2007-05-04" xml:lang="es">caracteriza la derivación del texto</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica la provenienza del testo.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="original">
           <desc versionDate="2007-06-27" xml:lang="en">text is original</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">텍스트가 원본이다.</desc>

--- a/P5/Source/Specs/desc.xml
+++ b/P5/Source/Specs/desc.xml
@@ -63,7 +63,7 @@
   </constraintSpec>
   <attList>
     <attDef ident="type" mode="change">
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="deprecationInfo">
           <gloss versionDate="2018-09-14" xml:lang="en">deprecation
           information</gloss>

--- a/P5/Source/Specs/dimensions.xml
+++ b/P5/Source/Specs/dimensions.xml
@@ -52,7 +52,7 @@ $Id$
       <desc versionDate="2007-05-04" xml:lang="es">indica que aspecto del objeto se mide.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">indica quale aspetto dell'oggetto viene misurato</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="leaves">
           <desc versionDate="2007-06-27" xml:lang="en">dimensions relate to one or more leaves (e.g. a single leaf, a
 gathering, or a separately bound part)</desc>

--- a/P5/Source/Specs/divGen.xml
+++ b/P5/Source/Specs/divGen.xml
@@ -46,7 +46,7 @@
       <desc versionDate="2007-05-04" xml:lang="es">especifica que tipo de divisón de texto generada aparece (p.ej. índice, tabla de contenidos, etc.)</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica quale tipo di partizione testuale generata (ad esempio indice, sommario, ecc.) apparirà</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="index">
           <desc versionDate="2007-06-27" xml:lang="en">an index is to be generated and inserted at this point.</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">색인은 이 지점에서 생성되고 삽입된다.</desc>

--- a/P5/Source/Specs/domain.xml
+++ b/P5/Source/Specs/domain.xml
@@ -44,7 +44,7 @@ education, religion, etc.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">clasifica el campo de uso.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica l'ambito di uso.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="art">
           <desc versionDate="2007-06-27" xml:lang="en">art and entertainment</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">예술과 연예</desc>

--- a/P5/Source/Specs/education.xml
+++ b/P5/Source/Specs/education.xml
@@ -63,7 +63,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
 	<valItem ident="primary"/>
 	<valItem ident="secondary"/>
 	<valItem ident="undergraduate"/>

--- a/P5/Source/Specs/factuality.xml
+++ b/P5/Source/Specs/factuality.xml
@@ -38,7 +38,7 @@ or a non-fictional world.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">clasifica la objetividad de un texto</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica la fattualità del testo.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="closed" mode="add">
+      <valList type="closed">
         <valItem ident="fiction">
           <desc versionDate="2007-06-27" xml:lang="en">the text is to be regarded as entirely imaginative</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">텍스트가 전적으로 상상적이라 간주된다.</desc>

--- a/P5/Source/Specs/faith.xml
+++ b/P5/Source/Specs/faith.xml
@@ -63,7 +63,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
 	<valItem ident="practicing"/>
 	<valItem ident="clandestine"/>
 	<valItem ident="patrilineal"/>

--- a/P5/Source/Specs/form.xml
+++ b/P5/Source/Specs/form.xml
@@ -54,7 +54,7 @@ $Id$
       <desc versionDate="2007-05-04" xml:lang="es">clasifica la forma como simple, compuesta, etc.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica la forma in simplice, composta, ecc.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="simple">
           <desc versionDate="2007-06-27" xml:lang="en">single free lexical item</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">단일 자립 어휘 항목</desc>

--- a/P5/Source/Specs/fw.xml
+++ b/P5/Source/Specs/fw.xml
@@ -42,7 +42,7 @@ $Id$
       <desc versionDate="2007-05-04" xml:lang="es">clasifica las convenciones usadas según una tipología funcional.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica le convenzioni usate secondo una tipologia funzionale</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="header">
           <desc versionDate="2007-04-02" xml:lang="en">a running title at the top of the page</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">페이지 상단의 현 제목</desc>

--- a/P5/Source/Specs/gram.xml
+++ b/P5/Source/Specs/gram.xml
@@ -62,7 +62,7 @@ $Id$
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="pos">
           <gloss versionDate="2007-08-25" xml:lang="en">part of speech</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">품사</gloss>

--- a/P5/Source/Specs/graph.xml
+++ b/P5/Source/Specs/graph.xml
@@ -65,7 +65,7 @@ connect the nodes.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">describe el tipo de gráfico</desc>
       <desc versionDate="2007-01-21" xml:lang="it">descrive il tipo di grafo</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="undirected">
           <desc versionDate="2007-06-27" xml:lang="en">undirected graph</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">무방향 그래프</desc>

--- a/P5/Source/Specs/iType.xml
+++ b/P5/Source/Specs/iType.xml
@@ -57,7 +57,7 @@ $Id$
         abbreviate solite (ad esempio <mentioned>inv</mentioned>)e altri tipi di indicatori, quali
         codici speciali per fare riferimento al tipo di coniugazione, ecc.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="abbrev">
           <desc versionDate="2007-06-27" xml:lang="en">abbreviated indicator</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">축약 지시자</desc>

--- a/P5/Source/Specs/idno.xml
+++ b/P5/Source/Specs/idno.xml
@@ -100,7 +100,7 @@ $Id$
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="ISBN">
           <desc versionDate="2016-07-02" xml:lang="en">International Standard Book Number: a 13- or
             (if assigned prior to 2007) 10-digit identifying number assigned by the publishing

--- a/P5/Source/Specs/interaction.xml
+++ b/P5/Source/Specs/interaction.xml
@@ -43,7 +43,7 @@ form of response or interjection, commentary, etc.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">describe el grado de interacción entre los participantes activos y pasivos en un texto.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica il grado di interazione tra partecipanti attivi e passivi all'interno del testo.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="closed" mode="add">
+      <valList type="closed">
         <valItem ident="none">
           <desc versionDate="2007-06-27" xml:lang="en">no interaction of any kind, e.g. a monologue</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">종류의 상호작용이 없다. 예, 독백.</desc>

--- a/P5/Source/Specs/langKnowledge.xml
+++ b/P5/Source/Specs/langKnowledge.xml
@@ -76,7 +76,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
 	<valItem ident="listening"/>
 	<valItem ident="speaking"/>
 	<valItem ident="reading"/>

--- a/P5/Source/Specs/list.xml
+++ b/P5/Source/Specs/list.xml
@@ -108,7 +108,7 @@
       <desc versionDate="2014-07-29" xml:lang="en">describes the nature of the items in the list.</desc>
       <desc versionDate="2016-11-25" xml:lang="de">beschreibt die Art der Listenpunkte.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="gloss">
           <gloss xml:lang="en" versionDate="2017-06-25">gloss</gloss>
           <gloss versionDate="2017-06-25" xml:lang="de">Gloss</gloss>

--- a/P5/Source/Specs/listAnnotation.xml
+++ b/P5/Source/Specs/listAnnotation.xml
@@ -7,7 +7,7 @@ $Date$
 $Id$
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="listAnnotation" mode="add" module="linking"
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="listAnnotation" module="linking"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <desc versionDate="2020-03-08" xml:lang="en">contains a list of annotations, typically encoded as
       <gi>annotation</gi>, <gi>annotationBlock</gi>, or <gi>note</gi>, possibly organized with

--- a/P5/Source/Specs/move.xml
+++ b/P5/Source/Specs/move.xml
@@ -43,7 +43,7 @@ $Id$
       <desc versionDate="2007-01-21" xml:lang="it">indica il tipo di movimento, ad esempio come entrata
         o uscita.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="entrance">
           <desc versionDate="2007-06-27" xml:lang="en">character is entering the stage.</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">등장인물이 무대에 등장하고 있다.</desc>

--- a/P5/Source/Specs/nationality.xml
+++ b/P5/Source/Specs/nationality.xml
@@ -66,7 +66,7 @@ $Id$
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
 	<valItem ident="birth"/>
 	<valItem ident="naturalised"/>
 	<valItem ident="self-assigned"/>

--- a/P5/Source/Specs/node.xml
+++ b/P5/Source/Specs/node.xml
@@ -48,7 +48,7 @@ other analytic element.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">define un tipo de nodo.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">definisce un tipo di nodo</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="initial">
           <desc versionDate="2007-06-27" xml:lang="en">initial node in a transition network</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">전이망에서 시작 노드</desc>

--- a/P5/Source/Specs/num.xml
+++ b/P5/Source/Specs/num.xml
@@ -43,7 +43,7 @@
       <desc versionDate="2007-01-21" xml:lang="it">indica il tipo di valore numerico</desc>
       <desc versionDate="2016-11-25" xml:lang="de">bestimmt die Art des numerischen Wertes.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="cardinal">
           <desc versionDate="2007-06-27" xml:lang="en">absolute number, e.g. 21, 21.5</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">예를 들어, 21, 21.5와 같은 절대값</desc>

--- a/P5/Source/Specs/oRef.xml
+++ b/P5/Source/Specs/oRef.xml
@@ -52,7 +52,7 @@ $Id$
       <desc versionDate="2007-01-21" xml:lang="it">indica il tipo di modifica tipografica del lemma in
         un riferimento.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="cap">
           <gloss versionDate="2007-07-04" xml:lang="en">capital</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">대문자</gloss>

--- a/P5/Source/Specs/occupation.xml
+++ b/P5/Source/Specs/occupation.xml
@@ -64,7 +64,7 @@ $Id$
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="primary"/>
         <valItem ident="other"/>
         <valItem ident="paid"/>

--- a/P5/Source/Specs/preparedness.xml
+++ b/P5/Source/Specs/preparedness.xml
@@ -37,7 +37,7 @@ prepared or spontaneous.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">una palabra clave que caracteriza el tipo de preparación.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">una parola chiava che caratterizza il grado di spontaneità</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="none">
           <desc versionDate="2007-06-27" xml:lang="en">spontaneous or unprepared</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">자발적 또는 준비되지 않은</desc>

--- a/P5/Source/Specs/purpose.xml
+++ b/P5/Source/Specs/purpose.xml
@@ -34,7 +34,7 @@ text.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">especifica un tipo particular de finalidad</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica un tipo particolare di scopo.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="persuade">
           <desc versionDate="2007-06-27" xml:lang="en">didactic, advertising, propaganda, etc.</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">설교, 광고, 선전 등</desc>

--- a/P5/Source/Specs/recording.xml
+++ b/P5/Source/Specs/recording.xml
@@ -55,7 +55,7 @@ a public broadcast.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">tipo di registrazione.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <defaultVal>audio</defaultVal>
-      <valList type="closed" mode="add">
+      <valList type="closed">
         <valItem ident="audio">
           <desc versionDate="2007-06-27" xml:lang="en">audio recording</desc>
           <desc versionDate="2009-01-05" xml:lang="fr">enregistrement audio</desc>

--- a/P5/Source/Specs/residence.xml
+++ b/P5/Source/Specs/residence.xml
@@ -67,7 +67,7 @@ $Id$
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="primary"/>
         <valItem ident="secondary"/>
         <valItem ident="temporary"/>

--- a/P5/Source/Specs/rt.xml
+++ b/P5/Source/Specs/rt.xml
@@ -51,7 +51,7 @@
           <att>to</att>.</p>
       </remarks>
     </attDef>
-    <attDef ident="from" usage="opt" mode="add">
+    <attDef ident="from" usage="opt">
       <desc xml:lang="en" versionDate="2021-01-06">points to the starting point of the span of text
         being glossed by this ruby text.</desc>
       <desc versionDate="2021-01-31" xml:lang="ja">ルビテキストの対象範囲の始点を示す。</desc>
@@ -71,7 +71,7 @@
         </constraint>
       </constraintSpec>
     </attDef>
-    <attDef ident="to" usage="opt" mode="add">
+    <attDef ident="to" usage="opt">
       <desc xml:lang="en" versionDate="2021-01-06">points to the ending point of the span of text
         being glossed.</desc>
       <desc versionDate="2021-01-31" xml:lang="ja">ルビテキストの対象範囲の終点を示す。</desc>

--- a/P5/Source/Specs/socecStatus.xml
+++ b/P5/Source/Specs/socecStatus.xml
@@ -91,7 +91,7 @@ $Id$
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="atBirth"/>
         <valItem ident="atDeath"/>
         <valItem ident="dependent"/>

--- a/P5/Source/Specs/standOff.xml
+++ b/P5/Source/Specs/standOff.xml
@@ -5,7 +5,7 @@ See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0"
-             ident="standOff" mode="add" module="linking"
+             ident="standOff" module="linking"
              xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <desc xml:lang="en" versionDate="2018-10-31">Functions as a
   container element for linked data, contextual information, and
@@ -22,7 +22,7 @@ See the file COPYING.txt for details
   <content>
     <classRef key="model.standOffPart" minOccurs="1" maxOccurs="unbounded"/>
   </content>
-  <constraintSpec ident="nested_standOff_should_be_typed" scheme="schematron" mode="add">
+  <constraintSpec ident="nested_standOff_should_be_typed" scheme="schematron">
     <constraint>
       <sch:assert test="@type or not(ancestor::tei:standOff)">This
       <sch:name/> element must have a @type attribute, since it is

--- a/P5/Source/Specs/tag.xml
+++ b/P5/Source/Specs/tag.xml
@@ -40,7 +40,7 @@ $Id$
       <desc versionDate="2009-01-23" xml:lang="fr">indique quel type de balise XML est prévu.</desc>
       <desc versionDate="2008-04-08" xml:lang="it">indica di quale tipo di marcatore XML si tratta</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="closed" mode="add">
+      <valList type="closed">
         <valItem ident="start">
           <desc versionDate="2008-04-05" xml:lang="en">a start-tag, with delimiters &lt; and &gt; is intended</desc>
           <desc versionDate="2009-01-23" xml:lang="fr">une balise de début, délimitée par les signes

--- a/P5/Source/Specs/tech.xml
+++ b/P5/Source/Specs/tech.xml
@@ -42,7 +42,7 @@ meant for the actors.</desc>
           scène.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica l'indicazione di scena tecnica.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="light">
           <desc versionDate="2007-06-27" xml:lang="en">a lighting cue</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">조명 신호</desc>

--- a/P5/Source/Specs/title.xml
+++ b/P5/Source/Specs/title.xml
@@ -284,7 +284,7 @@ doit pas être utilisé.</p>
                                         una tipologia conveniente.</desc>
       <desc versionDate="2017-06-04" xml:lang="de">klassifiziert den Titel entsprechend einer geeigneten Typologie.</desc> 
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="main">
           <desc versionDate="2007-06-27" xml:lang="en">main title</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">(주)제목</desc>

--- a/P5/Source/Specs/titlePart.xml
+++ b/P5/Source/Specs/titlePart.xml
@@ -44,7 +44,7 @@ indicated on a title page.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica il ruolo di tale sezione o partizione all'interno del titolo</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <defaultVal>main</defaultVal>
-      <valList type="semi" mode="add">
+      <valList type="semi">
         <valItem ident="main">
           <gloss xml:lang="en" versionDate="2017-06-19">main</gloss>
           <gloss versionDate="2017-06-19" xml:lang="de">Haupttitel</gloss>

--- a/P5/Source/Specs/usg.xml
+++ b/P5/Source/Specs/usg.xml
@@ -44,7 +44,7 @@ $Id$
       <desc versionDate="2007-05-04" xml:lang="es">clasifica la información sobre el uso aplicando una tipología funcional.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica le informazioni sull'uso secondo una tipologia funzionale.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="geo">
           <gloss versionDate="2007-07-04" xml:lang="en">geographic</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">지리적</gloss>

--- a/P5/Source/Specs/xr.xml
+++ b/P5/Source/Specs/xr.xml
@@ -58,7 +58,7 @@ $Id$
       <desc versionDate="2007-01-21" xml:lang="it">indica il tipo di riferimento incrociato secondo una
         tipologia funzionale</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open" mode="add">
+      <valList type="open">
         <valItem ident="syn">
           <gloss versionDate="2007-07-04" xml:lang="en">synonym</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">유의어</gloss>


### PR DESCRIPTION
Deleted `mode="add"` in the Source directory except in the `<egXML>` elements for issue #2498. 