### PR TITLE
Updated prose and added deprecation information for ´superEntry´ element

### DIFF
--- a/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
+++ b/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
@@ -160,7 +160,8 @@ etc. </p>
 basis of etymology, part-of-speech, or both, and typically provide a
 numeric superscript on the headword identifying the homograph
 number. In these cases each homograph should be encoded as a separate
-entry; an outer <gi>entry</gi> element with a <att>type</att> attribute value of <val>encompassing</val> may be used to group
+entry; an outer <gi>entry</gi> element, perhaps with a <att>type</att> attribute,
+may be used to group
 such successive homograph entries. In addition to a series of
 <gi>entry</gi> elements, the <gi>entry</gi> may contain a
 preliminary <gi>form</gi> group (see section <ptr target="#DITPFO"/>)
@@ -177,34 +178,35 @@ order of entries does not follow the local character-set collating
 sequence (as, for example, when an entry for <q>3D</q> appears at the
 place where <q>three-D</q> would appear). </p>
 
-
-
-<p>A dictionary with no internal divisions might thus have a structure like
-  the following; an outer <gi>entry</gi> element with a <att>type</att> attribute value of <val>encompassing</val> is shown grouping two homograph
-entries.<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="und">
-<body>
-<entry>
-<form>
+<p>A dictionary with no internal divisions might thus have a structure
+like the following; an outer <gi>entry</gi> element with a
+<att>type</att> attribute value of <val>wordFamily</val> is shown
+grouping two homograph entries.
+<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="und">
+  <body>
+    <entry>
+      <form>
 	<orth>manifestation</orth> <!-- demonstration -->
-</form>
-</entry>
-<entry>
-<form>
+      </form>
+    </entry>
+    <entry>
+      <form>
 	<orth>émeute</orth> <!-- riot -->
-</form></entry>
-<entry type="encompassing">
- <entry type="hom" n="1">
-<form>
-	<orth>grève</orth> <!-- strike -->
-</form>
-</entry>
- <entry type="hom" n="2">
-<form>
-	<orth>grève</orth> <!-- shore -->
-</form>
-</entry>
-</entry>
-</body>
+      </form>
+    </entry>
+    <entry type="wordFamily">
+      <entry type="hom" n="1">
+	<form>
+	  <orth>grève</orth> <!-- strike -->
+	</form>
+      </entry>
+      <entry type="hom" n="2">
+	<form>
+	  <orth>grève</orth> <!-- shore -->
+	</form>
+      </entry>
+    </entry>
+  </body>
 </egXML>
 </p>
 
@@ -298,37 +300,38 @@ anomalous, as further discussed in section <ptr target="#DIFR"/>.<specList>
 </p>
 <p>An entry with two homographs, the first with two senses and the second with three
  (one of which has two sub-senses), may have a structure like this:<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="und" source="#UND">
-<entry>
-<hom n="1">
-<sense n="1"> <!-- ... --> </sense>
-<sense n="2"> <!-- ... --> </sense>
-</hom>
-<hom n="2">
-<sense n="1">
-<sense n="a"> <!-- ... --> </sense>
-<sense n="b"> <!-- ... --> </sense>
-</sense>
-<sense n="2"> <!-- ... --> </sense>
-<sense n="3"> <!-- ... --> </sense>
-</hom>
+ <entry>
+   <hom n="1">
+     <sense n="1"> <!-- ... --> </sense>
+     <sense n="2"> <!-- ... --> </sense>
+   </hom>
+   <hom n="2">
+     <sense n="1">
+       <sense n="a"> <!-- ... --> </sense>
+       <sense n="b"> <!-- ... --> </sense>
+     </sense>
+     <sense n="2"> <!-- ... --> </sense>
+     <sense n="3"> <!-- ... --> </sense>
+   </hom>
 </entry>
 </egXML> In some dictionaries, homographs have separate entries; in
 such a case, as noted in section <ptr target="#DIBO"/>, the two homographs may be
-  treated as entries, optionally grouped in an outer <gi>entry</gi> element with a <att>type</att> attribute value of <val>encompassing</val>:<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="und" source="#UND">
-<entry type="encompassing">
-<entry n="1" type="hom">
-<sense n="1"> <!-- ... --> </sense>
-<sense n="2"> <!-- ... --> </sense>
-</entry>
-<entry n="2" type="hom">
-<sense n="1">
-<sense n="a"> <!-- ... --> </sense>
-<sense n="b"> <!-- ... --> </sense>
-</sense>
-<sense n="2"> <!-- ... --> </sense>
-<sense n="3"> <!-- ... --> </sense>
-</entry>
-</entry>
+treated as entries, optionally grouped in an outer <gi>entry</gi> element:
+<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="und" source="#UND">
+  <entry>
+    <entry n="1" type="hom">
+      <sense n="1"> <!-- ... --> </sense>
+      <sense n="2"> <!-- ... --> </sense>
+    </entry>
+    <entry n="2" type="hom">
+      <sense n="1">
+	<sense n="a"> <!-- ... --> </sense>
+	<sense n="b"> <!-- ... --> </sense>
+      </sense>
+      <sense n="2"> <!-- ... --> </sense>
+      <sense n="3"> <!-- ... --> </sense>
+    </entry>
+  </entry>
 </egXML>
 </p>
 <p>The hierarchic structure of a dictionary entry is enforced by the

