### PR TITLE
Cosmetic changes in prep for next …

### DIFF
--- a/P5/Exemplars/tei_enrich.odd
+++ b/P5/Exemplars/tei_enrich.odd
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-    
      xmlns:xi="http://www.w3.org/2001/XInclude"
      xmlns:s="http://www.ascc.net/xml/schematron"
      xml:lang="en"

--- a/P5/Exemplars/tei_simplePrint.odd
+++ b/P5/Exemplars/tei_simplePrint.odd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <teiHeader>
     <fileDesc>
       <titleStmt>
@@ -3483,13 +3483,13 @@ live without God in the world, and only mind earthly things.
                 <attDef ident="target" mode="change">
                   <constraintSpec ident="validtarget" scheme="schematron">
                     <constraint>
-                      <rule xmlns="http://purl.oclc.org/dsdl/schematron" context="tei:*[@target]">
-                        <let name="results"
+                      <sch:rule context="tei:*[@target]">
+                        <sch:let name="results"
                           value="for $t in  tokenize(normalize-space(@target),'\s+') return starts-with($t,'#') and not(id(substring($t,2)))"/>
-                        <report test="some $x in $results  satisfies $x"> Error: Every local pointer
-                          in "<value-of select="@target"/>" must point to an ID in this document
-                            (<value-of select="$results"/>)</report>
-                      </rule>
+                        <sch:report test="some $x in $results satisfies $x"> Error: Every local pointer
+                          in "<sch:value-of select="@target"/>" must point to an ID in this document
+                            (<sch:value-of select="$results"/>)</sch:report>
+                      </sch:rule>
                     </constraint>
                   </constraintSpec>
                 </attDef>
@@ -3498,24 +3498,28 @@ live without God in the world, and only mind earthly things.
             <classSpec type="atts" ident="att.global.rendition" mode="change">
               <constraintSpec ident="renditionpointer" scheme="schematron">
                 <constraint>
-                  <rule xmlns="http://purl.oclc.org/dsdl/schematron" context="tei:*[@rendition]">
-                    <let name="results"
-                      value="for $val in tokenize(normalize-space(@rendition),'\s+') return starts-with($val,'simple:')        or        (starts-with($val,'#')        and        //tei:rendition[@xml:id=substring($val,2)])"/>
-                    <assert test="every $x in $results satisfies $x"> Error: Each of the rendition
-                      values in "<value-of select="@rendition"/>" must point to a local ID or to a
-                      token in the Simple scheme (<value-of select="$results"/>)</assert>
-                  </rule>
+                  <sch:rule context="tei:*[@rendition]">
+                    <sch:let name="results"
+                      value="for $val in tokenize(normalize-space(@rendition),'\s+') return starts-with($val,'simple:')
+                             or
+                             (starts-with($val,'#')
+                             and
+                             //tei:rendition[@xml:id=substring($val,2)])"/>
+                    <sch:assert test="every $x in $results satisfies $x"> Error: Each of the rendition
+                      values in "<sch:value-of select="@rendition"/>" must point to a local ID or to a
+                      token in the Simple scheme (<sch:value-of select="$results"/>)</sch:assert>
+                  </sch:rule>
                 </constraint>
               </constraintSpec>
               <constraintSpec ident="corresppointer" scheme="schematron">
                 <constraint>
-                  <rule xmlns="http://purl.oclc.org/dsdl/schematron" context="tei:*[@corresp]">
-                    <let name="results"
+                  <sch:rule context="tei:*[@corresp]">
+                    <sch:let name="results"
                       value="for $t in tokenize(normalize-space(@corresp),'\s+') return starts-with($t,'#') and not(id(substring($t,2)))"/>
-                    <report test="some $x in $results  satisfies $x"> Error: Every local pointer in
-                        "<value-of select="@corresp"/>" must point to an ID in this document
-                        (<value-of select="$results"/>)</report>
-                  </rule>
+                    <sch:report test="some $x in $results  satisfies $x"> Error: Every local pointer in
+                        "<sch:value-of select="@corresp"/>" must point to an ID in this document
+                        (<sch:value-of select="$results"/>)</sch:report>
+                  </sch:rule>
                 </constraint>
               </constraintSpec>
               <!-- remove unused attributes @rend and @style; constrain values for @rendition -->
@@ -3993,9 +3997,8 @@ live without God in the world, and only mind earthly things.
             <elementSpec ident="bibl" mode="change">
               <constraintSpec mode="add" ident="noEmptyBibl" scheme="schematron">
                 <constraint>
-                  <assert xmlns="http://purl.oclc.org/dsdl/schematron"
-                    test="child::* or child::text()[normalize-space()]" role="ERROR"> Element
-                    "<name/>" may not be empty. </assert>
+                  <sch:assert test="child::* or child::text()[normalize-space()]" role="ERROR"> Element
+                    "<sch:name/>" may not be empty. </sch:assert>
                 </constraint>
               </constraintSpec>
               <model predicate="parent::listBibl" behaviour="listItem"/>
@@ -4109,16 +4112,26 @@ live without God in the world, and only mind earthly things.
             <elementSpec ident="choice" mode="change">
               <constraintSpec ident="choiceSize" scheme="schematron" mode="add">
                 <constraint>
-                  <assert xmlns="http://purl.oclc.org/dsdl/schematron" test="count(*) &gt; 1"
-                    role="ERROR"> Element "<name/>" must have at least two child elements.</assert>
+                  <sch:assert test="count(*) &gt; 1" role="ERROR"> Element "<sch:name/>" must have at least two child elements.</sch:assert>
                 </constraint>
               </constraintSpec>
               <constraintSpec ident="choiceContent" scheme="schematron" mode="add">
                 <constraint>
-                  <assert xmlns="http://purl.oclc.org/dsdl/schematron"
-                    test="(tei:corr or tei:sic or tei:expan or     tei:abbr or tei:reg or tei:orig) and ((tei:corr and tei:sic) or (tei:expan     and tei:abbr) or (tei:reg and tei:orig))"
-                    role="ERROR"> Element "<name/>" must have corresponding corr/sic, expand/abbr,
-                    reg/orig </assert>
+                  <sch:assert test="( tei:corr
+                                   or tei:sic
+                                   or tei:expan
+                                   or tei:abbr
+                                   or tei:reg
+                                   or tei:orig )
+                                   and
+                                   (
+                                     (tei:corr and tei:sic)
+                                     or
+                                     (tei:expan and tei:abbr)
+                                     or
+                                     (tei:reg and tei:orig)
+                                   )" role="ERROR">
+                    Element "<sch:name/>" must have corresponding corr/sic, expand/abbr, reg/orig </sch:assert>
                 </constraint>
               </constraintSpec>
               <model output="plain" predicate="sic and corr" behaviour="inline">
