### PR TITLE
Remove extraneous comma from `<geo>`

### DIFF
--- a/P5/Source/Guidelines/en/ND-NamesDates.xml
+++ b/P5/Source/Guidelines/en/ND-NamesDates.xml
@@ -879,7 +879,7 @@ target="#CONA"/>).  The tag -->The
       <egXML xmlns="http://www.tei-c.org/ns/Examples"><place xml:id="Rome">
                <placeName>Rome</placeName>
                <location>
-                  <geo>41.891775, 12.486137</geo>
+                  <geo>41.891775 12.486137</geo>
                </location>
                <idno type="Pleiades">423025</idno>
                <note>capital of the Roman Empire</note>
@@ -2206,7 +2206,7 @@ occupation and residence.</p>
             <place xml:id="l-GSN">
               <placeName xml:lang="fr">Gare de Saint-Nazaire</placeName>
               <location>
-                <geo>47.28657,-2.21171</geo>
+                <geo>47.28657 -2.21171</geo>
               </location>
             </place>
             <place xml:id="l-Joh">
@@ -2234,7 +2234,7 @@ occupation and residence.</p>
                 <region>Arnsberg</region>
                 <district>Hochsauerlandkreis</district>
                 <settlement>Schmallenberg</settlement>
-                <geo cert="low">51.154,8.357</geo>
+                <geo cert="low">51.154 8.357</geo>
               </location>
             </place>
             <place xml:id="l-PI" xml:lang="es">
@@ -2254,7 +2254,7 @@ occupation and residence.</p>
             <place xml:id="l-Seb">
               <placeName xml:lang="de">Sebnitz</placeName>
               <location>
-                <geo>50.966667,14.283333</geo>
+                <geo>50.966667 14.283333</geo>
               </location>
             </place>
             <place xml:id="l-WWIIEast">
@@ -2439,7 +2439,7 @@ occupation and residence.</p>
               <settlement>Cairo</settlement>
               <country>Egypt</country>
               <location>
-                <geo>30.047778, 31.233333</geo>
+                <geo>30.047778 31.233333</geo>
               </location>
             </address>
           </objectIdentifier>
@@ -2470,7 +2470,7 @@ occupation and residence.</p>
                   <settlement>Cairo</settlement>
                   <country>Egypt</country>
                   <location>
-                    <geo>30.047778, 31.233333</geo>
+                    <geo>30.047778 31.233333</geo>
                   </location>
                 </address>
               </objectIdentifier>

--- a/P5/Source/Specs/eventName.xml
+++ b/P5/Source/Specs/eventName.xml
@@ -33,7 +33,7 @@
             <listPlace type="affected">
               <place>
                 <placeName xml:lang="pl">Gdańsk</placeName>
-                <location><geo>54.350556, 18.652778</geo></location>
+                <location><geo>54.350556 18.652778</geo></location>
               </place>
             </listPlace>
           </event>

--- a/P5/Source/Specs/object.xml
+++ b/P5/Source/Specs/object.xml
@@ -105,7 +105,7 @@
               <settlement>Cairo</settlement>
               <country>Egypt</country>
               <location>
-                <geo>30.047778, 31.233333</geo>
+                <geo>30.047778 31.233333</geo>
               </location>
             </address>
           </objectIdentifier>


### PR DESCRIPTION
Removed extraneous commas from within examples of `<geo>` element, thus addressing main concern of #2560.

For each `<geo>` that had a comma, I checked to make sure it seemed to be in LAT LONG order (instead of LONG LAT). I did _not_ check those `<geo>`s that did _not_ have a comma.

**Note**
The following command was very useful in checking LAT LONG vs LONG LAT:
~~~bash
xmlstarlet sel -N x=http://www.tei-c.org/ns/Examples -t -m "//x:geo[ contains(.,'0')]" -n -o "---------" -f -o ":" -n -v "normalize-space(.)" -n Source/Specs/*.xml Source/Guidelines/en/*.xml | perl -pe 's;^([0-9.-]+),? ([0-9.-]+)$;normal= https://www.openstreetmap.org/?mlat=$1&mlon=$2&zoom=9\nreverse= https://www.openstreetmap.org/?mlat=$2&mlon=$1&zoom=9;'
~~~~