--- a/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
+++ b/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
@@ -88,8 +88,7 @@ text.</p>
 
 <p>Overall, dictionaries have the same structure of front matter,
 body, and back matter familiar from other texts. In addition,
-this module defines <gi>entry</gi>, <gi>entryFree</gi>,
-and <gi>superEntry</gi> as component-level elements which can occur
+this module defines <gi>entry</gi>, and <gi>entryFree</gi>, as component-level elements which can occur
 directly within a text division or the text body. </p>
 
 <p>The following tags can therefore be used to mark the gross structure of a
@@ -102,7 +101,6 @@ in the following section.<specList>
 <specDesc key="div"/>
 <specDesc key="entry"/>
 <specDesc key="entryFree"/>
-<specDesc key="superEntry"/>
 </specList></p>
 
 <p>As members of the classes <ident type="class">att.entryLike</ident> and 
@@ -162,9 +160,9 @@ etc. </p>
 basis of etymology, part-of-speech, or both, and typically provide a
 numeric superscript on the headword identifying the homograph
 number. In these cases each homograph should be encoded as a separate
-entry; the <gi>superEntry</gi> element may optionally be used to group
+entry; an outer <gi>entry</gi> element with a <att>type</att> attribute value of <val>encompassing</val> may be used to group
 such successive homograph entries. In addition to a series of
-<gi>entry</gi> elements, the <gi>superEntry</gi> may contain a
+<gi>entry</gi> elements, the <gi>entry</gi> may contain a
 preliminary <gi>form</gi> group (see section <ptr target="#DITPFO"/>)
 when information about hyphenation, pronunciation, etc., is given only
 once for two or more homograph entries. If the homograph number is to
@@ -182,7 +180,7 @@ place where <q>three-D</q> would appear). </p>
 
 
 <p>A dictionary with no internal divisions might thus have a structure like
-the following; a <gi>superEntry</gi> is shown grouping two homograph
+  the following; an outer <gi>entry</gi> element with a <att>type</att> attribute value of <val>encompassing</val> is shown grouping two homograph
 entries.<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="und">
 <body>
 <entry>
@@ -194,7 +192,7 @@ entries.<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="und">
 <form>
 	<orth>émeute</orth> <!-- riot -->
 </form></entry>
-<superEntry>
+<entry type="encompassing">
  <entry type="hom" n="1">
 <form>
 	<orth>grève</orth> <!-- strike -->
@@ -205,7 +203,7 @@ entries.<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="und">
 	<orth>grève</orth> <!-- shore -->
 </form>
 </entry>
-</superEntry>
+</entry>
 </body>
 </egXML>
 </p>
@@ -316,8 +314,8 @@ anomalous, as further discussed in section <ptr target="#DIFR"/>.<specList>
 </entry>
 </egXML> In some dictionaries, homographs have separate entries; in
 such a case, as noted in section <ptr target="#DIBO"/>, the two homographs may be
- treated as entries, optionally grouped in a <gi>superEntry</gi>:<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="und" source="#UND">
-<superEntry>
+  treated as entries, optionally grouped in an outer <gi>entry</gi> element with a <att>type</att> attribute value of <val>encompassing</val>:<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="und" source="#UND">
+<entry type="encompassing">
 <entry n="1" type="hom">
 <sense n="1"> <!-- ... --> </sense>
 <sense n="2"> <!-- ... --> </sense>
@@ -330,7 +328,7 @@ such a case, as noted in section <ptr target="#DIBO"/>, the two homographs may b
 <sense n="2"> <!-- ... --> </sense>
 <sense n="3"> <!-- ... --> </sense>
 </entry>
-</superEntry>
+</entry>
 </egXML>
 </p>
 <p>The hierarchic structure of a dictionary entry is enforced by the
@@ -646,14 +644,14 @@ appeal earnestly to ... [CP] </q>
 -->
 </p>
 <p>Alone among the constituent groups, <gi>form</gi> can appear at the
-<gi>superEntry</gi> level as well as at the <gi>entry</gi>, <gi>hom</gi>, and
+<gi>entry</gi>, <gi>hom</gi>, and
 <gi>sense</gi> levels:<q rend="display">
 <hi rend="bold">a.ban.don</hi> 1<code lang="ipa">/@"band@n/ </code>
 v [T1] 1 to leave completely and for ever; desert: The sailors abandoned the
 burning ship. 2 …<hi rend="bold">abandon</hi> 2 n [U] the state when one's
 feelings and actions are uncontrolled; freedom from control...<ref target="#DIC-LDOCE">LDOCE</ref></q>
 <egXML xmlns="http://www.tei-c.org/ns/Examples">
-<superEntry>
+<entry>
 <form>
 <orth>abandon</orth>
 <hyph>a|ban|don</hyph>
@@ -679,7 +677,7 @@ feelings and actions are uncontrolled; freedom from control...<ref target="#DIC-
 from control…</def>
 </sense>
 </entry>
