### PR TITLE
allow `<xenoData>` to have more than 1 child

### DIFF
--- a/P5/Source/Specs/xenoData.xml
+++ b/P5/Source/Specs/xenoData.xml
@@ -16,7 +16,7 @@
   <content>
     <alternate>
       <textNode/>
-      <anyElement/>
+      <anyElement minOccurs="1" maxOccurs="unbounded"/>
     </alternate>
   </content>
   <exemplum xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" versionDate="2017-05-11" xml:lang="en">


### PR DESCRIPTION
Fixes #2583 by adding `@minOccurs` and `@maxOccurs` to `<anyElement>` in content model of `<xenoData>`.