### PR TITLE
Unify reason attribute

### DIFF
--- a/P5/Source/Specs/gap.xml
+++ b/P5/Source/Specs/gap.xml
@@ -58,7 +58,7 @@
       <desc versionDate="2007-01-21" xml:lang="it">indica il motivo dell'omisione</desc>
       <desc versionDate="2017-02-07" xml:lang="de">gibt den Grund für die Auslassung an.</desc>
       <datatype maxOccurs="unbounded">
-	<dataRef key="teidata.enumerated"/>
+        <dataRef key="teidata.word"/>
       </datatype>
       <valList type="semi">
 	<valItem ident="cancelled">

--- a/P5/Source/Specs/gap.xml
+++ b/P5/Source/Specs/gap.xml
@@ -58,7 +58,7 @@
       <desc versionDate="2007-01-21" xml:lang="it">indica il motivo dell'omisione</desc>
       <desc versionDate="2017-02-07" xml:lang="de">gibt den Grund für die Auslassung an.</desc>
       <datatype maxOccurs="unbounded">
-        <dataRef key="teidata.word"/>
+        <dataRef key="teidata.enumerated"/>
       </datatype>
       <valList type="semi">
 	<valItem ident="cancelled">

--- a/P5/Source/Specs/secl.xml
+++ b/P5/Source/Specs/secl.xml
@@ -18,7 +18,7 @@
       <desc versionDate="2015-05-30" xml:lang="en">one or more words indicating why this text has been secluded, e.g.
       <mentioned>interpolated</mentioned> etc.</desc>
       <datatype maxOccurs="unbounded">
-        <dataRef key="teidata.word"/>
+        <dataRef key="teidata.enumerated"/>
       </datatype>
     </attDef>
   </attList>

--- a/P5/Source/Specs/secl.xml
+++ b/P5/Source/Specs/secl.xml
@@ -17,7 +17,9 @@
     <attDef ident="reason" usage="opt">
       <desc versionDate="2015-05-30" xml:lang="en">one or more words indicating why this text has been secluded, e.g.
       <mentioned>interpolated</mentioned> etc.</desc>
-      <datatype maxOccurs="unbounded"><dataRef key="teidata.word"/></datatype>
+      <datatype maxOccurs="unbounded">
+        <dataRef key="teidata.word"/>
+      </datatype>
     </attDef>
   </attList>
   <exemplum xml:lang="en">

--- a/P5/Source/Specs/supplied.xml
+++ b/P5/Source/Specs/supplied.xml
@@ -36,7 +36,9 @@
 <mentioned>feuillet-disparu</mentioned>, <mentioned>omis-sur-original</mentioned>.-->
       <desc versionDate="2007-05-04" xml:lang="es">explica los motivos de dicha inserción.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">spiega i motivi di tale inserimento</desc>
-      <datatype maxOccurs="unbounded"><dataRef key="teidata.word"/></datatype>
+      <datatype maxOccurs="unbounded">
+        <dataRef key="teidata.word"/>
+      </datatype>
     </attDef>
   </attList>
   <exemplum xml:lang="en">

--- a/P5/Source/Specs/supplied.xml
+++ b/P5/Source/Specs/supplied.xml
@@ -37,7 +37,7 @@
       <desc versionDate="2007-05-04" xml:lang="es">explica los motivos de dicha inserción.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">spiega i motivi di tale inserimento</desc>
       <datatype maxOccurs="unbounded">
-        <dataRef key="teidata.word"/>
+        <dataRef key="teidata.enumerated"/>
       </datatype>
     </attDef>
   </attList>

--- a/P5/Source/Specs/surplus.xml
+++ b/P5/Source/Specs/surplus.xml
@@ -23,7 +23,7 @@
       <mentioned>interpolated</mentioned> etc.</desc>
       <desc versionDate="2009-11-16" xml:lang="fr">indique les raisons pour lesquelles on considère cette partie de texte comme superflue.</desc>
       <datatype maxOccurs="unbounded">
-        <dataRef key="teidata.word"/>
+        <dataRef key="teidata.enumerated"/>
       </datatype>
     </attDef>
   </attList>

--- a/P5/Source/Specs/surplus.xml
+++ b/P5/Source/Specs/surplus.xml
@@ -22,7 +22,9 @@
 <mentioned>repeated</mentioned>,
       <mentioned>interpolated</mentioned> etc.</desc>
       <desc versionDate="2009-11-16" xml:lang="fr">indique les raisons pour lesquelles on considère cette partie de texte comme superflue.</desc>
-      <datatype maxOccurs="unbounded"><dataRef key="teidata.word"/></datatype>
+      <datatype maxOccurs="unbounded">
+        <dataRef key="teidata.word"/>
+      </datatype>
     </attDef>
   </attList>
   <exemplum xml:lang="en">

--- a/P5/Source/Specs/unclear.xml
+++ b/P5/Source/Specs/unclear.xml
@@ -42,7 +42,7 @@
                 trascrivere il brano.</desc>
       <desc versionDate="2016-11-24" xml:lang="de">gibt den Grund an, warum das Material schwer zu transkribieren ist.</desc>
       <datatype maxOccurs="unbounded">
-        <dataRef key="teidata.enumerated"/>
+        <dataRef key="teidata.word"/>
       </datatype>
       <valList type="semi">
         <valItem ident="illegible">

--- a/P5/Source/Specs/unclear.xml
+++ b/P5/Source/Specs/unclear.xml
@@ -42,7 +42,7 @@
                 trascrivere il brano.</desc>
       <desc versionDate="2016-11-24" xml:lang="de">gibt den Grund an, warum das Material schwer zu transkribieren ist.</desc>
       <datatype maxOccurs="unbounded">
-        <dataRef key="teidata.word"/>
+        <dataRef key="teidata.enumerated"/>
       </datatype>
       <valList type="semi">
         <valItem ident="illegible">


### PR DESCRIPTION
This PR unifies all occurrences of the `reason` attribute, to use `teidata.word`.
Closes #2580