### PR TITLE
Use reference to model.eventLike, not direct references to its members

### DIFF
--- a/P5/Source/Specs/event.xml
+++ b/P5/Source/Specs/event.xml
@@ -46,10 +46,7 @@
         <elementRef key="idno"/>
         <elementRef key="ptr"/>
       </alternate>
-      <alternate minOccurs="0" maxOccurs="unbounded">
-        <elementRef key="event" minOccurs="1" maxOccurs="1"/>
-        <elementRef key="listEvent" minOccurs="1" maxOccurs="1"/>
-      </alternate>
+      <classRef key="model.eventLike" minOccurs="0" maxOccurs="unbounded"/>
       <alternate minOccurs="0" maxOccurs="unbounded">
         <classRef key="model.personLike" minOccurs="1" maxOccurs="1"/>
         <elementRef key="listPerson" minOccurs="1" maxOccurs="1"/>

--- a/P5/Source/Specs/listEvent.xml
+++ b/P5/Source/Specs/listEvent.xml
@@ -11,8 +11,7 @@
   <gloss versionDate="2009-01-21" xml:lang="en">list of events</gloss>
   <gloss xml:lang="fr" versionDate="2009-03-19">liste d'événements</gloss>
   <gloss versionDate="2021-02-02" xml:lang="it">list di eventi</gloss>
-  <desc versionDate="2009-01-21" xml:lang="en">contains a list of descriptions, each of which provides information
-    about an identifiable event.</desc>
+  <desc versionDate="2009-01-21" xml:lang="en">contains a list of descriptions, each of which provides information about an identifiable event.</desc>
   <desc versionDate="2009-03-19" xml:lang="fr">contient une liste de descriptions, chacune d'entre elles fournissant des informations sur un événement connu.</desc>
   <desc versionDate="2021-02-02" xml:lang="it">contiene una lista di descrizioni, ognuna delle quali fornisce informazioni a proposito di un determinato evento.</desc>
   <classes>
@@ -32,14 +31,11 @@
         <elementRef key="listRelation" minOccurs="1" maxOccurs="1"/>
       </alternate>
       <sequence minOccurs="1" maxOccurs="unbounded">
-	<alternate minOccurs="1" maxOccurs="unbounded">
-	  <elementRef key="event" minOccurs="1" maxOccurs="1"/>
-	  <elementRef key="listEvent" minOccurs="1" maxOccurs="1"/>
-	</alternate>
-	<alternate minOccurs="0" maxOccurs="unbounded">
-	  <elementRef key="relation" minOccurs="1" maxOccurs="1"/>
-	  <elementRef key="listRelation" minOccurs="1" maxOccurs="1"/>
-	</alternate>
+        <classRef key="model.eventLike" minOccurs="1" maxOccurs="unbounded"/>
+        <alternate minOccurs="0" maxOccurs="unbounded">
+          <elementRef key="relation" minOccurs="1" maxOccurs="1"/>
+          <elementRef key="listRelation" minOccurs="1" maxOccurs="1"/>
+        </alternate>
       </sequence>
     </sequence>
   </content>


### PR DESCRIPTION
This is a pretty non-problematic change. Passes all tests on my system. I think _anyone_ can review, and once there has been at least one positive review _anyone_ can pull.