### PR TITLE
Fix remaining contextless constraints

### DIFF
--- a/P5/Exemplars/tei_enrich.odd
+++ b/P5/Exemplars/tei_enrich.odd
@@ -3453,8 +3453,11 @@ which should be supported by a more detailed description using the
           <elementSpec ident="date" mode="change" module="core">
             <constraintSpec scheme="schematron" ident="dates">
               <constraint>
-                <sch:assert test="@when or (@notAfter and @notBefore) or    (@from and @to)">
-                You must provide either @when or @to/@from, or @notAfter/@notBefore.</sch:assert>
+		<sch:rule context="tei:date">
+                  <sch:assert test="@when  or  (@notAfter and @notBefore)  or  (@from and @to)">
+                    You must provide either @when or @to/@from, or @notAfter/@notBefore.
+		  </sch:assert>
+		</sch:rule>
               </constraint>
             </constraintSpec>
           </elementSpec>

--- a/P5/Exemplars/tei_simplePrint.odd
+++ b/P5/Exemplars/tei_simplePrint.odd
@@ -3484,8 +3484,13 @@ live without God in the world, and only mind earthly things.
                   <constraintSpec ident="validtarget" scheme="schematron">
                     <constraint>
                       <sch:rule context="tei:*[@target]">
+			<!-- If & when we are confident the processor
+			     will be an XPath 3+ processor the
+			     “tokenize(normalize-space(@target),'\s+')”
+			     below could be shortened to just
+			     “tokenize(@target)”. —Syd, 2024-04-12 -->
                         <sch:let name="results"
-                          value="for $t in  tokenize(normalize-space(@target),'\s+') return starts-with($t,'#') and not(id(substring($t,2)))"/>
+                          value="for $t in tokenize(normalize-space(@target),'\s+') return starts-with($t,'#') and not(id(substring($t,2)))"/>
                         <sch:report test="some $x in $results satisfies $x"> Error: Every local pointer
                           in "<sch:value-of select="@target"/>" must point to an ID in this document
                             (<sch:value-of select="$results"/>)</sch:report>
@@ -3997,8 +4002,11 @@ live without God in the world, and only mind earthly things.
             <elementSpec ident="bibl" mode="change">
               <constraintSpec mode="add" ident="noEmptyBibl" scheme="schematron">
                 <constraint>
-                  <sch:assert test="child::* or child::text()[normalize-space()]" role="ERROR"> Element
-                    "<sch:name/>" may not be empty. </sch:assert>
+		   <sch:rule context="tei:bibl">		   		  
+                     <sch:assert test="child::* or child::text()[normalize-space()]" role="ERROR">
+		       Element "<sch:name/>" may not be empty.
+		     </sch:assert>
+		   </sch:rule>
                 </constraint>
               </constraintSpec>
               <model predicate="parent::listBibl" behaviour="listItem"/>
@@ -4112,26 +4120,24 @@ live without God in the world, and only mind earthly things.
             <elementSpec ident="choice" mode="change">
               <constraintSpec ident="choiceSize" scheme="schematron" mode="add">
                 <constraint>
-                  <sch:assert test="count(*) &gt; 1" role="ERROR"> Element "<sch:name/>" must have at least two child elements.</sch:assert>
+		   <sch:rule context="tei:choice"> 		  
+                     <sch:assert test="count(*) gt 1" role="ERROR">
+		       Element "<sch:name/>" must have at least two child elements.
+		     </sch:assert>
+		   </sch:rule>
                 </constraint>
               </constraintSpec>
               <constraintSpec ident="choiceContent" scheme="schematron" mode="add">
                 <constraint>