-</superEntry>
+</entry>
 </egXML>
 </p>
 </div>

--- a/P5/Source/Specs/superEntry.xml
+++ b/P5/Source/Specs/superEntry.xml
@@ -2,7 +2,7 @@
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="dictionaries" ident="superEntry" validUntil="2027-03-07">
-  <desc xml:lang="en" type="deprecationInfo" versionDate="2023-03-07">Because an <gi>entry</gi> can now occur inside an <gi>entry</gi>, the <gi>superEntry</gi> element is no longer needed. These Guidelines recommend using an <gi>entry</gi> with a <att>type</att> attribute value of <val>encompassing</val> instead.</desc>
+  <desc xml:lang="en" type="deprecationInfo" versionDate="2023-03-07">Because an <gi>entry</gi> can now occur inside an <gi>entry</gi>, the <gi>superEntry</gi> element is no longer needed. For instances where the <gi>superEntry</gi> element was used to group multiple <gi>entry</gi> elements, these Guidelines recommend using an outer <gi>entry</gi> element with a <att>type</att> attribute value of <val>encompassing</val> instead.</desc>
   <gloss xml:lang="en" versionDate="2020-12-20">super entry</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">groupe d'entrées</gloss>
   <desc versionDate="2011-04-29" xml:lang="en">groups a sequence of entries within any kind of lexical resource, such

--- a/P5/Source/Specs/superEntry.xml
+++ b/P5/Source/Specs/superEntry.xml
@@ -2,17 +2,20 @@
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="dictionaries" ident="superEntry" validUntil="2027-03-07">
-  <desc xml:lang="en" type="deprecationInfo" versionDate="2023-03-07">Because an <gi>entry</gi> can now occur inside an <gi>entry</gi>, the <gi>superEntry</gi> element is no longer needed. For instances where the <gi>superEntry</gi> element was used to group multiple <gi>entry</gi> elements, these Guidelines recommend using an outer <gi>entry</gi> element with a <att>type</att> attribute value of <val>encompassing</val> instead.</desc>
+  <desc xml:lang="en" type="deprecationInfo"
+  versionDate="2024-03-07">Because an <gi>entry</gi> can now occur
+  inside an <gi>entry</gi>, the <gi>superEntry</gi> element is no
+  longer needed. For instances where the <gi>superEntry</gi> element
+  was used to group multiple <gi>entry</gi> elements, these Guidelines
+  recommend using instead an outer <gi>entry</gi> element, perhaps
+  with a <att>type</att> attribute.</desc>
   <gloss xml:lang="en" versionDate="2020-12-20">super entry</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">groupe d'entrées</gloss>
-  <desc versionDate="2011-04-29" xml:lang="en">groups a sequence of entries within any kind of lexical resource, such
-  as a dictionary or lexicon which function as a single unit, for
-  example a set of homographs.</desc>
+  <desc versionDate="2011-04-29" xml:lang="en">groups a sequence of entries within any kind of lexical resource, such as a dictionary or lexicon which function as a single unit, for example a set of homographs.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">동형이의어 집합의 연속된 표제 항목을 모아 놓는다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">匯集一組同形異義字的連續辭條。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">同形異義語の集合にある、一連の項目をまとめる。</desc>
-  <desc versionDate="2007-06-12" xml:lang="fr">regroupe des entrées successives pour un ensemble
-			d'homographes.</desc>
+  <desc versionDate="2007-06-12" xml:lang="fr">regroupe des entrées successives pour un ensemble d'homographes.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">agrupa las entradas sucesivas para una serie de homógrafos.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">raggruppa voci successive per una serie di omografi.</desc>
   <classes>
@@ -25,12 +28,8 @@
   <content>
     <alternate>
       <sequence>
-        
-          <elementRef key="form" minOccurs="0"/>
-        
-        
-          <elementRef key="entry" minOccurs="1" maxOccurs="unbounded"/>
-        
+        <elementRef key="form" minOccurs="0"/>
+        <elementRef key="entry" minOccurs="1" maxOccurs="unbounded"/>
       </sequence>
       <elementRef key="dictScrap"/>
     </alternate>

--- a/P5/Source/Specs/superEntry.xml
+++ b/P5/Source/Specs/superEntry.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="dictionaries" ident="superEntry">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="dictionaries" ident="superEntry" validUntil="2027-03-07">
+  <desc xml:lang="en" type="deprecationInfo" versionDate="2023-03-07">Because an <gi>entry</gi> can now occur inside an <gi>entry</gi>, the <gi>superEntry</gi> element is no longer needed. These Guidelines recommend using an <gi>entry</gi> with a <att>type</att> attribute value of <val>encompassing</val> instead.</desc>
   <gloss xml:lang="en" versionDate="2020-12-20">super entry</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">groupe d'entrées</gloss>
   <desc versionDate="2011-04-29" xml:lang="en">groups a sequence of entries within any kind of lexical resource, such


### PR DESCRIPTION
Added deprecation information to the `<superEntry>` element spec page and updated the prose and examples related to the `<superEntry>` element accordingly.