### PR TITLE
fix description by restoring lost value

### DIFF
--- a/P5/Source/Specs/gap.xml
+++ b/P5/Source/Specs/gap.xml
@@ -49,7 +49,7 @@
       <desc versionDate="2007-12-20" xml:lang="ko">누락의 이유를 제시한다. 그 값의 예들은 다음과 같다: <val>sampling</val>,
           <val>illegible</val>, <val>inaudible</val>, <val>irrelevant</val>, <val>cancelled</val>,
           <val>cancelled and illegible</val></desc>
-      <desc versionDate="2007-05-02" xml:lang="zh-TW">說明省略的原因。屬性值的例子有<val>sampling</val>、、<val>inaudible</val>、<val>irrelevant</val>、<val>cancelled</val>、<val>cancelled
+      <desc versionDate="2007-05-02" xml:lang="zh-TW">說明省略的原因。屬性值的例子有<val>sampling</val>、<val>illegible</val>、<val>inaudible</val>、<val>irrelevant</val>、<val>cancelled</val>、<val>cancelled
           and illegible</val>。</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">省略の理由を示す。例えば、 <val>見本</val>、<val>聞こえない</val>、
           <val>無関係</val>、<val>取り消し</val>、<val>取り消しがありかつ判読できない</val>、など。</desc>


### PR DESCRIPTION
Small fix for Chinese description in `gap` where obviously one value got lost. Restored it from the similar Korean description.