-                  <sch:assert test="( tei:corr
-                                   or tei:sic
-                                   or tei:expan
-                                   or tei:abbr
-                                   or tei:reg
-                                   or tei:orig )
-                                   and
-                                   (
-                                     (tei:corr and tei:sic)
-                                     or
-                                     (tei:expan and tei:abbr)
-                                     or
-                                     (tei:reg and tei:orig)
-                                   )" role="ERROR">
-                    Element "<sch:name/>" must have corresponding corr/sic, expand/abbr, reg/orig </sch:assert>
+		  <sch:rule context="tei:choice">
+		    <sch:assert test="( tei:corr and tei:sic )
+                                      or
+                                      ( tei:expan and tei:abbr )
+                                      or
+                                      ( tei:reg and tei:orig )" role="ERROR">
+                      Element "<sch:name/>" must have corresponding corr/sic, expand/abbr, reg/orig
+		    </sch:assert>
+		  </sch:rule>
                 </constraint>
               </constraintSpec>
               <model output="plain" predicate="sic and corr" behaviour="inline">

--- a/P5/Test/testmeta2010.odd
+++ b/P5/Test/testmeta2010.odd
@@ -51,9 +51,10 @@
 	     <attDef ident="type" mode="change">
 	       <constraintSpec mode="add" ident="a1" scheme="schematron">
 		 <constraint>
-		   <sch:assert
-		       test="count(ancestor-or-self::tei:list[1]/tei:item)&lt;2">list
-		 too short </sch:assert></constraint>
+		   <sch:rule context="tei:list/@type">		   
+		     <sch:assert test="count( ancestor-or-self::tei:list[1]/tei:item ) lt 2">list too short </sch:assert>
+		   </sch:rule>
+		 </constraint>
 	       </constraintSpec>
 	       <valList type="closed" mode="replace">
 		 <valItem ident="enumerated"/>

--- a/P5/Utilities/TEI-to-tei_customization.xslt
+++ b/P5/Utilities/TEI-to-tei_customization.xslt
@@ -53,6 +53,10 @@
 
   <xsl:variable name="revisionDesc">
     <revisionDesc>
+      <change who="#sbauman.emt" when="2024-04-12">
+	Added <gi>sch:rule</gi> elements PRN to avoid new warning
+	about contextless Schematron.
+      </change>
       <change who="#sbauman.emt" when="2023-06-06">
 	<list>
 	  <item>Remove the <ident>altIdent-only-NCName</ident>
@@ -758,16 +762,17 @@
                 <constraintSpec scheme="schematron" ident="required-modules">
                   <gloss>required modules</gloss>
                   <constraint>
-                    <sch:assert test="
-                      ( tei:moduleRef[ @key eq 'tei'] or tei:specGrpRef[ id( substring-after( normalize-space( @target ), '#') )/tei:moduleRef[ @key eq 'tei'] ] )                      
-                      and
-                      ( tei:moduleRef[ @key eq 'core'] or tei:specGrpRef[ id( substring-after( normalize-space( @target ), '#') )/tei:moduleRef[ @key eq 'core'] ] )                      
-                      and
-                      ( tei:moduleRef[ @key eq 'header'] or tei:specGrpRef[ id( substring-after( normalize-space( @target ), '#') )/tei:moduleRef[ @key eq 'header'] ] )                      
-                      and
-                      ( tei:moduleRef[ @key eq 'textstructure'] or tei:specGrpRef[ id( substring-after( normalize-space( @target ), '#') )/tei:moduleRef[ @key eq 'textstructure'] ] )                      
-                      "> missing one or more of the required modules (tei, core, header,
-                      textstructure). </sch:assert>
+		    <sch:rule context="tei:schemaSpec">
+                      <sch:assert test="
+                        ( tei:moduleRef[ @key eq 'tei'] or tei:specGrpRef[ id( substring-after( normalize-space( @target ), '#') )/tei:moduleRef[ @key eq 'tei'] ] )                      
+                        and
+                        ( tei:moduleRef[ @key eq 'core'] or tei:specGrpRef[ id( substring-after( normalize-space( @target ), '#') )/tei:moduleRef[ @key eq 'core'] ] )                      
+                        and
+                        ( tei:moduleRef[ @key eq 'header'] or tei:specGrpRef[ id( substring-after( normalize-space( @target ), '#') )/tei:moduleRef[ @key eq 'header'] ] )                      
+                        and
+                        ( tei:moduleRef[ @key eq 'textstructure'] or tei:specGrpRef[ id( substring-after( normalize-space( @target ), '#') )/tei:moduleRef[ @key eq 'textstructure'] ] )                      
+                        ">missing one or more of the required modules (tei, core, header, textstructure).</sch:assert>
+		    </sch:rule>
                   </constraint>
                 </constraintSpec>
                 <constraintSpec scheme="schematron" ident="no-outside-specs">
