### PR TITLE
Allow hand attribute in emph

### DIFF
--- a/P5/Source/Specs/att.damaged.xml
+++ b/P5/Source/Specs/att.damaged.xml
@@ -16,19 +16,6 @@
     <memberOf key="att.written"/>
   </classes>
   <attList>
-    <!--<attDef ident="hand" usage="opt">
-      <desc versionDate="2013-11-22" xml:lang="en">in the case of damage (deliberate defacement, inking out, etc.) assignable to a distinct
-        hand, signifies the hand responsible for the damage by pointing to  one of the hand identifiers declared in the document header (see section <ptr target="#PHDH"/>).</desc>
-      <desc versionDate="2007-12-20" xml:lang="ko">(고의적 손상 등의) 식별가능한 방식의 손상의 경우 손상에 책임이 있는 당사자를 나타낸다.</desc>
-      <desc versionDate="2008-04-21" xml:lang="ja">当該損傷部分の書き手が特定できる場合，それを示す．</desc>
-      <desc versionDate="2008-03-30" xml:lang="fr">dans le cas de dommages (effacement volontaire, etc.)
-        attribuable à une main identifiable, identifie cette main.</desc>
-      <desc versionDate="2007-01-21" xml:lang="it">in caso di danneggiamento (volontario o meno)
-        riconducibile a una mano identificabile, indica la mano responsabile del danneggiamento</desc>
-      <desc versionDate="2007-05-04" xml:lang="es">en el caso de daño (deliberado o no) adscribible a
-        una mano identificable, indica la mano responsable del daño.</desc>
-      <datatype><dataRef key="teidata.pointer"/></datatype>
-</attDef>-->
     <attDef ident="agent" usage="opt">
       <desc versionDate="2007-09-03" xml:lang="en">categorizes the cause of the damage, if it can be identified.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">식별될 수 있다면 그 손상의 원인을 분류한다.</desc>

