### PR TITLE
compactify specGrps

### DIFF
--- a/P5/Source/Guidelines/en/AB-About.xml
+++ b/P5/Source/Guidelines/en/AB-About.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" type="div1" xml:id="AB" n="1">

--- a/P5/Source/Guidelines/en/CC-LanguageCorpora.xml
+++ b/P5/Source/Guidelines/en/CC-LanguageCorpora.xml
@@ -311,45 +311,9 @@ elements, members of the <ident type="class">model.profileDescPart</ident>, are 
 remainder of the chapter.
 
 <specGrp>
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/textDesc.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/particDesc.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/settingDesc.xml"/>
-
-
-
-
-
 </specGrp>
 <specGrpRef target="#DCCAHTD"/>
 
@@ -467,134 +431,14 @@ parameters might be used to characterize a novel:
 
 
 <specGrp xml:id="DCCAHTD" n="Text description">
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/channel.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/constitution.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/derivation.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/domain.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/factuality.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/interaction.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/preparedness.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/purpose.xml"/>
-
-
-
-
-
-
 </specGrp>
 
 
@@ -750,45 +594,9 @@ schema. The above examples assume that only the
 general purpose <gi>name</gi> element supplied in the core module is
 available.
 <specGrp xml:id="DCCAHSE" n="Setting description">
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/setting.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/locale.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/activity.xml"/>
-
-
-
-
-
 </specGrp></p></div></div>
 <div type="div2" xml:id="CCAS"><head>Associating Contextual
 Information with a Text</head>

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -1021,7 +1021,6 @@ overshadows the historical content</quote>.</egXML>
  strings.</egXML>
  </p>
  <specGrp xml:id="DCOHQQ" n="Quotation">
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/said.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/quote.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/q.xml"/>
@@ -1900,7 +1899,6 @@ distinguish editorial changes from those visible in the source text.
 </p>
 
 <specGrp xml:id="DCOEDA" n="Other editorial tags">
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/gap.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/ellipsis.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/add.xml"/>
@@ -2517,7 +2515,6 @@ recommendations is discussed in <ptr target="#PHCH"/>, which includes
 additional elements made available for the purpose by the <ident type="module">transcr</ident> module. </p>
 
 <specGrp xml:id="DCOAB" n="Abbreviations">
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/abbr.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/expan.xml"/></specGrp>
 </div></div>
@@ -4622,7 +4619,6 @@ names of authors, titles etc. </p>
 <specGrp xml:id="DCOBILV" n="Levels of bibliographic information"><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/analytic.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/monogr.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/series.xml"/>
-
 </specGrp>
 </div>
 <div type="div4" xml:id="COBICOR"><head>Titles, Authors, and Editors</head>
@@ -5808,7 +5804,6 @@ chapter <ptr target="#VE"/>.
  </p>
 
 <specGrp xml:id="DCOVE" n="Verse">
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/l.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/lg.xml"/></specGrp>
 </div>

--- a/P5/Source/Guidelines/en/COL-Colophon.xml
+++ b/P5/Source/Guidelines/en/COL-Colophon.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" xml:id="COL">