@@ -5082,22 +5095,18 @@ live without God in the world, and only mind earthly things.
 
             </elementSpec>
             <elementSpec ident="text" mode="change">
-              <constraintSpec xmlns="http://www.tei-c.org/ns/1.0"
-                xmlns:XSL="http://www.w3.org/1999/XSL/Transform" ident="headeronlyelement"
-                scheme="schematron">
+              <constraintSpec ident="headeronlyelement" scheme="schematron">
                 <constraint>
-                  <!-- <rule xmlns="http://purl.oclc.org/dsdl/schematron"
+                  <!-- <sch:rule
                     context="tei:att | tei:biblFull | tei:biblStruct | tei:change | tei:charDecl | tei:charProp | tei:editor
                     | tei:editorialDecl | tei:email | tei:encodingDesc | tei:extent | tei:fileDesc | tei:gi | tei:glyph | tei:glyphName | 
                     tei:idno | tei:imprint | tei:keywords | tei:licence | tei:listChange | tei:listPerson | tei:localName | tei:monogr | 
                     tei:msDesc | tei:msIdentifier | tei:person | tei:physDesc | tei:profileDesc | tei:publicationStmt | tei:relatedItem | 
                     tei:repository | tei:resp | tei:respStmt | tei:sourceDesc | tei:tag | tei:teiHeader | tei:term | tei:textClass | tei:textDesc 
                     | tei:titleStmt | tei:typeDesc | tei:val | tei:value">-->
-                  <rule xmlns="http://purl.oclc.org/dsdl/schematron"
-                    context="tei:term | tei:biblFull ">
-                    <report test="ancestor::tei:text">Error: The element <name/> is not permitted
-                      outside the header</report>
-                  </rule>
+                  <sch:rule context="tei:term | tei:biblFull">
+                    <sch:report test="ancestor::tei:text">Error: The element <sch:name/> is not permitted outside the header</sch:report>
+                  </sch:rule>
                 </constraint>
               </constraintSpec>
               <model behaviour="body">

--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -714,9 +714,9 @@ $Id$
         <elementSpec mode="change" ident="TEI">
           <constraintSpec ident="must-have-attglobal" scheme="schematron" mode="add">
             <constraint>
-              <rule context="tei:elementSpec[not(@mode)]" xmlns="http://purl.oclc.org/dsdl/schematron">
-                <assert test="tei:classes/tei:memberOf[@key='att.global']">Error: TEI element <value-of select="@ident"/> must be member of att.global class</assert>
-              </rule>
+              <sch:rule context="tei:elementSpec[not(@mode)]">
+                <sch:assert test="tei:classes/tei:memberOf[@key='att.global']">Error: TEI element <sch:value-of select="@ident"/> must be member of att.global class</sch:assert>
+              </sch:rule>
             </constraint>
           </constraintSpec>
         </elementSpec>
@@ -724,14 +724,14 @@ $Id$
         <elementSpec ident="remarks" mode="change">          
           <constraintSpec ident="only-one-remark-per-lang" scheme="schematron" mode="add">
             <constraint>
-              <rule context="tei:remarks[@xml:lang]" xmlns="http://purl.oclc.org/dsdl/schematron">
-                <let name="langVal" value="@xml:lang"/>
-                <assert test="not(following-sibling::tei:remarks[@xml:lang=$langVal])">
-                  Error: There should only be one <value-of select="@ident"/> element per 
-                  language. Merge the contents of multiple <value-of select="@ident"/> elements
+              <sch:rule context="tei:remarks[@xml:lang]">
+                <sch:let name="langVal" value="@xml:lang"/>
+                <sch:assert test="not(following-sibling::tei:remarks[@xml:lang=$langVal])">
+                  Error: There should only be one <sch:value-of select="@ident"/> element per 
+                  language. Merge the contents of multiple <sch:value-of select="@ident"/> elements
                   using separate p elements.
-                </assert>
-              </rule>
+                </sch:assert>
+              </sch:rule>
             </constraint>
           </constraintSpec>
         </elementSpec>


### PR DESCRIPTION
No actual changes to constraints or prose. Passes tests locally. (But neither xelatex nor onvdl work on my system, and I have been have trouble with the docker image lately.)

1. Use namespace prefixes instead of declarations; and
2. some whitespace tweaks.