### PR TITLE
Remove superfluous namespace declarations

### DIFF
--- a/P5/Source/Specs/teidata.authority.xml
+++ b/P5/Source/Specs/teidata.authority.xml
@@ -5,8 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei"
-  ident="teidata.authority">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.authority">
   <desc versionDate="2020-02-12" xml:lang="en">defines attribute values which derive from an 
     authority list, which may be an enumerated list defined in the document's schema, a list 
     or taxonomy elsewhere in the document, or an online taxonomy, gazetteer, or other authority.</desc>

--- a/P5/Source/Specs/teidata.certainty.xml
+++ b/P5/Source/Specs/teidata.certainty.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.certainty">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.certainty">
   <desc versionDate="2007-10-18" xml:lang="en">defines the range of attribute values expressing a degree of certainty.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">확실성 정도를 표현하는 속성 값의 범위를 정의한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">定義表示正確度的屬性值範圍</desc>

--- a/P5/Source/Specs/teidata.count.xml
+++ b/P5/Source/Specs/teidata.count.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.count">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.count">
   <desc versionDate="2007-10-18" xml:lang="en">defines the range of attribute values used for a non-negative
 integer value used as a count.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">계산으로 사용된 음이 아닌 정수 값의 속성 값 범위를 정의한다.</desc>

--- a/P5/Source/Specs/teidata.duration.iso.xml
+++ b/P5/Source/Specs/teidata.duration.iso.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.duration.iso">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.duration.iso">
   <desc versionDate="2007-04-09" xml:lang="en">defines the range of attribute values available for representation of a duration in time
     using ISO 8601 standard formats</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">ISO 8601 표준 형식을 사용하여 시간의 지속을 나타내는 속성 값 범위를 정의한다.</desc>

--- a/P5/Source/Specs/teidata.duration.w3c.xml
+++ b/P5/Source/Specs/teidata.duration.w3c.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.duration.w3c">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.duration.w3c">
   <desc versionDate="2007-10-18" xml:lang="en">defines the range of attribute values available for representation of a duration in time using W3C datatypes.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">W3C 데이터 유형을 사용해서 시간 지속을 나타내는 속성 값 범위를 정의한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">以W3C datatypes標準格式來定義表示一段持續性時間的屬性值範圍</desc>

--- a/P5/Source/Specs/teidata.enumerated.xml
+++ b/P5/Source/Specs/teidata.enumerated.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.enumerated">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.enumerated">
   <desc versionDate="2007-10-22" xml:lang="en">defines the range of attribute values expressed as a single XML name taken from a list of
     documented possibilities.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">기록된 확률의 목록으로부터 얻어진 단일 XML 이름으로 표현된 속성 값 범위를 정의한다.</desc>

--- a/P5/Source/Specs/teidata.gender.xml
+++ b/P5/Source/Specs/teidata.gender.xml
@@ -4,8 +4,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei"
-  ident="teidata.gender">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.gender">
   <desc versionDate="2022-05-17" xml:lang="en">defines the range of attribute values used to
     represent the gender of a person, persona, or character.</desc>
   <content>

--- a/P5/Source/Specs/teidata.interval.xml
+++ b/P5/Source/Specs/teidata.interval.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.interval">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.interval">
   <desc versionDate="2013-04-13" xml:lang="en">defines attribute values used to express an interval value.</desc>
   <content>
       <alternate>

--- a/P5/Source/Specs/teidata.key.xml
+++ b/P5/Source/Specs/teidata.key.xml
@@ -3,10 +3,8 @@ Copyright TEI Consortium.
 Dual-licensed under CC-by and BSD2 licences 
 See the file COPYING.txt for details
 -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><dataSpec xmlns="http://www.tei-c.org/ns/1.0"
-          xmlns:tei="http://www.tei-c.org/ns/1.0"
-          module="tei"
-          ident="teidata.key">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.key">
   <desc versionDate="2007-10-22"
          xml:lang="en">defines the range of attribute values expressing a coded value by means of an arbitrary
     identifier, typically taken from a set of externally-defined possibilities.</desc>