@@ -1204,38 +1209,44 @@
                 </content>
                 <constraintSpec scheme="schematron" ident="module-except-when-add">
                   <constraint>
-                    <sch:assert test="@mode">in a customization ODD, the mode= attribute of
-                      ＜elementSpec＞ should be specified</sch:assert>
-                    <sch:report
-                      test="not( @module )  and  not( @mode='add')"
-                      >the module= attribute of ＜elementSpec＞ must be specified anytime the mode= is
-                      not 'add'</sch:report>
+		   <sch:rule context="tei:elementSpec">
+                     <sch:assert test="@mode">
+		       in a customization ODD, the mode= attribute of ＜elementSpec＞ should be specified
+		     </sch:assert>
+                     <sch:report test="not( @module )  and  not( @mode='add')" >
+		       the module= attribute of ＜elementSpec＞ must be specified anytime the mode= is not 'add'
+		     </sch:report>
+		   </sch:rule>
                   </constraint>
                 </constraintSpec>
                 <constraintSpec scheme="schematron" ident="only-1-per">
                   <constraint>
-                    <sch:report test=
-                      "//tei:elementSpec[ @ident eq current()/@ident  and  not( . is current() ) ]"
-                      >Current ODD processors will not correctly handle more than one ＜elementSpec＞ with the same @ident</sch:report>
+		   <sch:rule context="tei:elementSpec">
+                     <sch:report test="//tei:elementSpec[ @ident eq current()/@ident  and  not( . is current() ) ]" >
+		       Current ODD processors will not correctly handle more than one ＜elementSpec＞ with the same @ident
+		     </sch:report>
+		   </sch:rule>
                   </constraint>
                 </constraintSpec>
                 <constraintSpec scheme="schematron" ident="dont-delete-required">
                   <constraint>
-                    <sch:report test="@mode='delete' and @ident='TEI'">Removing ＜TEI＞ from your
-                      schema guarantees it is not TEI conformant</sch:report>
-                    <sch:report test="@mode='delete' and @ident='teiHeader'">Removing ＜teiHeader＞
-                      from your schema guarantees it is not TEI conformant</sch:report>
-                    <sch:report test="@mode='delete' and @ident='fileDesc'">Removing ＜fileDesc＞ from
-                      your schema guarantees it is not TEI conformant</sch:report>
-                    <sch:report test="@mode='delete' and @ident='titleStmt'">Removing ＜titleStmt＞
-                      from your schema guarantees it is not TEI conformant</sch:report>
-                    <sch:report test="@mode='delete' and @ident='title'">Removing ＜title＞ from your
-                      schema guarantees it is not TEI conformant</sch:report>
-                    <sch:report test="@mode='delete' and @ident='publicationStmt'">Removing
-                      ＜publicationStmt＞ from your schema guarantees it is not TEI
-                      conformant</sch:report>
-                    <sch:report test="@mode='delete' and @ident='sourceDesc'">Removing ＜sourceDesc＞
-                      from your schema guarantees it is not TEI conformant</sch:report>
+		    <sch:rule context="tei:elementSpec">
+                      <sch:report test="@mode='delete' and @ident='TEI'">Removing ＜TEI＞ from your
+                        schema guarantees it is not TEI conformant</sch:report>
+                      <sch:report test="@mode='delete' and @ident='teiHeader'">Removing ＜teiHeader＞
+                        from your schema guarantees it is not TEI conformant</sch:report>
+                      <sch:report test="@mode='delete' and @ident='fileDesc'">Removing ＜fileDesc＞ from
+                        your schema guarantees it is not TEI conformant</sch:report>
+                      <sch:report test="@mode='delete' and @ident='titleStmt'">Removing ＜titleStmt＞
+                        from your schema guarantees it is not TEI conformant</sch:report>
+                      <sch:report test="@mode='delete' and @ident='title'">Removing ＜title＞ from your
+                        schema guarantees it is not TEI conformant</sch:report>
+                      <sch:report test="@mode='delete' and @ident='publicationStmt'">Removing
+                        ＜publicationStmt＞ from your schema guarantees it is not TEI
+                        conformant</sch:report>
+                      <sch:report test="@mode='delete' and @ident='sourceDesc'">Removing ＜sourceDesc＞
+                        from your schema guarantees it is not TEI conformant</sch:report>
+		    </sch:rule>
                   </constraint>
                 </constraintSpec>
                 <constraintSpec scheme="schematron" ident="content_when_adding">