--- a/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
+++ b/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
@@ -342,75 +342,11 @@ or senses, and may be nested to any depth to reflect the embedding of
 sub-senses. Any of the top-level constituents (<gi>def</gi>,
 <gi>usg</gi>, <gi>form</gi>, etc.) can appear at any level (i.e.,
 within entries, homographs, or senses).<specGrp xml:id="DDIEN" n="Dictionary entries and their structure">
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/superEntry.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/entry.xml"/>
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/entryFree.xml"/>
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/hom.xml"/>
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/sense.xml"/>
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/dictScrap.xml"/>
 
 
@@ -1047,51 +983,9 @@ reason and act, esp quickly … <ref target="#DIC-CED">CED</ref> </q>
 </egXML>
 </p>
 <specGrp xml:id="DDITPGR" n="The gram group">
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/gramGrp.xml"/>
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/pos.xml"/>
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/subc.xml"/>
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/colloc.xml"/>
 
 
@@ -1181,11 +1075,6 @@ distinguished from the translation information within which it appears.<q rend="
 </egXML>
 </p>
 <specGrp xml:id="DDITPDE" n="Definition text">
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/def.xml"/>
 
 
@@ -1916,11 +1805,6 @@ convenable au moyen de blancs (2, sens 1, 3). <ref target="#DIC-DNT">DNT</ref> <
 
 </p>
 <specGrp xml:id="DDITPXR" n="Cross-References">
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/xr.xml"/>
 
 
@@ -2025,15 +1909,6 @@ the same elements as an <gi>entry</gi> element. </p>
 </egXML>
 </p>
 <specGrp xml:id="DDITPRE" n="Related entries">
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/re.xml"/>
 
 

--- a/P5/Source/Guidelines/en/DR-PerformanceTexts.xml
+++ b/P5/Source/Guidelines/en/DR-PerformanceTexts.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" type="div1" xml:id="DR" n="10"><head>Performance Texts</head>

--- a/P5/Source/Guidelines/en/DR-PerformanceTexts.xml
+++ b/P5/Source/Guidelines/en/DR-PerformanceTexts.xml
@@ -126,7 +126,6 @@ following examples:
  </p>
 
 <specGrp xml:id="DDRSET" n="The set element">
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/set.xml"/>
 </specGrp>
 </div>
@@ -252,32 +251,8 @@ Prospero's speech as a part of the preceding scene:
  </p>
 
 <specGrp xml:id="DDRPRO" n="The prologue and epilogue elements">
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/prologue.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/epilogue.xml"/>
-
-
-
-
-
 </specGrp>
 </div>
 <div type="div3" xml:id="DRPERF"><head>Records of Performances</head>
@@ -358,19 +333,7 @@ Or:
 <!-- La Machine Infernale, Jean Cocteau -->
  </p>
 <specGrp xml:id="DDRPERF" n="The performance element">
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/performance.xml"/>
-
-
-
-
-
 </specGrp>
 </div>
 <div type="div3" xml:id="DRCAST"><head>Cast Lists</head>

--- a/P5/Source/Guidelines/en/DS-DefaultTextStructure.xml
+++ b/P5/Source/Guidelines/en/DS-DefaultTextStructure.xml
@@ -172,8 +172,6 @@ or simply quoted within it. This is useful in such common literary contexts as
 the <q>play within a play</q> or the narrative interrupted by other (often
 deeply nested) multiple narratives. <specGrp xml:id="DDSTEXT">
 <!--n="Top-level parts of default structure"-->
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/body.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/group.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/floatingText.xml"/>
@@ -259,8 +257,6 @@ composed of two chapters, might be represented as follows:
  </p>
 <specGrp xml:id="DDSDIV">
 <!-- n="Un-numbered divisions"-->
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/div.xml"/>
 </specGrp>
 </div>
@@ -319,8 +315,6 @@ composed of two chapters, might be represented as follows:
 
 <specGrp xml:id="DDSDIVN">
 <!--n="Numbered divisions"-->
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/div1.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/div2.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/div3.xml"/>
@@ -901,8 +895,6 @@ module these may appear at any point; there is no requirement that
 elements from the same module be kept together.</p>
 <specGrp xml:id="DDSDIVX">
 <!-- n="Tags for start and end of divisions"-->
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/trailer.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/byline.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/dateline.xml"/>
@@ -1693,8 +1685,6 @@ provided in chapter <ptr target="#PH"/>.
  </p>
 
 <specGrp xml:id="DDSFRONT">
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/front.xml"/>
 <specGrpRef target="#DDSTPAGE"/>
 </specGrp>
@@ -1803,8 +1793,6 @@ monsters, Reader, with thy quill.</p>
 	<!--  end of draft -->
  </p>
 <specGrp xml:id="DDSBACK">
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/back.xml"/>
 </specGrp>
 </div>