--- a/P5/Source/Specs/teidata.language.xml
+++ b/P5/Source/Specs/teidata.language.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.language">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.language">
   <desc versionDate="2007-10-18" xml:lang="en">defines the range of attribute values used to identify a particular combination of human
     language and writing system.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">인간의 언어와 문자 체계의 특별한 조합을 식별하는 속성 값 범위를 정의한다.</desc>

--- a/P5/Source/Specs/teidata.name.xml
+++ b/P5/Source/Specs/teidata.name.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.name">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.name">
   <desc versionDate="2007-10-18" xml:lang="en">defines the range of attribute values expressed as an XML Name.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">XML 이름으로 표현되는 속성 값 범위를 정의한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">定義的屬性值範圍以XML名稱或識別符碼表示</desc>

--- a/P5/Source/Specs/teidata.namespace.xml
+++ b/P5/Source/Specs/teidata.namespace.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.namespace">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.namespace">
   <desc versionDate="2007-10-14" xml:lang="en">defines the range of attribute values used to indicate XML namespaces as defined by the W3C
     <ref target="https://www.w3.org/TR/1999/REC-xml-names-19990114/">Namespaces in XML</ref>
     Technical Recommendation.</desc>

--- a/P5/Source/Specs/teidata.namespaceOrName.xml
+++ b/P5/Source/Specs/teidata.namespaceOrName.xml
@@ -4,10 +4,8 @@ Copyright TEI Consortium.
 Dual-licensed under CC-by and BSD2 licences 
 See the file COPYING.txt for details
 -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><dataSpec xmlns="http://www.tei-c.org/ns/1.0"
-          xmlns:tei="http://www.tei-c.org/ns/1.0"
-          module="tei"
-          ident="teidata.namespaceOrName">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.namespaceOrName">
   <desc versionDate="2017-05-23"
          xml:lang="en">defines attribute values which contain either an absolute namespace URI or a qualified XML name.</desc>
   <content>

--- a/P5/Source/Specs/teidata.nullOrName.xml
+++ b/P5/Source/Specs/teidata.nullOrName.xml
@@ -3,20 +3,17 @@ Copyright TEI Consortium.
 Dual-licensed under CC-by and BSD2 licences 
 See the file COPYING.txt for details
 -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><dataSpec xmlns="http://www.tei-c.org/ns/1.0"
-          xmlns:tei="http://www.tei-c.org/ns/1.0"
-          module="tei"
-          ident="teidata.nullOrName">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.nullOrName">
   <desc versionDate="2013-04-13"
          xml:lang="en">defines attribute values which contain either the null string or an XML name.</desc>
   <content>
-      <alternate>
-        <valList><valItem ident=""/></valList>
-          <dataRef name="NCName"/>
-   </alternate>
+    <alternate>
+      <valList><valItem ident=""/></valList>
+      <dataRef name="NCName"/>
+    </alternate>
   </content>
-  <remarks versionDate="2013-04-13"
-            xml:lang="en">
+  <remarks versionDate="2013-04-13" xml:lang="en">
       <p>The rules defining an XML name form a part of the XML Specification.</p>
   </remarks>
 </dataSpec>

--- a/P5/Source/Specs/teidata.numeric.xml
+++ b/P5/Source/Specs/teidata.numeric.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.numeric">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.numeric">
   <desc versionDate="2007-10-18" xml:lang="en">defines the range of attribute values used for numeric values.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">수치에 사용되는 속성 값의 범위를 정의한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">定義用於數值的屬性值範圍</desc>

--- a/P5/Source/Specs/teidata.outputMeasurement.xml
+++ b/P5/Source/Specs/teidata.outputMeasurement.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.outputMeasurement">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.outputMeasurement">
   <desc versionDate="2013-03-26" xml:lang="en">defines a range of values for use in specifying the size of an object that is intended for
     display.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">웹에서 디스플레이 목적의 대상 크기를 명시하는 값의 범위를 정의한다.</desc>