@@ -1514,17 +1525,18 @@
                   <attDef ident="xml:id" mode="change" ns="http://www.w3.org/XML/1998/namespace">
                     <constraintSpec scheme="schematron" ident="unique_xmlIDs">
                       <constraint>
-                        <sch:let name="myID" value="normalize-space(.)"/>
-                        <sch:report test="../(ancestor::*|preceding::*)/@xml:id[ normalize-space(.) eq $myID ]"
-                          >The @xml:id "<sch:value-of select="."
-                          />" on ＜<sch:value-of select="name(..)"
-                          />＞ duplicates an @xml:id found earlier in the document</sch:report>
+			<sch:rule context="@xml:id">
+                          <sch:let name="myID" value="normalize-space(.)"/>
+                          <sch:report test="../(ancestor::*|preceding::*)/@xml:id[ normalize-space(.) eq $myID ]"
+                            >The @xml:id "<sch:value-of select="."
+                            />" on ＜<sch:value-of select="name(..)"
+                            />＞ duplicates an @xml:id found earlier in the document</sch:report>
+			</sch:rule>
                       </constraint>
                     </constraintSpec>
                   </attDef>
                 </attList>
               </classSpec>
-
 
               <classSpec ident="model.entryPart.top" module="tei" mode="delete" type="model"/>
               <classSpec ident="model.msItemPart" module="tei" mode="delete" type="model"/>

--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -183,8 +183,10 @@ $Id$
               if you really want a newline at the end, follow it with U+00A0.
             </desc>
             <constraint>
-              <sch:report test="matches( .//text()[last()], '&#x0A;\s*$')">trailing newline not allowed</sch:report>
-              <sch:report test="matches( .//text()[1],      '^\s*&#x0A;')">leading newline not allowed</sch:report>
+	      <sch:rule context="tei:eg">
+		<sch:report test="matches( .//text()[last()], '&#x0A;\s*$')">trailing newline not allowed</sch:report>
+		<sch:report test="matches( .//text()[1],      '^\s*&#x0A;')">leading newline not allowed</sch:report>
+	      </sch:rule>
             </constraint>
           </constraintSpec>
         </elementSpec>
@@ -740,7 +742,9 @@ $Id$
 	<elementSpec ident="altIdent" module="tagdocs" mode="change">
 	  <constraintSpec scheme="schematron" ident="restricted-altIdent-placement">
 	    <constraint>
-	      <sch:assert test="parent::tei:elementSpec|parent::tei:attDef|parent::tei:valItem">The &lt;altIdent> element should only be used as a child of &lt;elementSpec>, &lt;attDef>, or &lt;valItem>.</sch:assert>
+	      <sch:rule context="tei:altIdent">
+		<sch:assert test="parent::tei:elementSpec|parent::tei:attDef|parent::tei:valItem">The &lt;altIdent> element should only be used as a child of &lt;elementSpec>, &lt;attDef>, or &lt;valItem>.</sch:assert>
+	      </sch:rule>
 	    </constraint>
 	  </constraintSpec>
 	</elementSpec>


### PR DESCRIPTION
Fix several remaining contextless assertions & reports.

Passes all builds & tests (in this repo) on my local system. (There are 3 warnings about `<superEntry>`.)

Only code changes are:

1. Added roughly a dozen new `<sch:rule>` elements in 5 files.
2. Pared down a somewhat convoluted XPath in a `@test` in the "choiceContent" constraint in tei_simplePrint.

All other changes are whitespace or comments.