--- a/P5/Source/Guidelines/en/FS-FeatureStructures.xml
+++ b/P5/Source/Guidelines/en/FS-FeatureStructures.xml
@@ -1331,65 +1331,10 @@ is a legal XML name; for example, they cannot include whitespace or
 begin with digits.  Multiple base types are separated with spaces,
 e.g. <tag>fsDecl type="Sub" baseTypes="Super1 Super2"</tag>.</p>
 <specGrp xml:id="DFDFSD2" n="Feature System Declaration">
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/fsdDecl.xml"/>
-
-
-
-
-
- 
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/fsDecl.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/fsDescr.xml"/>
-
-
-
-
-
- 
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/fsdLink.xml"/>
-
-
-
-
 </specGrp>
 
 </div>
@@ -1640,93 +1585,12 @@ the class <ident type="class">model.featureVal</ident> includes all possible
 single feature values, including  feature structures, alternations
 (<gi>vAlt</gi>) and complex collections (<gi>vColl</gi>).</p>
 <specGrp xml:id="DFDX" n="Feature definitions">
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/fDecl.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/fDescr.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/vRange.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/vDefault.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/if.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/then.xml"/>
-
-
-
-
-
-
 </specGrp></div>
 <div type="div2" xml:id="FDFS"><head>Feature Structure Constraints</head>
 <p>Ensuring the validity of feature structures may require much more
@@ -1809,67 +1673,10 @@ Note that <gi>cond</gi> and <gi>bicond</gi> use the empty tags
 and consequent.  These are primarily for the sake of enhancing human
 readability.</p>
 <specGrp xml:id="DFD2" n="Feature structure constraints">
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/fsConstraints.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/cond.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/bicond.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/iff.xml"/>
-
-
-
-
-
-
 </specGrp></div>
 <div type="div2" xml:id="FDEG"><head>A Complete Example</head>
 <p>To summarize this chapter, the complete FSD for the example that has

--- a/P5/Source/Guidelines/en/GD-GraphsNetworksTrees.xml
+++ b/P5/Source/Guidelines/en/GD-GraphsNetworksTrees.xml
@@ -273,54 +273,9 @@ elements, as in the following example.
 </graph></egXML>
 <!-- indegree/outdegree removed at DD's suggestion --></p>
 <specGrp xml:id="DGDGR" n="Graphs">
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/graph.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/node.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/arc.xml"/>
-
-
-
-
-
-
 </specGrp>
 <div type="div3" xml:id="GDTN"><head>Transition Networks</head>
 <p>For encoding transition networks and other kinds of directed graphs
@@ -873,70 +828,10 @@ VB to PT crosses the arc from VP to PN.
     </root>
 </tree></egXML></p>
 <specGrp xml:id="DGDTR" n="Trees (basic method)">
-  
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/tree.xml"/>
-
-
-
-
-
-
-  
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/root.xml"/>
-
-
-
-
-
-
-  
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/iNode.xml"/>
-
-
-
-
-
-
-  
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/leaf.xml"/>
-
-
-
-
-
-
 </specGrp>
 </div>
 <div type="div2" xml:id="GDAT"><head>Another Tree Notation</head>
@@ -1262,79 +1157,10 @@ first stage that are not copies of them.</p>
 syntactic, semantic, and phonological subderivations) is to be
 articulated, the grouping element <gi>listForest</gi> may be used.</p>
 <specGrp xml:id="DGDAL" n="Trees (alternate method)">
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/eTree.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/triangle.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/eLeaf.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/forest.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/listForest.xml"/>
 </specGrp></div>
 

--- a/P5/Source/Guidelines/en/HD-Header.xml
+++ b/P5/Source/Guidelines/en/HD-Header.xml
@@ -1430,7 +1430,6 @@ with the number of such elements present in the associated
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/namespace.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/rendition.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/styleDefDecl.xml"/>
-
 </specGrp></p></div>
 </div>
 