--- a/P5/Source/Specs/teidata.point.xml
+++ b/P5/Source/Specs/teidata.point.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tei" ident="teidata.point">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.point">
   <desc versionDate="2010-10-17" xml:lang="en">defines the data type used to express a point in cartesian space.</desc>
   <content>
     <dataRef name="token" restriction="(-?[0-9]+(\.[0-9]+)?,-?[0-9]+(\.[0-9]+)?)"/>

--- a/P5/Source/Specs/teidata.pointer.xml
+++ b/P5/Source/Specs/teidata.pointer.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.pointer">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.pointer">
   <desc versionDate="2013-01-19" xml:lang="en">defines the range of attribute values used to provide a single
   URI, absolute or relative, pointing to some other
 resource, either within the current document or elsewhere.</desc>

--- a/P5/Source/Specs/teidata.prefix.xml
+++ b/P5/Source/Specs/teidata.prefix.xml
@@ -6,10 +6,7 @@ See the file COPYING.txt for details
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl"
             type="application/xml"
 	    schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0"
-          xmlns:tei="http://www.tei-c.org/ns/1.0"
-	  module="tei"
-          ident="teidata.prefix">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.prefix">
   <desc versionDate="2016-11-28"
 	xml:lang="en">defines a range of values that may function as a URI scheme name.</desc>
   <content>

--- a/P5/Source/Specs/teidata.probCert.xml
+++ b/P5/Source/Specs/teidata.probCert.xml
@@ -3,16 +3,15 @@ Copyright TEI Consortium.
 Dual-licensed under CC-by and BSD2 licences 
 See the file COPYING.txt for details
 -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><dataSpec xmlns="http://www.tei-c.org/ns/1.0"
-          xmlns:tei="http://www.tei-c.org/ns/1.0"
-          module="tei"
-          ident="teidata.probCert">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.probCert">
   <desc versionDate="2007-10-18"
-         xml:lang="en">defines a range of attribute values which can be expressed either as a numeric probability or as a coded certainty value.</desc>
-<content>  
-  <alternate><dataRef key="teidata.probability"/>
-  <dataRef key="teidata.certainty"/>
-  </alternate>
+    xml:lang="en">defines a range of attribute values which can be expressed either as a numeric
+    probability or as a coded certainty value.</desc>
+  <content>
+    <alternate>
+      <dataRef key="teidata.probability" />
+      <dataRef key="teidata.certainty" />
+    </alternate>
   </content>
-  
 </dataSpec>

--- a/P5/Source/Specs/teidata.probability.xml
+++ b/P5/Source/Specs/teidata.probability.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.probability">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.probability">
   <desc versionDate="2007-10-18" xml:lang="en">defines the range of attribute values expressing a probability.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">확률을 표현하는 속성 값의 범위를 정의한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">定義表示可能性的屬性值範圍</desc>

--- a/P5/Source/Specs/teidata.replacement.xml
+++ b/P5/Source/Specs/teidata.replacement.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.replacement">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.replacement">
   <desc versionDate="2013-04-14" xml:lang="en">defines attribute values which contain a replacement template.</desc>
   <content>
       <textNode/>

--- a/P5/Source/Specs/teidata.sex.xml
+++ b/P5/Source/Specs/teidata.sex.xml
@@ -4,8 +4,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei"
-  ident="teidata.sex">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.sex">
   <desc versionDate="2022-05-10" xml:lang="en">defines the range of attribute values used to identify
     the sex of an organism.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">인간 또는 동물의 성을 식별하는 속성 값 범위를 정의한다.</desc>

--- a/P5/Source/Specs/teidata.temporal.iso.xml
+++ b/P5/Source/Specs/teidata.temporal.iso.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.temporal.iso">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.temporal.iso">
   <desc versionDate="2007-04-08" xml:lang="en">defines the range of attribute values expressing a temporal expression such as a date, a
     time, or a combination of them, that conform to the international standard <title>Data elements
       and interchange formats – Information interchange – Representation of dates and times</title>.</desc>

