### PR TITLE
Require both`@class` and `@name` of `<attRef>`

### DIFF
--- a/P5/Source/Specs/attRef.xml
+++ b/P5/Source/Specs/attRef.xml
@@ -12,8 +12,7 @@
   <desc versionDate="2007-12-20" xml:lang="ko">속성 또는 속성의 그룹에 대한 정의를 가리킨다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">連結到屬性或屬性群組的定義。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">1つまたは複数の属性の定義の場所を示す。</desc>
-  <desc versionDate="2007-06-12" xml:lang="fr">pointe vers la définition d'un attribut ou d'un
-			groupe d'attributs.</desc>
+  <desc versionDate="2007-06-12" xml:lang="fr">pointe vers la définition d'un attribut ou d'un groupe d'attributs.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">señala a la definición de un atributo o grupo de atributos.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">rimanda alla definizione di un attributo o gruppo di attributi</desc>
   <classes>
@@ -21,11 +20,11 @@
   </classes>
   <content><empty/></content>
   <attList>
-    <attDef ident="class">
+    <attDef ident="class" usage="req">
       <desc versionDate="2013-11-16" xml:lang="en">the name of the attribute class</desc>
       <datatype><dataRef key="teidata.name"/></datatype>
     </attDef>
-    <attDef ident="name">
+    <attDef ident="name" usage="req">
       <desc versionDate="2013-11-16" xml:lang="en">the name of the attribute</desc>
       <datatype><dataRef key="teidata.name"/></datatype>
     </attDef>


### PR DESCRIPTION
This PR addresses #2282. It is an on-hold draft that cannot be merged yet, because it will break the build process until a mechanism for pointing to a RELAX NG pattern from within an `<attList>` is created and used (instead of `<attRef>` with a RELAX NG pattern as its `@name` and no `@class`) in Exemplars/tei_its.odd. (This mechanism is to be discussed on #2548.)