--- a/P5/Source/Guidelines/en/NH-Non-hierarchical.xml
+++ b/P5/Source/Guidelines/en/NH-Non-hierarchical.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" n="31" type="div1" xml:id="NH">

--- a/P5/Source/Guidelines/en/PARTIND.xml
+++ b/P5/Source/Guidelines/en/PARTIND.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" xml:id="PARTIND"><head>Index</head>

--- a/P5/Source/Guidelines/en/PrefatoryNote.xml
+++ b/P5/Source/Guidelines/en/PrefatoryNote.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" xml:id="PREFS"><head>Prefatory Notes</head>

--- a/P5/Source/Guidelines/en/REF-ATTRIBUTES.xml
+++ b/P5/Source/Guidelines/en/REF-ATTRIBUTES.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" type="div1" xml:id="REF-ATTS">

--- a/P5/Source/Guidelines/en/REF-CLASSES-ATTS.xml
+++ b/P5/Source/Guidelines/en/REF-CLASSES-ATTS.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" type="div1" xml:id="REF-CLASSES-ATTS">

--- a/P5/Source/Guidelines/en/REF-CLASSES-MODEL.xml
+++ b/P5/Source/Guidelines/en/REF-CLASSES-MODEL.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" type="div1" xml:id="REF-CLASSES-MODEL">

--- a/P5/Source/Guidelines/en/REF-ELEMENTS.xml
+++ b/P5/Source/Guidelines/en/REF-ELEMENTS.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" type="div1" xml:id="REF-ELEMENTS">

--- a/P5/Source/Guidelines/en/REF-MACROS.xml
+++ b/P5/Source/Guidelines/en/REF-MACROS.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" type="div1" xml:id="REF-MACROS">

--- a/P5/Source/Guidelines/en/TS-TranscriptionsofSpeech.xml
+++ b/P5/Source/Guidelines/en/TS-TranscriptionsofSpeech.xml
@@ -345,7 +345,6 @@ and <att>version</att> may be used to refer to such conventions in a machine tra
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/equipment.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/broadcast.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/transcriptionDesc.xml"/>
-
 </specGrp>
 </div>
 
@@ -771,119 +770,13 @@ text header (see section <ptr target="#HD5"/>) or as part of a TEI customization
 
  </p>
 <specGrp xml:id="DTSCOMP" n="Components of Transcribed Speech">
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/u.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/pause.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/vocal.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/kinesic.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/incident.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/writing.xml"/>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/shift.xml"/>
-
-
-
-
-
-
 </specGrp>
 </div>
 </div>

--- a/P5/Source/Guidelines/en/TitlePageVerso.xml
+++ b/P5/Source/Guidelines/en/TitlePageVerso.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-
-
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 
 <div xmlns="http://www.tei-c.org/ns/1.0" type="titlePageVerso" xml:id="TitlePageVerso">

--- a/P5/Source/Guidelines/en/WD-NonStandardCharacters.xml
+++ b/P5/Source/Guidelines/en/WD-NonStandardCharacters.xml
@@ -1322,7 +1322,6 @@ The selection and combination of modules to form a TEI schema is described in
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/unihanProp.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/unicodeProp.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/att.gaijiProp.xml"/>
-
 </specGrp>
 </div>
 </div>

--- a/P5/Source/Guidelines/fr/HD-Header.xml
+++ b/P5/Source/Guidelines/fr/HD-Header.xml
@@ -557,7 +557,6 @@ L’élément <gi>extent</gi> a comme définition formelle :
 <specGrp xml:id="D2223" n="Importance matérielle = The extent statement">
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/titleStmt.xml"/>
 <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/extent.xml"/>
-
 </specGrp>
 </p>
 </div>


### PR DESCRIPTION
There were tons of whitespace within `specGrp` elements in the Guidelines. I don't know where this came from, but it makes working with these files a nightmare. I removed the superfluous whitespace between the includes there to improve readability.