--- a/P5/Source/Specs/teidata.temporal.w3c.xml
+++ b/P5/Source/Specs/teidata.temporal.w3c.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.temporal.w3c">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.temporal.w3c">
   <desc versionDate="2007-04-08" xml:lang="en">defines the range of attribute values expressing a temporal
   expression such as a date, a time, or a combination of them, that
   conform to the W3C <ref target="#XSD2">XML Schema Part 2: Datatypes Second Edition</ref>

--- a/P5/Source/Specs/teidata.temporal.working.xml
+++ b/P5/Source/Specs/teidata.temporal.working.xml
@@ -4,9 +4,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0"
-          module="tei"
-          ident="teidata.temporal.working">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.temporal.working">
   <desc versionDate="2020-11-19" xml:lang="en">defines the range of
     values, conforming to the W3C <ref target="#XSD2">XML Schema Part 2:
   Datatypes Second Edition</ref> specification, expressing a date or

--- a/P5/Source/Specs/teidata.text.xml
+++ b/P5/Source/Specs/teidata.text.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.text">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.text">
   <desc versionDate="2012-06-17" xml:lang="en">defines the range of attribute values used to express some
   kind of identifying string as a single sequence
   of Unicode characters possibly including whitespace.</desc>

--- a/P5/Source/Specs/teidata.truthValue.xml
+++ b/P5/Source/Specs/teidata.truthValue.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.truthValue">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.truthValue">
   <desc versionDate="2007-10-22" xml:lang="en">defines the range of attribute values used to express a truth
 value.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">진리값을 표현하는 속성 값 범위를 정의한다.</desc>

--- a/P5/Source/Specs/teidata.version.xml
+++ b/P5/Source/Specs/teidata.version.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.version">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.version">
   <desc versionDate="2013-11-20" xml:lang="en">defines the range of attribute values which may be used to
   specify a TEI or Unicode version number.</desc>
   <desc xml:lang="fr" versionDate="2007-06-12">définit la gamme des valeurs d'attribut

--- a/P5/Source/Specs/teidata.versionNumber.xml
+++ b/P5/Source/Specs/teidata.versionNumber.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.versionNumber">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.versionNumber">
   <desc versionDate="2013-04-14" xml:lang="en">defines the range of attribute values used for version numbers.</desc>
   <content>
       <dataRef name="token" restriction="[\d]+[a-z]*[\d]*(\.[\d]+[a-z]*[\d]*){0,3}"/>

--- a/P5/Source/Specs/teidata.word.xml
+++ b/P5/Source/Specs/teidata.word.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.word">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.word">
   <desc versionDate="2007-10-22" xml:lang="en">defines the range of attribute values expressed as a single
   word or token.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">단일 단어 또는 토큰으로 표현된 속성 값 범위를 정의한다.</desc>

--- a/P5/Source/Specs/teidata.xTruthValue.xml
+++ b/P5/Source/Specs/teidata.xTruthValue.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.xTruthValue">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.xTruthValue">
   <gloss versionDate="2007-07-04" xml:lang="en">extended truth value</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">확장 진리값</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW"/>

--- a/P5/Source/Specs/teidata.xmlName.xml
+++ b/P5/Source/Specs/teidata.xmlName.xml
@@ -5,7 +5,7 @@ Dual-licensed under CC-by and BSD2 licences
 See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.xmlName">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.xmlName">
   <desc versionDate="2013-04-13" xml:lang="en">defines attribute values which contain an XML name.</desc>
   <content>
       <dataRef name="NCName"/>

--- a/P5/Source/Specs/teidata.xpath.xml
+++ b/P5/Source/Specs/teidata.xpath.xml
@@ -5,7 +5,7 @@
     See the file COPYING.txt for details
 -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<dataSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.xpath">
+<dataSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" ident="teidata.xpath">
 <desc versionDate="2013-04-14" xml:lang="en">defines attribute values
 which contain an XPath expression.</desc>
 <content>


### PR DESCRIPTION
For some reason in several `teidata` files there remained extra declarations of the TEI namespace. 
This PR cleans up all `teidata` files by removing these unnecessary namespace declarations.
(In order to increase readability I've added/removed some line breaks here and there.)