--- a/P5/Source/Specs/att.textCritical.xml
+++ b/P5/Source/Specs/att.textCritical.xml
@@ -121,37 +121,6 @@ des séquences de variantes plus complexes (par exemple comportant de multiples 
       <desc versionDate="2016-08-19" xml:lang="it">punta ad altre letture che vanno obbligatoriamente considerate insieme all'elemento corrente</desc>
       <datatype maxOccurs="unbounded"><dataRef key="teidata.pointer"/></datatype>
     </attDef>
-    <!--  <attDef ident="hand" usage="opt">
-      <desc versionDate="2005-10-10" xml:lang="en">indicates the hand responsible for a particular reading in the
-witness.</desc>
-      <desc versionDate="2007-12-20" xml:lang="ko">비교 대상 텍스트에서 특정 독본에 대한 책임이 있는 기법을 표시한다.</desc>
-      <desc versionDate="2007-05-02" xml:lang="zh-TW">指出該版本中特定對應本的負責人。</desc>
-      <desc versionDate="2008-04-05" xml:lang="ja">当該文献における特定の解釈に責任を持つ筆致を示す．</desc>
-      <desc versionDate="2007-06-12" xml:lang="fr">désigne la main responsable d'une leçon particulière dans le témoin.</desc>
-      <desc versionDate="2007-05-04" xml:lang="es">indica la mano responsable de una lectura determinada en el testimonio.</desc>
-      <desc versionDate="2007-01-21" xml:lang="it">identifica la mano responsabile di una determinata lettura nel testimone</desc>
-      <datatype><dataRef key="teidata.pointer"/></datatype>
-      <remarks versionDate="2005-10-10" xml:lang="en">
-        <p>This attribute is only available within an apparatus
-gathering variant readings in the transcription of an individual
-witness.  It may not occur in an apparatus gathering readings from
-different witnesses.
- </p>
-      </remarks>
-      <remarks xml:lang="fr" versionDate="2007-06-12">
-        <p>Cet attribut n'est disponible qu'à l'intérieur d'un apparat qui réunit des
-                        variantes de leçons dans la description d'un témoin isolé. Il ne peut pas
-                        figurer dans un apparat qui réunit des leçons provenant de différents
-                        témoins. </p>
-      </remarks>
-      <remarks xml:lang="ja" versionDate="2008-04-05">
-        <p>
-        当該属性は，ひとつの現存資料の転記における複数の解釈を集めた校
-    勘資料中でのみ使用することができる．複数の文献から解釈を集めた校勘
-    資料中では使われないかもしれない．
-	</p>
-      </remarks>
-    </attDef>-->
   </attList>
   <remarks versionDate="2005-10-10" xml:lang="en">
     <p>This element class defines attributes inherited by

--- a/P5/Source/Specs/att.transcriptional.xml
+++ b/P5/Source/Specs/att.transcriptional.xml
@@ -16,19 +16,8 @@ transcription de sources manuscrites ou assimilées.</desc>
   <classes>
     <memberOf key="att.editLike"/>
     <memberOf key="att.written"/>
-    
   </classes>
   <attList>
-  <!--  <attDef ident="hand" usage="opt">
-      <desc versionDate="2007-09-03" xml:lang="en">indicates the hand of the agent which made the intervention.</desc>
-      <desc versionDate="2007-12-20" xml:lang="ko">간섭을 만든 당사자의 필적을 나타낸다.</desc>
-      <desc versionDate="2008-04-05" xml:lang="ja">当該調整を行った主体の筆致を特定する．</desc>
-      <desc versionDate="2008-03-30" xml:lang="fr">signale la main de celui qui est intervenue.</desc>
-      <desc versionDate="2007-01-21" xml:lang="it">indica il responsabile dell'aggiunta o della cancellazione</desc>
-      <desc versionDate="2007-05-04" xml:lang="es">indica el responsable de la adición o de la omisión.</desc>
-      <datatype><dataRef key="teidata.pointer"/></datatype>
-
-    </attDef>-->
     <attDef ident="status" usage="opt">
       <desc versionDate="2007-09-03" xml:lang="en">indicates the effect of the intervention, for example in
       the case of a deletion, strikeouts

--- a/P5/Source/Specs/att.written.xml
+++ b/P5/Source/Specs/att.written.xml
@@ -5,8 +5,8 @@
 <classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" type="atts" ident="att.written">
   <desc versionDate="2021-08-22" xml:lang="en">provides attributes to indicate the hand in which
     the content of an element was written in the source being transcribed.</desc>
-  <!--<desc versionDate="2014-01-10" xml:lang="en">provides an attribute to indicate the hand in which
-  	the textual content of an element was written in the source being transcribed.</desc>-->
+  <desc versionDate="2024-08-18" xml:lang="de">stellt Attribute bereit, um anzuzeigen, von welcher
+    Hand der Inhalt eines Elements in der transkribierten Quelle stammt.</desc>
   <classes/>
   <attList>
   	<attDef ident="hand" usage="opt">

--- a/P5/Source/Specs/att.written.xml
+++ b/P5/Source/Specs/att.written.xml
@@ -9,42 +9,22 @@
     Hand der Inhalt eines Elements in der transkribierten Quelle stammt.</desc>
   <classes/>
   <attList>
-  	<attDef ident="hand" usage="opt">
-  	  <desc versionDate="2018-06-15" xml:lang="en">points to a <gi>handNote</gi> element describing the hand considered responsible for the
-  	    content of the element concerned.</desc>
-  		<!--<desc versionDate="2016-02-19" xml:lang="en">points to a <gi>handNote</gi> element describing the hand considered responsible for the
-  			textual content of the element concerned.</desc>-->
-  		<!--<desc versionDate="2013-11-22" xml:lang="en">in the case of damage (deliberate defacement, inking out, etc.) assignable to a distinct
-  			hand, signifies the hand responsible for the damage by pointing to  one of the hand identifiers declared in the document header (see section <ptr target="#PHDH"/>).</desc>
-  		<desc versionDate="2005-10-10" xml:lang="en">indicates the hand responsible for a particular reading in the
-  			witness.</desc>-->
-  		<!--      <valDesc>must be one of the hand identifiers declared in the document
-header (see section <ptr target="#PHDH"/>).</valDesc>
-  		<remarks versionDate="2005-10-10" xml:lang="en">
-  			<p>This attribute is only available within an apparatus
-  				gathering variant readings in the transcription of an individual
-  				witness.  It may not occur in an apparatus gathering readings from
-  				different witnesses.
-  			</p>
-  		</remarks>-->
-  	<!--	<desc versionDate="2005-01-14" xml:lang="en">in the case of text omitted from the transcription because of deliberate deletion by an
-  			identifiable hand, indicates the hand which made the deletion.</desc>
-  		<desc versionDate="2005-01-14" xml:lang="en">Where the difficulty in transcription arises from action (partial deletion, etc.)
-  			assignable to an identifiable hand, signifies the hand responsible for the action.</desc>
-  		-->
-  		
-  		<desc versionDate="2007-12-20" xml:lang="ko">간섭을 만든 당사자의 필적을 나타낸다.</desc>
-  		<desc versionDate="2008-04-05" xml:lang="ja">当該調整を行った主体の筆致を特定する。</desc>
-  		<desc versionDate="2008-03-30" xml:lang="fr">signale la main de celui qui est intervenue.</desc>
-  		<desc versionDate="2007-01-21" xml:lang="it">indica il responsabile dell'aggiunta o della cancellazione</desc>
-  		<desc versionDate="2007-05-04" xml:lang="es">indica el responsable de la adición o de la omisión.</desc>
-  		<datatype><dataRef key="teidata.pointer"/></datatype>
-  		<!--      <valDesc>must refer to a <gi>handNote</gi> element, typically
-      declared in the document header (see section <ptr target="#PHDH"/>).</valDesc>
-      <valDesc versionDate="2009-05-28" xml:lang="fr">doit faire référence à un élément <gi>handNote</gi>, en général déclaré dans l'en-tête TEI (voir la section <ptr target="#PHDH"/>).</valDesc>-->
-  		<!-- shdnt there be a constraintspec for this? LB 2013-12-09 -->
-  	</attDef>
-  	
+    <attDef ident="hand" usage="opt">
+      <desc versionDate="2018-06-15" xml:lang="en">points to a <gi>handNote</gi> element describing the hand considered responsible for the
+        content of the element concerned.</desc>
+      <desc versionDate="2007-12-20" xml:lang="ko">간섭을 만든 당사자의 필적을 나타낸다.</desc>
+      <desc versionDate="2008-04-05" xml:lang="ja">当該調整を行った主体の筆致を特定する。</desc>
+      <desc versionDate="2008-03-30" xml:lang="fr">signale la main de celui qui est intervenue.</desc>
+      <desc versionDate="2007-01-21" xml:lang="it">indica il responsabile dell'aggiunta o della cancellazione</desc>
+      <desc versionDate="2007-05-04" xml:lang="es">indica el responsable de la adición o de la omisión.</desc>
+      <datatype>
+        <dataRef key="teidata.pointer"/>
+      </datatype>
+      <!--      <valDesc>must refer to a <gi>handNote</gi> element, typically
+        declared in the document header (see section <ptr target="#PHDH"/>).</valDesc>
+        <valDesc versionDate="2009-05-28" xml:lang="fr">doit faire référence à un élément <gi>handNote</gi>, en général déclaré dans l'en-tête TEI (voir la section <ptr target="#PHDH"/>).</valDesc>-->
+      <!-- shdnt there be a constraintspec for this? LB 2013-12-09 -->
+    </attDef>
   </attList>
   <listRef>
     <ptr target="#STECAT"/>

--- a/P5/Source/Specs/att.written.xml
+++ b/P5/Source/Specs/att.written.xml
@@ -5,7 +5,7 @@
 <classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" type="atts" ident="att.written">
   <desc versionDate="2021-08-22" xml:lang="en">provides attributes to indicate the hand in which
     the content of an element was written in the source being transcribed.</desc>
-  <desc versionDate="2024-08-18" xml:lang="de">stellt Attribute bereit, um anzuzeigen, von welcher
+  <desc versionDate="2024-08-16" xml:lang="de">stellt Attribute bereit, um anzuzeigen, von welcher
     Hand der Inhalt eines Elements in der transkribierten Quelle stammt.</desc>
   <classes/>
   <attList>

--- a/P5/Source/Specs/emph.xml
+++ b/P5/Source/Specs/emph.xml
@@ -20,6 +20,7 @@
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.emphLike"/>
+    <memberOf key="att.written"/>
     <memberOf key="att.cmc"/>
   </classes>
   <content>


### PR DESCRIPTION
This PR makes `emph` member of `att.written` making `@hand` available.
Additionally it brings some cleaning up: 

- outdated direct definitions of `@hand` attributes have been removed
- some minor formatting of `att.written`, removing commented content
- a German description for `att.written` has been provided

addresses #2550