### PR TITLE
remove deprecation, it is now an error

### DIFF
--- a/P5/Source/Specs/acquisition.xml
+++ b/P5/Source/Specs/acquisition.xml
@@ -23,39 +23,6 @@ institution.</desc>
   <content>
     <macroRef key="macro.specialPara"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc versionDate="2019-02-03" xml:lang="ja">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-acquisition">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#UND">
       <acquisition>Left to the <name type="place">Bodleian</name> by 

--- a/P5/Source/Specs/affiliation.xml
+++ b/P5/Source/Specs/affiliation.xml
@@ -4,22 +4,14 @@
   <gloss versionDate="2008-12-09" xml:lang="en">affiliation</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">affiliation</gloss>
   <gloss versionDate="2024-04-11" xml:lang="de">Affiliation</gloss>
-  <desc versionDate="2005-01-14" xml:lang="en">contains an informal description of a person's present or past affiliation with some
-        organization, for example an employer or sponsor.</desc>
+  <desc versionDate="2005-01-14" xml:lang="en">contains an informal description of a person's present or past affiliation with some organization, for example an employer or sponsor.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">고용주 또는 후원자와 같이 개인의 현재 또는 과거 소속 조직에 대한 비공식적 기술을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含非正式性的描述，關於個人現在或過去隸屬的團體，例如雇主或贊助者。</desc>
   <desc versionDate="2022-06-07" xml:lang="ja">人物が所属している、またはしていた団体に関する情報を示す。例えば、雇い主や出資者など。</desc>
-  <desc versionDate="2008-12-09" xml:lang="fr">contient une description non formalisée portant sur
-        l'affiliation présente ou passée d'une personne à une organisation, par exemple un employeur
-        ou un sponsor.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene una descripción informal de la afiliación
-        presente o pasada de una persona a una determinada organización, p.ej. un empleado o un
-        patrocinador.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene una descrizione informale dell'appartenenza
-        presente o passata di una persona a una determinata organizzazione, per esempio un'azienda o
-        un ente finanziatore</desc>
-  <desc versionDate="2024-04-11" xml:lang="de">enthält eine informelle Beschreibung der gegenwärtigen
-        oder früheren Zugehörigkeit einer Person zu einer Organisation, z. B. eines Arbeitgebers oder Sponsors.</desc>
+  <desc versionDate="2008-12-09" xml:lang="fr">contient une description non formalisée portant sur l'affiliation présente ou passée d'une personne à une organisation, par exemple un employeur ou un sponsor.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene una descripción informal de la afiliación presente o pasada de una persona a una determinada organización, p.ej. un empleado o un patrocinador.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene una descrizione informale dell'appartenenza presente o passata di una persona a una determinata organizzazione, per esempio un'azienda o un ente finanziatore</desc>
+  <desc versionDate="2024-04-11" xml:lang="de">enthält eine informelle Beschreibung der gegenwärtigen oder früheren Zugehörigkeit einer Person zu einer Organisation, z. B. eines Arbeitgebers oder Sponsors.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.addressLike"/>
@@ -34,48 +26,15 @@
     <macroRef key="macro.phraseSeq"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc versionDate="2019-02-03" xml:lang="ja">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-affiliation">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="type" usage="opt" mode="change">
+    <attDef ident="type" usage="opt" mode="change">
       <datatype>
-	<dataRef key="teidata.enumerated"/>
+        <dataRef key="teidata.enumerated"/>
       </datatype>
       <valList type="open">
-	<valItem ident="sponsor"/>
-	<valItem ident="recommend"/>
-	<valItem ident="discredit"/>
-	<valItem ident="pledged"/>
+        <valItem ident="sponsor"/>
+        <valItem ident="recommend"/>
+        <valItem ident="discredit"/>
+        <valItem ident="pledged"/>
       </valList>
     </attDef>
   </attList>

--- a/P5/Source/Specs/age.xml
+++ b/P5/Source/Specs/age.xml
@@ -22,62 +22,27 @@
     <macroRef key="macro.phraseSeq.limited"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-age">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="type" usage="opt" mode="change">
+    <attDef ident="type" usage="opt" mode="change">
       <datatype>
-	<dataRef key="teidata.enumerated"/>
+        <dataRef key="teidata.enumerated"/>
       </datatype>
       <valList type="open">
-	<valItem ident="western"/>
-	<valItem ident="sui"/>
-	<valItem ident="subjective"/>
-	<valItem ident="objective"/>
-	<valItem ident="inWorld">
-	  <gloss versionDate="2017-06-08" xml:lang="en">in world</gloss>
-  <gloss versionDate="2018-09-08" xml:lang="es">en el mundo</gloss>
-	  <gloss versionDate="2018-12-20" xml:lang="ja">物語世界</gloss>
-	  <desc versionDate="2017-06-08" xml:lang="en">age of a fictional character at the time the story
-	  takes place, rather than at the time the story is
-	  told</desc>
-  <desc versionDate="2018-09-08" xml:lang="es">Edad de un personaje ficcional en el tiempo en el que la historia sucede (no en el tiempo en el cual es contada).</desc>
-	  <desc versionDate="2018-12-20" xml:lang="ja">物語を語る時点ではなく、物語の中の時点における架空の人物の年齢。</desc>
-	</valItem>
-	<valItem ident="chronological"/>
-	<valItem ident="biological"/>
-	<valItem ident="psychological"/>
-	<valItem ident="functional"/>
+        <valItem ident="western"/>
+        <valItem ident="sui"/>
+        <valItem ident="subjective"/>
+        <valItem ident="objective"/>
+        <valItem ident="inWorld">
+          <gloss versionDate="2017-06-08" xml:lang="en">in world</gloss>
+          <gloss versionDate="2018-09-08" xml:lang="es">en el mundo</gloss>
+          <gloss versionDate="2018-12-20" xml:lang="ja">物語世界</gloss>
+          <desc versionDate="2017-06-08" xml:lang="en">age of a fictional character at the time the story takes place, rather than at the time the story is told</desc>
+          <desc versionDate="2018-09-08" xml:lang="es">Edad de un personaje ficcional en el tiempo en el que la historia sucede (no en el tiempo en el cual es contada).</desc>
+          <desc versionDate="2018-12-20" xml:lang="ja">物語を語る時点ではなく、物語の中の時点における架空の人物の年齢。</desc>
+        </valItem>
+        <valItem ident="chronological"/>
+        <valItem ident="biological"/>
+        <valItem ident="psychological"/>
+        <valItem ident="functional"/>
       </valList>
     </attDef>
     <attDef ident="value" usage="opt">
@@ -85,12 +50,9 @@
       <desc versionDate="2007-12-20" xml:lang="ko">나이 또는 연령대를 표시하는 수치 부호를 제시한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">提供一個代表該年齡或年齡層的數字代碼</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">年齢または年齢層を数値で示す。</desc>
-      <desc versionDate="2008-12-09" xml:lang="fr">fournit un code numérique représentant l'âge ou la
-        tranche d'âge.</desc>
-      <desc versionDate="2007-05-04" xml:lang="es">proporciona un código numérico que representa la edad
-        o el intervalo de edad.</desc>
-      <desc versionDate="2007-01-21" xml:lang="it">assegna un codice numerico che rappresenta l'età o la
-        fascia di età</desc>
+      <desc versionDate="2008-12-09" xml:lang="fr">fournit un code numérique représentant l'âge ou la tranche d'âge.</desc>
+      <desc versionDate="2007-05-04" xml:lang="es">proporciona un código numérico que representa la edad o el intervalo de edad.</desc>
+      <desc versionDate="2007-01-21" xml:lang="it">assegna un codice numerico che rappresenta l'età o la fascia di età</desc>
       <datatype><dataRef key="teidata.count"/></datatype>
       <remarks versionDate="2006-10-08" xml:lang="en">
         <p>This attribute may be used to complement a more detailed discussion of a person's age in

--- a/P5/Source/Specs/altIdentifier.xml
+++ b/P5/Source/Specs/altIdentifier.xml
@@ -22,7 +22,6 @@
     <memberOf key="att.typed"/>
     <memberOf key="att.datable"/>
   </classes>
-
   <content>
     <sequence>
       <classRef key="model.placeNamePart" expand="sequenceOptional"/>    
@@ -33,39 +32,6 @@
       <elementRef key="note" minOccurs="0"/>
     </sequence>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-altIdentifier">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#UND">
       <altIdentifier>

--- a/P5/Source/Specs/application.xml
+++ b/P5/Source/Specs/application.xml
@@ -3,13 +3,10 @@
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="application" module="header">
   <desc versionDate="2007-07-31" xml:lang="en">provides information about an application which has acted upon the document.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">문서에 사용한 애플리케이션에 관한 정보를 제시한다.</desc>
-  <desc versionDate="2008-04-06" xml:lang="es">proporciona información sobre la aplicación que ha
-    actuado sobre el documento.</desc>
+  <desc versionDate="2008-04-06" xml:lang="es">proporciona información sobre la aplicación que ha actuado sobre el documento.</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">当該文書に作用するソフトウェアに関する情報を示す。</desc>
-  <desc versionDate="2008-12-09" xml:lang="fr">fournit des informations sur une application qui a été
-    utilisée pour le traitement du document.</desc>
-  <desc versionDate="2007-11-06" xml:lang="it">registra informazioni relative a un'applicazione che ha
-    agito sul documento</desc>
+  <desc versionDate="2008-12-09" xml:lang="fr">fournit des informations sur une application qui a été utilisée pour le traitement du document.</desc>
+  <desc versionDate="2007-11-06" xml:lang="it">registra informazioni relative a un'applicazione che ha agito sul documento</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.typed"/>
@@ -18,77 +15,30 @@
   </classes>
   <content>
     <sequence>
-      
-        <classRef key="model.labelLike" minOccurs="1" maxOccurs="unbounded"/>
-      
+      <classRef key="model.labelLike" minOccurs="1" maxOccurs="unbounded"/>
       <alternate>
-        
-          <classRef key="model.ptrLike" minOccurs="0" maxOccurs="unbounded"/>
-        
-        
-          <classRef key="model.pLike" minOccurs="0" maxOccurs="unbounded"/>
-        
+        <classRef key="model.ptrLike" minOccurs="0" maxOccurs="unbounded"/>
+        <classRef key="model.pLike" minOccurs="0" maxOccurs="unbounded"/>        
       </alternate>
     </sequence>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-application">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="ident" usage="req">
-      <desc versionDate="2013-04-12" xml:lang="en">supplies an identifier for the application, independent of its version number or display
-        name.</desc>
+    <attDef ident="ident" usage="req">
+      <desc versionDate="2013-04-12" xml:lang="en">supplies an identifier for the application, independent of its version number or display name.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">버전 또는 표시명과 상관없이 애플리케이션의 확인소를 제공한다.</desc>
-      <desc versionDate="2008-04-06" xml:lang="es">proporciona un identificador para la aplicación,
-        independientemente de su número de versión o el nombre de la visualización.</desc>
+      <desc versionDate="2008-04-06" xml:lang="es">proporciona un identificador para la aplicación, independientemente de su número de versión o el nombre de la visualización.</desc>
       <desc xml:lang="ja" versionDate="2018-12-28">当該ソフトウェアの識別子を示す。これは、版番号や表示名とは異なる。</desc>
-      <desc versionDate="2008-03-30" xml:lang="fr">fournit un identifiant pour l'application,
-        indépendamment de son numéro de version ou du nom affiché.</desc>
-      <desc versionDate="2007-11-06" xml:lang="it">indica un identificatore per l'applicazione,
-        indipendentemente dal numero di versione o dal nome visualizzato</desc>
+      <desc versionDate="2008-03-30" xml:lang="fr">fournit un identifiant pour l'application, indépendamment de son numéro de version ou du nom affiché.</desc>
+      <desc versionDate="2007-11-06" xml:lang="it">indica un identificatore per l'applicazione, indipendentemente dal numero di versione o dal nome visualizzato</desc>
       <datatype><dataRef key="teidata.name"/></datatype>
     </attDef>
     <attDef ident="version" usage="req">
-      <desc versionDate="2013-04-12" xml:lang="en">supplies a version number for the application, independent of its identifier or display
-        name.</desc>
+      <desc versionDate="2013-04-12" xml:lang="en">supplies a version number for the application, independent of its identifier or display name.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">확인소 또는 표시명과 상관없이 애플리케이션의 버전을 제공한다.</desc>
-      <desc versionDate="2008-04-06" xml:lang="es">Suministra un número de versión para la aplicación,
-        independientemente de su identificador o el nombre de la visualización.</desc>
+      <desc versionDate="2008-04-06" xml:lang="es">Suministra un número de versión para la aplicación, independientemente de su identificador o el nombre de la visualización.</desc>
       <desc xml:lang="ja" versionDate="2018-12-28">当該ソフトウェアの版番号を示す。識別子や表示名とは異なる。</desc>
-      <desc versionDate="2008-03-30" xml:lang="fr">fournit un numéro de version pour l'application,
-        indépendamment de son identifiant ou du nom affiché.</desc>
-      <desc versionDate="2007-11-06" xml:lang="it">indica un numero di versione per l'applicazione,
-        indipendentemente dall'identificatore o dal nome visualizzato</desc>
+      <desc versionDate="2008-03-30" xml:lang="fr">fournit un numéro de version pour l'application, indépendamment de son identifiant ou du nom affiché.</desc>
+      <desc versionDate="2007-11-06" xml:lang="it">indica un numero di versione per l'applicazione, indipendentemente dall'identificatore o dal nome visualizzato</desc>
       <datatype><dataRef key="teidata.versionNumber"/></datatype>
     </attDef>
   </attList>

--- a/P5/Source/Specs/att.datable.xml
+++ b/P5/Source/Specs/att.datable.xml
@@ -20,8 +20,7 @@
   </classes>
   <attList>
     <attDef ident="period" usage="opt">
-      <desc versionDate="2021-04-19" xml:lang="en">supplies pointers to one or more definitions of 
-        named periods of time (typically <gi>category</gi>s, <gi>date</gi>s or <gi>event</gi>s) within which the datable item is understood to have occurred.</desc>
+      <desc versionDate="2021-04-19" xml:lang="en">supplies pointers to one or more definitions of named periods of time (typically <gi>category</gi>s, <gi>date</gi>s, or <gi>event</gi>s) within which the datable item is understood to have occurred.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">시간을 명시할 수 있는 항목이 일어난 시간의 기간명을 정의하는 특정 위치로의 포인터를
         제공한다.</desc>
       <desc versionDate="2008-04-06" xml:lang="es">suministra un indicador a una localización

--- a/P5/Source/Specs/author.xml
+++ b/P5/Source/Specs/author.xml
@@ -5,22 +5,14 @@
   <gloss xml:lang="es" versionDate="2022-02-24">autor/a</gloss>
   <gloss versionDate="2011-11-26" xml:lang="fr">auteur</gloss>
   <gloss versionDate="2017-06-04" xml:lang="de">Autor</gloss>
-  <desc versionDate="2011-11-26" xml:lang="en">in a bibliographic reference, contains the name(s) of an
-  author, personal or corporate, of a work; for example in the same
-  form as that provided by a recognized bibliographic name authority.</desc>
+  <desc versionDate="2011-11-26" xml:lang="en">in a bibliographic reference, contains the name(s) of an author, personal or corporate, of a work; for example in the same form as that provided by a recognized bibliographic name authority.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">참고문헌에 작가, 단독 저자, 공동 저자의 이름을 포함한다; 서지 항목의 책임에 관한 1차적 진술.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">在書目參照中，包含一件作品的作者 (群) 姓名，無論是個人或是團體性質；這也是書目項目責任歸屬的主要陳述。</desc>
   <desc versionDate="2023-08-30" xml:lang="ja">書誌参照において、作品の著者となる人や法人の名前を、たとえば、よく知られた書誌典拠情報機関の形式で提供されるものに合わせるなどして記述する。</desc>
-  <desc versionDate="2009-01-06" xml:lang="fr">dans une référence bibliographique contient le nom de la
-    (des) personne(s) physique(s) ou du collectif, auteur(s) d'une oeuvre ; par exemple dans la même forme que celle utilisée par une référence bibliographique reconnue.</desc>
-  <desc versionDate="2022-02-24" xml:lang="es">en una referencia bibliográfica, contiene el nombre del
-autor/a/es, ya sea una persona o una institución, de una obra; por ejemplo, en la misma forma que la proporcionada por una autoridad bibliográfica reconocida.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">in un riferimento bibliografico contiene il nome
-    dell'autore (o degli autori), personale o collettivo, di un'opera; è la dichiarazione di
-    responsabilità primaria di ciascuna unità bibliografica.</desc>
-  <desc versionDate="2017-06-04" xml:lang="de">enthält in einer bibliografischen Referenz den oder die Namen eines Autors eines Werks
-    (oder einer für das Werk verantwortlichen Körperschaft); zum Beispiel in der Form, wie sie eine
-    anerkannte bibliografische Instanz anbietet.</desc>
+  <desc versionDate="2009-01-06" xml:lang="fr">dans une référence bibliographique contient le nom de la (des) personne(s) physique(s) ou du collectif, auteur(s) d'une oeuvre ; par exemple dans la même forme que celle utilisée par une référence bibliographique reconnue.</desc>
+  <desc versionDate="2022-02-24" xml:lang="es">en una referencia bibliográfica, contiene el nombre del autor/a/es, ya sea una persona o una institución, de una obra; por ejemplo, en la misma forma que la proporcionada por una autoridad bibliográfica reconocida.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">in un riferimento bibliografico contiene il nome dell'autore (o degli autori), personale o collettivo, di un'opera; è la dichiarazione di responsabilità primaria di ciascuna unità bibliografica.</desc>
+  <desc versionDate="2017-06-04" xml:lang="de">enthält in einer bibliografischen Referenz den oder die Namen eines Autors eines Werks (oder einer für das Werk verantwortlichen Körperschaft); zum Beispiel in der Form, wie sie eine anerkannte bibliografische Instanz anbietet.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.naming"/>
@@ -30,48 +22,17 @@ autor/a/es, ya sea una persona o una institución, de una obra; por ejemplo, en 
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-author">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#COBICOR-eg-251">
       <author>British Broadcasting Corporation</author>
       <author>La Fayette, Marie Madeleine Pioche de la Vergne, comtesse de (1634–1693)</author>
       <author>Anonymous</author>
       <author>Bill and Melinda Gates Foundation</author>
-      <author><persName>Beaumont, Francis</persName> and
-      <persName>John Fletcher</persName>
-         </author>
+      <author>
+        <persName>Beaumont, Francis</persName>
+        and
+        <persName>John Fletcher</persName>
+      </author>
       <author><orgName key="BBC">British Broadcasting
       Corporation</orgName>: Radio 3 Network</author>
     </egXML>
@@ -80,7 +41,7 @@ autor/a/es, ya sea una persona o una institución, de una obra; por ejemplo, en 
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <author>La Fayette, Marie Madeleine Pioche de la Vergne, comtesse de (1634–1693)</author>
       <author>Anonyme</author>
-      <author> Erckmann-Chatrian</author>
+      <author>Erckmann-Chatrian</author>
       <author>
         <orgName key="ARTE">Association relative à la télévision européenne</orgName>
       </author>
@@ -103,10 +64,10 @@ autor/a/es, ya sea una persona o una institución, de una obra; por ejemplo, en 
     <p>In the case of a broadcast, use this element for the name of
     the company or network responsible for making the broadcast.</p>
     <p>Where an author is unknown or unspecified, this element may contain
-text such as <mentioned>Unknown</mentioned> or
-<mentioned>Anonymous</mentioned>. When the appropriate TEI modules are
-in use, it may also contain detailed tagging of the names used for people, organizations or
-places, in particular where  multiple names are given.</p>
+    text such as <mentioned>Unknown</mentioned> or
+    <mentioned>Anonymous</mentioned>. When the appropriate TEI modules are
+    in use, it may also contain detailed tagging of the names used for people, organizations or
+    places, in particular where  multiple names are given.</p>
   </remarks>
   <remarks versionDate="2022-04-10" xml:lang="es">
     <p>En particular, cuando es probable que la catalogación se base en el contenido del encabezado, 

--- a/P5/Source/Specs/binding.xml
+++ b/P5/Source/Specs/binding.xml
@@ -1,67 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="BINDING" ident="binding">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="BINDING" ident="binding">
   <gloss xml:lang="en" versionDate="2007-06-12">binding</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">reliure</gloss>
-  <desc versionDate="2019-01-17" xml:lang="en" xml:id="binding.desc">contains a description of one binding, i.e. type of covering, boards,
-    etc. applied to a manuscript or other object.</desc>
+  <desc versionDate="2019-01-17" xml:lang="en" xml:id="binding.desc">contains a description of one binding, i.e. type of covering, boards, etc. applied to a manuscript or other object.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">하나의 제본에 대한 기술을 포함한다. 즉, 원고에 적용된 커버, 표지 등의 유형</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">一個裝訂的描述，例如使用於該手稿的封面類型、封面等。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">1つの装訂に関する情報を示す。例えば、手書き資料でいうカバーの種類、 表紙など。</desc>
-  <desc versionDate="2007-06-12" xml:lang="fr">contient la description d'une reliure, i.e. du type de
-    couverture, d'ais, etc., rencontrés.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene la descripción de una encuadernación, p.ej. tipo
-    de cubiertas, tablas, etc. presentes en un manuscrito.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene la descrizione di una legatura, cioè del tipo di
-    copertine, tavole, ecc. utilizzate per il manoscritto</desc>
+  <desc versionDate="2007-06-12" xml:lang="fr">contient la description d'une reliure, i.e. du type de couverture, d'ais, etc., rencontrés.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene la descripción de una encuadernación, p.ej. tipo de cubiertas, tablas, etc. presentes en un manuscrito.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene la descrizione di una legatura, cioè del tipo di copertine, tavole, ecc. utilizzate per il manoscritto</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.datable"/>
   </classes>
   <content>
-    
-      <alternate minOccurs="1" maxOccurs="unbounded">
-        <classRef key="model.pLike"/>
-        <elementRef key="condition"/>
-        <elementRef key="decoNote"/>
-      </alternate>
-    
+    <alternate minOccurs="1" maxOccurs="unbounded">
+      <classRef key="model.pLike"/>
+      <elementRef key="condition"/>
+      <elementRef key="decoNote"/>
+    </alternate>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-binding">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="contemporary">
+    <attDef ident="contemporary">
       <gloss xml:lang="en" versionDate="2007-06-12">contemporary</gloss>
       <gloss versionDate="2007-06-12" xml:lang="fr">contemporaine</gloss>
       <desc versionDate="2005-01-14" xml:lang="en">specifies whether or not the binding is contemporary with the majority of its

--- a/P5/Source/Specs/birth.xml
+++ b/P5/Source/Specs/birth.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="birth">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="birth">
   <gloss xml:lang="en" versionDate="2008-12-09">birth</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">naissance</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">contains information about a person's birth, such as its date and place.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">날짜, 장소와 같이 개인의 출생에 관한 정보를 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含個人的出生資訊，例如日期及地點等。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">人物の出生に関する情報を示す。例えば、日時や場所など。</desc>
-  <desc versionDate="2008-12-09" xml:lang="fr">contient des informations sur la naissance d'une
-    personne, comme la date et le lieu</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene información relativa al nacimiento de una
-    persona, p.ej. fecha y lugar de nacimiento.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene informazioni relative al luogo e alla data di
-    nascita di una persona</desc>
+  <desc versionDate="2008-12-09" xml:lang="fr">contient des informations sur la naissance d'une personne, comme la date et le lieu</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene información relativa al nacimiento de una persona, p.ej. fecha y lugar de nacimiento.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene informazioni relative al luogo e alla data di nascita di una persona</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.personPart"/>
@@ -26,40 +24,7 @@
     <macroRef key="macro.phraseSeq"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-birth">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="type" usage="opt" mode="change">
+    <attDef ident="type" usage="opt" mode="change">
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>

--- a/P5/Source/Specs/bloc.xml
+++ b/P5/Source/Specs/bloc.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="bloc">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="bloc">
   <gloss xml:lang="en" versionDate="2008-12-09">bloc</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">bloc</gloss>
-  <desc versionDate="2007-02-27" xml:lang="en">contains the name of a geo-political unit consisting of two or more nation states or
-    countries.</desc>
+  <desc versionDate="2007-02-27" xml:lang="en">contains the name of a geo-political unit consisting of two or more nation states or countries.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">둘 이상의 민족국가 또는 국가로 구성된 지리-정치적 단위의 이름을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含一個地理政治區域名稱，由一個或多個國家所組成。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">複数の国や地域を跨ぐ地政学的な名前を示す。</desc>
-  <desc versionDate="2008-12-09" xml:lang="fr">contient le nom d'une unité géo-politique composée d'au
-    moins deux états ou pays</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene el nombre de una unidad geopolítica que
-    comprende uno o más estados nacionales o países.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene il nome di un'unità geopolitica comprendente uno
-    o più stati nazione o paesi</desc>
+  <desc versionDate="2008-12-09" xml:lang="fr">contient le nom d'une unité géo-politique composée d'au moins deux états ou pays</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene el nombre de una unidad geopolítica que comprende uno o más estados nacionales o países.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene il nome di un'unità geopolitica comprendente uno o più stati nazione o paesi</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.placeNamePart"/>
@@ -25,39 +22,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-bloc">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <bloc type="union">the European Union</bloc>

--- a/P5/Source/Specs/change.xml
+++ b/P5/Source/Specs/change.xml
@@ -1,23 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="change">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="change">
   <gloss xml:lang="en" versionDate="2016-11-25">change</gloss>
   <gloss versionDate="2016-11-25" xml:lang="de">Änderung</gloss>
   <gloss versionDate="2023-10-02" xml:lang="ja">変更</gloss>
-  <desc versionDate="2011-10-31" xml:lang="en">documents a change or set of changes made during the production
-    of a source document, or during the revision of an electronic file.</desc>
-  <desc versionDate="2009-01-05" xml:lang="fr">résume une modification ou une correction apportée à une
-    version particulière d’un texte électronique partagé entre plusieurs chercheurs.</desc>
+  <desc versionDate="2011-10-31" xml:lang="en">documents a change or set of changes made during the production of a source document, or during the revision of an electronic file.</desc>
+  <desc versionDate="2009-01-05" xml:lang="fr">résume une modification ou une correction apportée à une version particulière d’un texte électronique partagé entre plusieurs chercheurs.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">몇몇 연구자들 사이에 공유된 전자 텍스트의 특정 버전에 대한 특정 변경 또는 수정 사항을 요약한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">概述多位研究者共享的某版本電子文本當中，某特定的內容變更或修正。</desc>
   <desc versionDate="2023-10-02" xml:lang="ja">元文書の作成や電子ファイルの改訂においてなされた一つあるいは一連の変更を記述する。</desc>
-  <desc versionDate="2016-11-25" xml:lang="de">verzeichnet Änderungen oder Korrekturen während der Erstellung eines 
-    Basisdokuments oder während der Überarbeitung einer elektronischen Datei.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">resume un cambio o corrección determinada llevada a cabo
-    en una versión dada de un texto electrónico en el que trabajan diversos investigadores.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">sintetizza un particolare cambiamento o correzione
-    effettuato ad una particolare versione di un documento elettronico, condivisa da più
-    ricercatori.</desc>
+  <desc versionDate="2016-11-25" xml:lang="de">verzeichnet Änderungen oder Korrekturen während der Erstellung eines Basisdokuments oder während der Überarbeitung einer elektronischen Datei.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">resume un cambio o corrección determinada llevada a cabo en una versión dada de un texto electrónico en el que trabajan diversos investigadores.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">sintetizza un particolare cambiamento o correzione effettuato ad una particolare versione di un documento elettronico, condivisa da più ricercatori.</desc>
   <classes>
     <memberOf key="att.ascribed"/>
     <memberOf key="att.datable"/>
@@ -38,40 +33,7 @@
     <macroRef key="macro.specialPara"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-change">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="target">
+    <attDef ident="target">
       <gloss xml:lang="en" versionDate="2016-11-25">target</gloss>
       <gloss versionDate="2016-11-25" xml:lang="de">Ziel</gloss>
       <gloss versionDate="2023-10-02" xml:lang="ja">対象</gloss>

--- a/P5/Source/Specs/climate.xml
+++ b/P5/Source/Specs/climate.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="climate" module="namesdates">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="climate" module="namesdates">
   <gloss xml:lang="en" versionDate="2008-12-09">climate</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">climat</gloss>
   <desc versionDate="2007-06-14" xml:lang="en">contains information about the physical climate of a place.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">장소의 기후에 관한 정보를 포함한다.</desc>
   <desc versionDate="2008-04-06" xml:lang="es">contiene información sobre el clima físico de un lugar.</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">ある場所の天候に関する情報を示す。</desc>
-  <desc versionDate="2008-12-09" xml:lang="fr">contient des informations sur le climat physique d'un
-        lieu.</desc>
-  <desc versionDate="2007-11-06" xml:lang="it">contiene informazioni relative al clima fisico di un
-        luogo</desc>
+  <desc versionDate="2008-12-09" xml:lang="fr">contient des informations sur le climat physique d'un lieu.</desc>
+  <desc versionDate="2007-11-06" xml:lang="it">contiene informazioni relative al clima fisico di un luogo</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.datable"/>
@@ -22,68 +21,19 @@
   </classes>
   <content>
     <sequence>
-      
-         <elementRef key="precision" minOccurs="0" maxOccurs="unbounded"/>
-      
-      
-        <classRef key="model.headLike" minOccurs="0" maxOccurs="unbounded"/>
-      
+      <elementRef key="precision" minOccurs="0" maxOccurs="unbounded"/>
+      <classRef key="model.headLike" minOccurs="0" maxOccurs="unbounded"/>
       <alternate>
-        
-          
-            <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>
-          
-        
-        
-          
-            <classRef key="model.labelLike" minOccurs="1" maxOccurs="unbounded"/>
-          
-        
+        <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>
+        <classRef key="model.labelLike" minOccurs="1" maxOccurs="unbounded"/>
       </alternate>
-      
-        <alternate minOccurs="0" maxOccurs="unbounded">
-          <classRef key="model.noteLike"/>
-          <classRef key="model.biblLike"/>
-        </alternate>
-      
-      
-        <elementRef key="climate" minOccurs="0" maxOccurs="unbounded"/>
-      
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.noteLike"/>
+        <classRef key="model.biblLike"/>
+      </alternate>
+      <elementRef key="climate" minOccurs="0" maxOccurs="unbounded"/>
     </sequence>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-climate">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <place xml:id="ROMA">

--- a/P5/Source/Specs/conversion.xml
+++ b/P5/Source/Specs/conversion.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="conversion">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="conversion">
   <desc versionDate="2019-07-03" xml:lang="en">defines how to calculate one unit of measure in terms of another.</desc>
   <classes>
     <memberOf key="att.global"/>
@@ -10,39 +11,6 @@
   </classes>
   <content><empty/></content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-conversion">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
       <attDef ident="fromUnit" usage="req">
       <desc versionDate="2019-06-26" xml:lang="en">indicates a source unit of measure that is to be converted into another unit indicated in <att>toUnit</att>.</desc>
       <datatype>

--- a/P5/Source/Specs/country.xml
+++ b/P5/Source/Specs/country.xml
@@ -1,24 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="country">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="country">
   <gloss xml:lang="en" versionDate="2008-12-09">country</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">pays</gloss>
-  <desc versionDate="2006-01-22" xml:lang="en">contains the name of a geo-political unit, such as a nation, country, colony, or
-    commonwealth, larger than or administratively superior to a region and smaller than a bloc.</desc>
-  <desc versionDate="2007-12-20" xml:lang="ko">하나의 블록보다 큰 국가, 지역, 식민지, 또는 공화국, 또는 하나의 블록보다 작은 지역의 상급
-    행정기관과 같은, 지리-정치 단위명을 포함한다.</desc>
+  <desc versionDate="2006-01-22" xml:lang="en">contains the name of a geo-political unit, such as a nation, country, colony, or commonwealth, larger than or administratively superior to a region and smaller than a bloc.</desc>
+  <desc versionDate="2007-12-20" xml:lang="ko">하나의 블록보다 큰 국가, 지역, 식민지, 또는 공화국, 또는 하나의 블록보다 작은 지역의 상급 행정기관과 같은, 지리-정치 단위명을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含一個地理政治區域名稱，例如民族、國家、殖民地、或聯邦區域，範圍大於一般地區或行政地位較高，但小於國家聯盟性的地理政治區。</desc>
-  <desc versionDate="2008-04-06" xml:lang="es">contiene el nombre de una unidad geopolítica, como una
-    nación, país, colonia, etc. más grande o administrativamente superior que una región y más
-    pequeño que un bloque.</desc>
-  <desc versionDate="2008-04-05" xml:lang="ja">1つの国家に相当する地政学的な単位名を示す。国家、植民地、共同体・連
-    邦を含む。これは、行政単位上の地域よりも大きい単位で、連合より小さな 単位である。</desc>
-  <desc versionDate="2008-12-09" xml:lang="fr">contient le nom d'une unité géo-politique, comme une
-    nation, un pays, une colonie ou une communauté, plus grande ou administrativement supérieure à
-    une région et plus petite qu'un bloc.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene il nome di un'unità geopolitica, come una
-    nazione, un paese, una colonia, o un'unione di stati, che sia più ampia o amministrativamente
-    superiore rispetto a una regione ma di dimensioni inferiori rispetto a un blocco</desc>
+  <desc versionDate="2008-04-06" xml:lang="es">contiene el nombre de una unidad geopolítica, como una nación, país, colonia, etc. más grande o administrativamente superior que una región y más pequeño que un bloque.</desc>
+  <desc versionDate="2008-04-05" xml:lang="ja">1つの国家に相当する地政学的な単位名を示す。国家、植民地、共同体・連 邦を含む。これは、行政単位上の地域よりも大きい単位で、連合より小さな 単位である。</desc>
+  <desc versionDate="2008-12-09" xml:lang="fr">contient le nom d'une unité géo-politique, comme une nation, un pays, une colonie ou une communauté, plus grande ou administrativement supérieure à une région et plus petite qu'un bloc.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene il nome di un'unità geopolitica, come una nazione, un paese, una colonia, o un'unione di stati, che sia più ampia o amministrativamente superiore rispetto a una regione ma di dimensioni inferiori rispetto a un blocco</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.placeNamePart"/>
@@ -30,39 +22,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-country">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <country key="DK">Denmark</country>

--- a/P5/Source/Specs/creation.xml
+++ b/P5/Source/Specs/creation.xml
@@ -1,66 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="creation">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="creation">
   <gloss xml:lang="en" versionDate="2007-06-12">creation</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">création</gloss>
   <gloss versionDate="2016-11-17" xml:lang="de">Entstehung</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">contains information about the creation of a text.</desc>
-  <desc versionDate="2009-01-05" xml:lang="fr">contient des informations concernant la création d’un
-    texte.</desc>
+  <desc versionDate="2009-01-05" xml:lang="fr">contient des informations concernant la création d’un texte.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">텍스트 생성에 관한 정보를 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含關於文件建置的資訊。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">テキストの作成に関する情報を示す。</desc>
-    <desc versionDate="2016-11-17" xml:lang="de">beinhaltet Informationen zur Entstehung eines Textes.</desc>
+  <desc versionDate="2016-11-17" xml:lang="de">beinhaltet Informationen zur Entstehung eines Textes.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">contiene información sobre la creación del texto.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene informazioni riguardanti la creazione di un
-    testo.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene informazioni riguardanti la creazione di un testo.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.datable"/>
     <memberOf key="model.profileDescPart"/>
   </classes>
   <content>
-    
-      <alternate minOccurs="0" maxOccurs="unbounded">
-        <textNode/>
-        <classRef key="model.limitedPhrase"/>
-        <elementRef key="listChange"/>
-      </alternate>
-    
+    <alternate minOccurs="0" maxOccurs="unbounded">
+      <textNode/>
+      <classRef key="model.limitedPhrase"/>
+      <elementRef key="listChange"/>
+    </alternate>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-creation">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <creation>

--- a/P5/Source/Specs/custEvent.xml
+++ b/P5/Source/Specs/custEvent.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="CUSTEVENT" ident="custEvent">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="CUSTEVENT" ident="custEvent">
   <gloss versionDate="2007-07-04" xml:lang="en">custodial event</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">보관 사건</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW"/>
@@ -11,8 +12,7 @@
   <desc versionDate="2007-12-20" xml:lang="ko">원고의 보관 이력 중 단일 사건에 대하여 기술한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">描述手稿保管歷史中的單一事件。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">手書き資料の管理履歴における、ひとつの事象を示す。</desc>
-  <desc versionDate="2007-06-12" xml:lang="fr">décrit un événement dans l'histoire de la
-      conservation du manuscrit.</desc>
+  <desc versionDate="2007-06-12" xml:lang="fr">décrit un événement dans l'histoire de la conservation du manuscrit.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">describe un único evento en la historia de la conservación de un manuscrito.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">descrive un singolo evento nella storia della conservazione di un manoscritto</desc>
   <classes>
@@ -23,39 +23,6 @@
   <content>
     <macroRef key="macro.specialPara"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-custEvent">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <custEvent type="photography">Photographed by David Cooper on <date>12 Dec 1964</date>

--- a/P5/Source/Specs/death.xml
+++ b/P5/Source/Specs/death.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="death">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="death">
   <gloss xml:lang="en" versionDate="2008-12-09">death</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">décès</gloss>
   <desc versionDate="2005-12-13" xml:lang="en">contains information about a person's death, such as its date and place.</desc>
@@ -23,40 +24,7 @@
     <macroRef key="macro.phraseSeq"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-death">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="type" usage="opt" mode="change">
+    <attDef ident="type" usage="opt" mode="change">
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>

--- a/P5/Source/Specs/district.xml
+++ b/P5/Source/Specs/district.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="district">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="district">
   <gloss xml:lang="en" versionDate="2008-12-09">district</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">district</gloss>
   <desc versionDate="2006-01-22" xml:lang="en">contains the name of any kind of subdivision of a settlement, such as a parish, ward, or other administrative or geographic unit.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">교구, 구 또는 다른 행정 지리적 단위와 같이 거주지의 하위 구분명을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含任何次行政區名稱，例如教區、選區、或其他行政或地理單元。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">場所を示す要素として、集落より小さい名前を示す。例えば、小教区や区な ど、行政上・地勢上の単位。</desc>
-  <desc versionDate="2009-03-19" xml:lang="fr">contient le nom d'une subdivision quelconque d'une ville, comme une paroisse, une circonscription
-        électorale ou toute autre unité administrative ou géographique.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene el nombre de cualquier subdivisión al interno de un asentamiento, como una circunscripción, un
-        barrio u otras unidades administrativas o geográficas.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene il nome di una qualsiasi suddivisione all'interno di un insediamento, come una circoscrizione,
-        un quartiere o altre unità amministrative o geografiche</desc>
+  <desc versionDate="2009-03-19" xml:lang="fr">contient le nom d'une subdivision quelconque d'une ville, comme une paroisse, une circonscription électorale ou toute autre unité administrative ou géographique.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene el nombre de cualquier subdivisión al interno de un asentamiento, como una circunscripción, un barrio u otras unidades administrativas o geográficas.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene il nome di una qualsiasi suddivisione all'interno di un insediamento, come una circoscrizione, un quartiere o altre unità amministrative o geografiche</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.placeNamePart"/>
@@ -24,39 +22,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-district">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <placeName>

--- a/P5/Source/Specs/editor.xml
+++ b/P5/Source/Specs/editor.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="core" ident="editor">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="core" ident="editor">
   <!--gloss>editor</gloss-->
-  <desc versionDate="2012-12-27" xml:lang="en">contains a secondary statement of responsibility for a bibliographic item, for example the name of an
-    individual, institution or organization, (or of several such) acting as editor, compiler,
-    translator, etc.</desc>
+  <desc versionDate="2012-12-27" xml:lang="en">contains a secondary statement of responsibility for a bibliographic item, for example the name of an individual, institution or organization, (or of several such) acting as editor, compiler, translator, etc.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">서지 항목의 책임에 관한 2차적 진술, 예를 들어, 편집, 번역 등의 작업을 한 편집, 개인, 기관,
     또는 기구의 이름</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">書目項目的次要責任歸屬，例如扮演編輯、編譯、翻譯等角色的個人、機構或組織 (或其他類似者) 的名稱。</desc>
@@ -12,15 +11,9 @@
   <desc versionDate="2009-01-06" xml:lang="fr">mention de responsabilité secondaire pour un item
     bibliographique, par exemple le nom d'une personne, d'une institution ou d'un organisme (ou de
     plusieurs d'entre eux) comme éditeur scientifique, compilateur, traducteur, etc.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">declaración secundaria de responsabilidad para un ítem
-    bibliográfico, por ejemplo un nombre particular, o institucional (o cualquier otro) que ha
-    actuado como editor, compilador, traductor, etc.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">è la dichiarazione di responsabilità secondaria di
-    ciascuna unità bibliografica, ad esempio il nome di un individuo, di un'istituzione o
-    organizzazione che agisce come curatore, compilatore, traduttore, ecc.</desc>
-  <desc versionDate="2017-06-04" xml:lang="de">beinhaltet zusätzliche Angaben zur Verantwortlichkeit für ein bibliografisches Objekt, z.
-    B. den Namen einer Person, Institution oder Organisation (oder mehreren davon), welche als
-    Herausgeber, Kompilator, Übersetzer etc. fungiert.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">declaración secundaria de responsabilidad para un ítem bibliográfico, por ejemplo un nombre particular, o institucional (o cualquier otro) que ha actuado como editor, compilador, traductor, etc.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">è la dichiarazione di responsabilità secondaria di ciascuna unità bibliografica, ad esempio il nome di un individuo, di un'istituzione o organizzazione che agisce come curatore, compilatore, traduttore, ecc.</desc>
+  <desc versionDate="2017-06-04" xml:lang="de">beinhaltet zusätzliche Angaben zur Verantwortlichkeit für ein bibliografisches Objekt, z. B. den Namen einer Person, Institution oder Organisation (oder mehreren davon), welche als Herausgeber, Kompilator, Übersetzer etc. fungiert.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.naming"/>
@@ -30,40 +23,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-editor">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
-
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <editor role="Technical_Editor">Ron Van den Branden</editor>

--- a/P5/Source/Specs/education.xml
+++ b/P5/Source/Specs/education.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="education">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="education">
   <gloss xml:lang="en" versionDate="2008-12-09">education</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">éducation</gloss>
   <desc versionDate="2005-12-14" xml:lang="en">contains a description of the educational experience of a person.</desc>
@@ -22,40 +23,7 @@
     <macroRef key="macro.phraseSeq"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-education">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="type" usage="opt" mode="change">
+    <attDef ident="type" usage="opt" mode="change">
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>

--- a/P5/Source/Specs/event.xml
+++ b/P5/Source/Specs/event.xml
@@ -56,35 +56,6 @@
       </alternate>
     </sequence>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-      <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-        as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-        (unlike <att>datingMethod</att> defined in
-        <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-        in the original material defined by the parent element, <emph>not</emph> the calendar to
-        which the date is normalized.</desc>
-      <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the date represented by the content of this element belongs.</desc>
-      <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-      <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-      <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-      <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel appartient la date exprimée dans le contenu de l'élément.</desc>
-      <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra una fecha.</desc>
-      <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data appartiene.</desc>
-      <datatype minOccurs="1" maxOccurs="unbounded">
-        <dataRef key="teidata.pointer"/>
-      </datatype>
-      <constraintSpec scheme="schematron" ident="calendar-check-event">
-        <constraint>
-          <sch:rule context="tei:*[@calendar]">
-            <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-            systems or calendars to which the date represented by the content of this element belongs,
-            but this <sch:name/> element has no textual content.</sch:assert>
-          </sch:rule>
-        </constraint>
-      </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <listEvent>

--- a/P5/Source/Specs/faith.xml
+++ b/P5/Source/Specs/faith.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="faith">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="faith">
   <gloss xml:lang="en" versionDate="2008-12-09">faith</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">religion</gloss>
   <desc versionDate="2006-06-21" xml:lang="en">specifies the faith, religion, or belief set of a person.</desc>
@@ -22,40 +23,7 @@
     <macroRef key="macro.phraseSeq"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-faith">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="type" usage="opt" mode="change">
+    <attDef ident="type" usage="opt" mode="change">
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>

--- a/P5/Source/Specs/floruit.xml
+++ b/P5/Source/Specs/floruit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="floruit">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="floruit">
   <gloss xml:lang="en" versionDate="2008-12-09">floruit</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">période d'activité</gloss>
   <desc versionDate="2006-06-21" xml:lang="en">contains information about a person's period of activity.</desc>
@@ -20,39 +21,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-floruit">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="und">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#UND">
       <floruit notBefore="1066" notAfter="1100"/>

--- a/P5/Source/Specs/funder.xml
+++ b/P5/Source/Specs/funder.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="funder">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="funder">
   <gloss versionDate="2007-07-04" xml:lang="en">funding body</gloss>
   <gloss versionDate="2009-01-05" xml:lang="fr">financeur</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">재정 지원 조직체</gloss>
@@ -8,19 +9,14 @@
   <gloss versionDate="2016-11-17" xml:lang="de">Geldgeber</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">responsable de la financiación</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">finanziatore</gloss>
-  <desc versionDate="2005-01-14" xml:lang="en">specifies the name of an individual, institution, or organization responsible for the
-    funding of a project or text.</desc>
-  <desc versionDate="2009-01-05" xml:lang="fr">désigne le nom d’une personne ou d’un organisme
-    responsable du financement d’un projet ou d’un texte.</desc>
+  <desc versionDate="2005-01-14" xml:lang="en">specifies the name of an individual, institution, or organization responsible for the funding of a project or text.</desc>
+  <desc versionDate="2009-01-05" xml:lang="fr">désigne le nom d’une personne ou d’un organisme responsable du financement d’un projet ou d’un texte.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">프로젝트 또는 텍스트의 재정 지원 책임을 지는 개인, 기관, 조직의 이름을 명시한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">標明負責資助一項計畫或文件製作的個人、機構或組織名稱。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">テキストやプロジェクトの資金提供に責任を持つ個人、団体、組織の名前を 示す。</desc>
-    <desc versionDate="2016-11-17" xml:lang="de">gibt den Namen einer Einzelperson, Institution oder Organisation an, die für die 
-        Finanzierung eines Projekts oder Textes verantwortlich ist.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">proporciona el nombre del individuo, la institución o la
-    organización responsable de la financiación de un proyecto o de un texto.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">indica il nome di un individuo, istituzione o
-    organizzazione responsabile del finanziamento di un progetto o testo.</desc>
+  <desc versionDate="2016-11-17" xml:lang="de">gibt den Namen einer Einzelperson, Institution oder Organisation an, die für die Finanzierung eines Projekts oder Textes verantwortlich ist.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">proporciona el nombre del individuo, la institución o la organización responsable de la financiación de un proyecto o de un texto.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">indica il nome di un individuo, istituzione o organizzazione responsabile del finanziamento di un progetto o testo.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.canonical"/>
@@ -30,39 +26,6 @@
   <content>
     <macroRef key="macro.phraseSeq.limited"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-funder">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <funder>The National Endowment for the Humanities, an independent federal agency</funder>

--- a/P5/Source/Specs/gender.xml
+++ b/P5/Source/Specs/gender.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="gender">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="gender">
   <gloss xml:lang="en" versionDate="2022-05-03">gender</gloss>
   <desc versionDate="2022-05-17" xml:lang="en">specifies the gender identity of a person, persona, or character.</desc>
   <desc versionDate="2022-05-03" xml:lang="es">especifica la identidad de género de una persona.</desc>
@@ -17,40 +18,7 @@
     <macroRef key="macro.phraseSeq"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-gender">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="value" usage="opt">
+    <attDef ident="value" usage="opt">
       <desc versionDate="2022-05-03" xml:lang="en">supplies a coded value for gender identity</desc>
       <datatype minOccurs="1" maxOccurs="unbounded"><dataRef key="teidata.gender"/></datatype>
       <remarks versionDate="2022-08-27" xml:lang="en">

--- a/P5/Source/Specs/geogFeat.xml
+++ b/P5/Source/Specs/geogFeat.xml
@@ -1,21 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="geogFeat">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="geogFeat">
   <gloss versionDate="2007-06-15" xml:lang="en">geographical feature name</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">지리적 특성명</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">nom de caractéristique géographique</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">nombre de un elemento geográfico.</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">nome di elemento geografico</gloss>
-  <desc versionDate="2008-01-27" xml:lang="en">contains a common noun identifying some geographical feature contained within a geographic
-        name, such as valley, mount, etc.</desc>
+  <desc versionDate="2008-01-27" xml:lang="en">contains a common noun identifying some geographical feature contained within a geographic name, such as valley, mount, etc.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">계곡 산 등과 같이 지리적명에 포함된 지리적 특성을 식별하는 일반명사를 포함한다.</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">地理上の名前、例えば、谷、山などに含まれている地物を特定する名前を示 す。</desc>
-  <desc versionDate="2008-12-09" xml:lang="fr">contient un nom commun identifiant une caractéristique
-        géographique contenue dans un nom de lieu, comme vallée, mont, etc.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene un nombre común que identifica elementos
-        geográficos incluidos en un nombre propio geográfico, como valle, monte, etc.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene un nome comune che identifica elementi
-        geografici inclusi in un nome proprio geografico, come valle, monte, ecc.</desc>
+  <desc versionDate="2008-12-09" xml:lang="fr">contient un nom commun identifiant une caractéristique géographique contenue dans un nom de lieu, comme vallée, mont, etc.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene un nombre común que identifica elementos geográficos incluidos en un nombre propio geográfico, como valle, monte, etc.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene un nome comune che identifica elementi geografici inclusi in un nome proprio geografico, come valle, monte, ecc.</desc>
   <classes>
     <memberOf key="att.datable"/>
     <memberOf key="att.editLike"/>
@@ -29,42 +26,9 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-geogFeat">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
-      <geogName> The <geogFeat>vale</geogFeat> of White Horse</geogName>
+      <geogName>The <geogFeat>vale</geogFeat> of White Horse</geogName>
     </egXML>
   </exemplum>
   <exemplum versionDate="2008-04-06" xml:lang="fr">

--- a/P5/Source/Specs/geogName.xml
+++ b/P5/Source/Specs/geogName.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="geogName">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="geogName">
   <gloss versionDate="2005-01-14" xml:lang="en">geographical name</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">지리명</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">地理名稱</gloss>
@@ -26,39 +27,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-geogName">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <geogName>

--- a/P5/Source/Specs/idno.xml
+++ b/P5/Source/Specs/idno.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="idno">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="idno">
   <gloss versionDate="2010-04-30" xml:lang="en">identifier</gloss>
   <gloss versionDate="2009-01-05" xml:lang="fr">identifiant</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">식별 숫자</gloss>
@@ -8,24 +9,14 @@
   <gloss versionDate="2016-11-17" xml:lang="de">Identifikator</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">número identificativo</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">numero identificatore</gloss>
-  <desc versionDate="2010-04-30" xml:lang="en">supplies any form of identifier used to identify some
-    object, such as a bibliographic item, a person, a title, an organization, etc. in a standardized
-    way.</desc>
-  <desc versionDate="2021-02-15" xml:lang="fr">donne un identifiant standardisé qui peut être
-    utilisé pour identifier une référence bibliographique, une personne, un titre d'ouvrage ou une
-    organisation.</desc>
+  <desc versionDate="2010-04-30" xml:lang="en">supplies any form of identifier used to identify some object, such as a bibliographic item, a person, a title, an organization, etc. in a standardized way.</desc>
+  <desc versionDate="2021-02-15" xml:lang="fr">donne un identifiant standardisé qui peut être utilisé pour identifier une référence bibliographique, une personne, un titre d'ouvrage ou une organisation.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">서지 정보 항목을 식별하기 위해 사용되는 표준 또는 비표준 숫자를 제시한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">提供任何用來識別書目項目的標準或非標準編碼。</desc>
   <desc versionDate="2021-02-15" xml:lang="ja">書誌項目、人物、タイトル、組織など、何らかのオブジェクトを標準化された方法で識別するために使用される任意の形式の識別子を提供する。</desc>
-  <desc versionDate="2016-11-17" xml:lang="de">enthält einen frei wählbaren Identifikator, der ein
-    beliebiges Objekt, z. B. eine bibliografische Einheit, eine Person, einen Titel, eine
-    Organisation, in standardisierter Weise identifiziert.</desc>
-  <desc versionDate="2021-02-15" xml:lang="es">proporciona un identificador estándar para un
-    objecto; se usa parla la identificación de, por ejemplo, un elemento bibliográfico, una persona,
-    un título o una organización.</desc>
-  <desc versionDate="2020-10-25" xml:lang="it">fornisce un identificatore, standard o meno, usato
-    per identificare un oggetto, come per esempio un'unità bibliografica, una persona, un titolo,
-    un'organizzazione, ecc.</desc>
+  <desc versionDate="2016-11-17" xml:lang="de">enthält einen frei wählbaren Identifikator, der ein beliebiges Objekt, z. B. eine bibliografische Einheit, eine Person, einen Titel, eine Organisation, in standardisierter Weise identifiziert.</desc>
+  <desc versionDate="2021-02-15" xml:lang="es">proporciona un identificador estándar para un objecto; se usa parla la identificación de, por ejemplo, un elemento bibliográfico, una persona, un título o una organización.</desc>
+  <desc versionDate="2020-10-25" xml:lang="it">fornisce un identificatore, standard o meno, usato per identificare un oggetto, come per esempio un'unità bibliografica, una persona, un titolo, un'organizzazione, ecc.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.sortable"/>
@@ -38,62 +29,22 @@
     <memberOf key="att.cmc"/>
   </classes>
   <content>
-
     <alternate minOccurs="0" maxOccurs="unbounded">
       <textNode/>
       <classRef key="model.gLike"/>
       <elementRef key="idno"/>
     </alternate>
-
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-idno">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="type" usage="opt" mode="change">
-      <desc versionDate="2010-04-30" xml:lang="en">categorizes the identifier, for example as an
-        ISBN, Social Security number, etc.</desc>
-      <desc versionDate="2009-01-05" xml:lang="fr">classe un numéro dans une catégorie, par exemple
-        comme étant un numéro ISBN ou comme appartenant une autre série normalisée.</desc>
+    <attDef ident="type" usage="opt" mode="change">
+      <desc versionDate="2010-04-30" xml:lang="en">categorizes the identifier, for example as an ISBN, Social Security number, etc.</desc>
+      <desc versionDate="2009-01-05" xml:lang="fr">classe un numéro dans une catégorie, par exemple comme étant un numéro ISBN ou comme appartenant une autre série normalisée.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">예를 들어 ISBN 또는 기타 표준 일련번호로, 숫자를 범주화한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">表明編碼的種類，例如國際標準書號 (ISBN) 或其他標準系列編碼。</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">当該数値の分類を示す。例えば、ISBNなど。</desc>
-      <desc versionDate="2016-11-17" xml:lang="de">bestimmt die Art des Identifikators (z. B. ISBN,
-        Sozialversicherungsnummer, URI)</desc>
-      <desc versionDate="2007-05-04" xml:lang="es">clasifica el número, por ejemplo como un ISBN o
-        cualquier otro número estándard.</desc>
-      <desc versionDate="2007-01-21" xml:lang="it">classifica l'identificatore, ad esempio come
-        codice ISBN o altri generi di identificatori standard.</desc>
+      <desc versionDate="2016-11-17" xml:lang="de">bestimmt die Art des Identifikators (z. B. ISBN, Sozialversicherungsnummer, URI)</desc>
+      <desc versionDate="2007-05-04" xml:lang="es">clasifica el número, por ejemplo como un ISBN o cualquier otro número estándard.</desc>
+      <desc versionDate="2007-01-21" xml:lang="it">classifica l'identificatore, ad esempio come codice ISBN o altri generi di identificatori standard.</desc>
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>

--- a/P5/Source/Specs/langKnowledge.xml
+++ b/P5/Source/Specs/langKnowledge.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="langKnowledge">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="langKnowledge">
   <gloss versionDate="2007-07-04" xml:lang="en">language knowledge</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">언어 지식</gloss>
   <gloss versionDate="2008-04-06" xml:lang="es">conocimiento del lenguaje</gloss>
@@ -10,12 +11,9 @@
   <desc versionDate="2007-12-20" xml:lang="ko">산문체 또는 <gi>langKnown</gi> 요소 목록으로 개인의 언어 지식 상태를 요약한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含個人的語言認知狀態，可用敘述的方式或元素<gi>langKnown</gi>的條列形式來表達。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">個人の言語学的知識を散文または要素<gi>langKnown</gi>のリストでまとめ る。</desc>
-  <desc versionDate="2009-03-19" xml:lang="fr">synthétise l'état des connaissances linguistiques d'une personne, soit en texte libre soit par une liste
-        d'éléments <gi>langKnown</gi>.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">resume los conocimientos lingüísticos de una persona de forma descriptiva o a través de una lista de
-        elementos <gi>langKnown</gi></desc>
-  <desc versionDate="2007-01-21" xml:lang="it">riassume la conoscenza linguistica di una persona in forma descrittiva o tramite una lista di elementi
-            <gi>langKnown</gi></desc>
+  <desc versionDate="2009-03-19" xml:lang="fr">synthétise l'état des connaissances linguistiques d'une personne, soit en texte libre soit par une liste d'éléments <gi>langKnown</gi>.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">resume los conocimientos lingüísticos de una persona de forma descriptiva o a través de una lista de elementos <gi>langKnown</gi></desc>
+  <desc versionDate="2007-01-21" xml:lang="it">riassume la conoscenza linguistica di una persona in forma descrittiva o tramite una lista di elementi <gi>langKnown</gi></desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.persStateLike"/>
@@ -24,49 +22,16 @@
     <memberOf key="att.typed"/>
   </classes>
   <content>
-     <sequence>        
-       <elementRef key="precision" minOccurs="0" maxOccurs="unbounded"/>
-       <alternate>
-	 <classRef key="model.pLike"/>
-	 <elementRef key="langKnown" minOccurs="1" maxOccurs="unbounded"/>
-       </alternate>
-     </sequence>
+    <sequence>        
+      <elementRef key="precision" minOccurs="0" maxOccurs="unbounded"/>
+      <alternate>
+	<classRef key="model.pLike"/>
+	<elementRef key="langKnown" minOccurs="1" maxOccurs="unbounded"/>
+      </alternate>
+    </sequence>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-langKnowledge">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="type" usage="opt" mode="change">
+    <attDef ident="type" usage="opt" mode="change">
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>

--- a/P5/Source/Specs/langKnown.xml
+++ b/P5/Source/Specs/langKnown.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="langKnown">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="langKnown">
   <gloss versionDate="2007-07-04" xml:lang="en">language known</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">언어 능력</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">語言能力</gloss>
@@ -23,40 +24,7 @@
     <macroRef key="macro.phraseSeq.limited"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-langKnown">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="tag" usage="req">
+    <attDef ident="tag" usage="req">
       <desc versionDate="2006-06-21" xml:lang="en">supplies a valid language tag for the language concerned.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">관련 언어에 대한 유효한 언어 태그를 제공한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">用有效的語言標籤來表示所指語言。</desc>

--- a/P5/Source/Specs/licence.xml
+++ b/P5/Source/Specs/licence.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="licence">
-  <desc versionDate="2011-04-25" xml:lang="en">contains information about a licence or other legal agreement
-  applicable to the text.</desc>
-  <desc xml:lang="fr" versionDate="2013-02-27">contient des informations
-légales applicables au texte, notamment le contrat de licence
-définissant les droits d'utilisation.</desc>
-    <desc xml:lang="de" versionDate="2016-11-17">beinhaltet für den Text gültige Lizenzinformationen oder andere rechtswirksame Vereinbarungen.</desc>
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="licence">
+  <desc versionDate="2011-04-25" xml:lang="en">contains information about a licence or other legal agreement applicable to the text.</desc>
+  <desc xml:lang="fr" versionDate="2013-02-27">contient des informations légales applicables au texte, notamment le contrat de licence définissant les droits d'utilisation.</desc>
+  <desc xml:lang="de" versionDate="2016-11-17">beinhaltet für den Text gültige Lizenzinformationen oder andere rechtswirksame Vereinbarungen.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.pointing"/>
@@ -16,39 +14,6 @@ définissant les droits d'utilisation.</desc>
   <content>
     <macroRef key="macro.specialPara"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-licence">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <licence target="http://www.nzetc.org/tm/scholarly/tei-NZETC-Help.html#licensing">

--- a/P5/Source/Specs/location.xml
+++ b/P5/Source/Specs/location.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="location" module="namesdates">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="location" module="namesdates">
   <gloss xml:lang="en" versionDate="2008-12-09">location</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">localisation</gloss>
-  <desc versionDate="2012-02-14" xml:lang="en">defines the location of a place as a set of geographical coordinates, in terms of other named geo-political entities, or as an
-        address.</desc>
+  <desc versionDate="2012-02-14" xml:lang="en">defines the location of a place as a set of geographical coordinates, in terms of other named geo-political entities, or as an address.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">다른 이름의 지리-정치적 개체를 통하여 지리적 좌표의 집합으로, 또는 주소로 장소의 위치를 정의한다.</desc>
-  <desc versionDate="2008-04-06" xml:lang="es">define la localización de un lugar como conjunto de coordenadas geográficas, en términos de alguna
-        entidades geopolítica dada, o como dirección.</desc>
+  <desc versionDate="2008-04-06" xml:lang="es">define la localización de un lugar como conjunto de coordenadas geográficas, en términos de alguna entidades geopolítica dada, o como dirección.</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">地理上の座標集合、地政学上の名前付き実体、アドレスなどにより場所を定 義する。</desc>
-  <desc versionDate="2008-12-09" xml:lang="fr">définit l'emplacement d'un lieu par des coordonnées géographiques, en termes d'entités nommées dites
-        géopolitiques, ou par une adresse.</desc>
-  <desc versionDate="2007-11-06" xml:lang="it">definisce la posizione di un luogo tramite una serie di coordinate geografiche, in termini di entità
-        geopolitiche definite da altri o sotto forma di indirizzo</desc>
+  <desc versionDate="2008-12-09" xml:lang="fr">définit l'emplacement d'un lieu par des coordonnées géographiques, en termes d'entités nommées dites géopolitiques, ou par une adresse.</desc>
+  <desc versionDate="2007-11-06" xml:lang="it">definisce la posizione di un luogo tramite una serie di coordinate geografiche, in termini di entità geopolitiche definite da altri o sotto forma di indirizzo</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.typed"/>
@@ -22,52 +19,17 @@
     <memberOf key="att.cmc"/>
   </classes>
   <content>
-    
-      <alternate minOccurs="0" maxOccurs="unbounded">
-        <elementRef key="precision"/>
-        <classRef key="model.labelLike"/>
-        <classRef key="model.placeNamePart"/>
-        <classRef key="model.offsetLike"/>
-        <classRef key="model.measureLike"/>
-        <classRef key="model.addressLike"/>
-        <classRef key="model.noteLike"/>
-        <classRef key="model.biblLike"/>
-      </alternate>
-    
+    <alternate minOccurs="0" maxOccurs="unbounded">
+      <elementRef key="precision"/>
+      <classRef key="model.labelLike"/>
+      <classRef key="model.placeNamePart"/>
+      <classRef key="model.offsetLike"/>
+      <classRef key="model.measureLike"/>
+      <classRef key="model.addressLike"/>
+      <classRef key="model.noteLike"/>
+      <classRef key="model.biblLike"/>
+    </alternate>    
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-location">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <place>

--- a/P5/Source/Specs/meeting.xml
+++ b/P5/Source/Specs/meeting.xml
@@ -1,21 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="core" ident="meeting">
-  <desc versionDate="2007-10-15" xml:lang="en">contains the formalized descriptive title for a meeting or conference, for use in a
-    bibliographic description for an item derived from such a meeting, or as a heading or preamble
-    to publications emanating from it.</desc>
-  <desc versionDate="2007-12-20" xml:lang="ko">회의에서 배포된 항목 또는 회의에서 산출된 출판물의 표제 및 서문에 대한 서지적 설명으로 사용된 경우
-    회의 또는 학술회의의 공식적 설명을 포함한다.</desc>
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="core" ident="meeting">
+  <desc versionDate="2007-10-15" xml:lang="en">contains the formalized descriptive title for a meeting or conference, for use in a bibliographic description for an item derived from such a meeting, or as a heading or preamble to publications emanating from it.</desc>
+  <desc versionDate="2007-12-20" xml:lang="ko">회의에서 배포된 항목 또는 회의에서 산출된 출판물의 표제 및 서문에 대한 서지적 설명으로 사용된 경우 회의 또는 학술회의의 공식적 설명을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">在書目參照當中，標記該書目項目來源的會議相關描述。</desc>
-  <desc versionDate="2008-04-05" xml:lang="ja">会議中の項目を書誌情報で記述する際や、発行物の見出しや序文に現れる、
-    会合や会議を表す、形式化された記述的タイトルを示す。</desc>
-  <desc versionDate="2009-01-06" xml:lang="fr">contient le titre descriptif formalisé d’une réunion ou
-    d’une conférence, employé dans une description bibliographique pour un article provenant d'une
-    telle réunion, ou comme le titre ou le préambule aux publications qui en émanent.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">en referencias bibliográficas, contiene una descripción
-    del encuentro o conferencia del que deriva el elemento bibliográfico.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">nei riferimenti biliografici, contiene una descrizione di
-    un incontro o convegno dal quale deriva l'unità bibliografica.</desc>
+  <desc versionDate="2008-04-05" xml:lang="ja">会議中の項目を書誌情報で記述する際や、発行物の見出しや序文に現れる、 会合や会議を表す、形式化された記述的タイトルを示す。</desc>
+  <desc versionDate="2009-01-06" xml:lang="fr">contient le titre descriptif formalisé d’une réunion ou d’une conférence, employé dans une description bibliographique pour un article provenant d'une telle réunion, ou comme le titre ou le préambule aux publications qui en émanent.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">en referencias bibliográficas, contiene una descripción del encuentro o conferencia del que deriva el elemento bibliográfico.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">nei riferimenti biliografici, contiene una descrizione di un incontro o convegno dal quale deriva l'unità bibliografica.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.datable"/>
@@ -27,39 +20,6 @@
   <content>
     <macroRef key="macro.limitedContent"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-meeting">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <div>

--- a/P5/Source/Specs/name.xml
+++ b/P5/Source/Specs/name.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="core" ident="name">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="core" ident="name">
   <gloss versionDate="2005-01-14" xml:lang="en">name, proper noun</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">이름, 고유명사</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">名稱，特定名稱</gloss>
@@ -29,39 +30,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-name">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="mul">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#NONE">
       <name type="person">Thomas Hoccleve</name>

--- a/P5/Source/Specs/nationality.xml
+++ b/P5/Source/Specs/nationality.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="nationality">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="nationality">
   <gloss xml:lang="en" versionDate="2009-03-19">nationality</gloss>
   <gloss versionDate="2009-03-19" xml:lang="fr">nationalité</gloss>
   <desc versionDate="2005-12-14" xml:lang="en">contains an informal description of a person's present or past nationality or citizenship.</desc>
-  <desc versionDate="2009-03-19" xml:lang="fr">contient une description non formalisée de la nationalité ou citoyenneté présente ou passée d'une
-        personne.</desc>
+  <desc versionDate="2009-03-19" xml:lang="fr">contient une description non formalisée de la nationalité ou citoyenneté présente ou passée d'une personne.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">개인의 현재 또는 과거의 국적 또는 시민권에 대한 비공식적 기술을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含一非正式的敘述，表示個人現在或過去擁有的國籍或公民身分。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">人物の国籍や市民権の形式的でない解説を示す。</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene una descripción informal de la nacionalidad o ciudadanía presente o pasada de una
-        persona.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene una descrizione informale della nazionalità o cittadinanza presente o passata di una
-        persona</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene una descripción informal de la nacionalidad o ciudadanía presente o pasada de una persona.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene una descrizione informale della nazionalità o cittadinanza presente o passata di una persona</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.persStateLike"/>
@@ -25,40 +23,7 @@
     <macroRef key="macro.phraseSeq"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-nationality">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="type" usage="opt" mode="change">
+    <attDef ident="type" usage="opt" mode="change">
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>

--- a/P5/Source/Specs/objectName.xml
+++ b/P5/Source/Specs/objectName.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="objectName">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="objectName">
   <gloss versionDate="2018-07-15" xml:lang="en">name of an object</gloss>
   <gloss versionDate="2019-01-22" xml:lang="de">Name eines Objekts</gloss>
   <desc versionDate="2018-07-15" xml:lang="en">contains a proper noun or noun phrase used to refer to an object.</desc>
@@ -17,40 +18,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-objectName">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
-  
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <p> 
@@ -62,6 +29,5 @@
   </exemplum>
   <listRef>
     <ptr target="#NDOBJN"/>
-  </listRef>
-  
+  </listRef>  
 </elementSpec>

--- a/P5/Source/Specs/occupation.xml
+++ b/P5/Source/Specs/occupation.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="occupation">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="occupation">
   <gloss xml:lang="en" versionDate="2008-12-09">occupation</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">activité</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">contains an informal description of a person's trade, profession or occupation.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">개인의 직업에 대한 비공식적 기술을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含非正式的敘述，表示個人所從事的行業或所屬的專業。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">人物の仕事や職業の、形式的でない説明を示す。</desc>
-  <desc versionDate="2009-03-19" xml:lang="fr">contient une description non formalisée de l'activité, de la profession ou de l'occupation d'une
-        personne.</desc>
+  <desc versionDate="2009-03-19" xml:lang="fr">contient une description non formalisée de l'activité, de la profession ou de l'occupation d'une personne.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">contiene una descripción informal de las actividades, la profesión o la ocupación de una persona.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">contiene una descrizione informale dell'attività, professione o occupazione di una persona</desc>
   <classes>
@@ -23,40 +23,7 @@
     <macroRef key="macro.specialPara"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-occupation">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="type" usage="opt" mode="change">
+    <attDef ident="type" usage="opt" mode="change">
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>

--- a/P5/Source/Specs/offset.xml
+++ b/P5/Source/Specs/offset.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="offset">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="offset">
   <gloss xml:lang="en" versionDate="2008-12-09">offset</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">distance relative</gloss>
-  <desc versionDate="2012-12-27" xml:lang="en">marks that part of a relative temporal or spatial expression which indicates the direction of the offset between the two place names, dates, or
-        times involved in the expression.</desc>
+  <desc versionDate="2012-12-27" xml:lang="en">marks that part of a relative temporal or spatial expression which indicates the direction of the offset between the two place names, dates, or times involved in the expression.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">표현에 포함된 두 장소명, 날짜, 또는 시간 사이의 차이 방향을 표시하는 상대적 시간 또는 공간 표현의 부분</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">在時間或空間差距的表示中，該部分指出兩個地名、日期、或時間之間差距的方向性。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">当該表現に含まれている2つの場所名、日付、時間のオフセットの方向を示 す、相対的な時空表現の部分を示す。</desc>
-  <desc versionDate="2009-03-19" xml:lang="fr">la partie d'une expression temporelle ou spatiale qui indique la distance et/ou la direction entre les
-        deux lieux, dates ou heures sur lesquels porte l'expression.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">la parte de una expresión temporal o espacial relativa que indica la dirección del desfase entre dos
-        nombres de lugar, fecha u horario al interno de la expresión.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">la parte di un'espressione temporale o spaziale relativa che indica la direzione dello sfasamento tra due
-        nomi di luogo, date o orari all'interno dell'espressione</desc>
+  <desc versionDate="2009-03-19" xml:lang="fr">la partie d'une expression temporelle ou spatiale qui indique la distance et/ou la direction entre les deux lieux, dates ou heures sur lesquels porte l'expression.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">la parte de una expresión temporal o espacial relativa que indica la dirección del desfase entre dos nombres de lugar, fecha u horario al interno de la expresión.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">la parte di un'espressione temporale o spaziale relativa che indica la direzione dello sfasamento tra due nomi di luogo, date o orari all'interno dell'espressione</desc>
   <classes>
     <memberOf key="att.datable"/>
     <memberOf key="att.editLike"/>
@@ -27,39 +24,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-offset">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <placeName key="NRPA1">

--- a/P5/Source/Specs/orgName.xml
+++ b/P5/Source/Specs/orgName.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="orgName">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="orgName">
   <gloss versionDate="2005-01-14" xml:lang="en">organization name</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">조직명</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">組織名稱</gloss>
@@ -26,39 +27,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-orgName">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">About a year back, a question of considerable interest was agitated in the <orgName key="PAS1" type="voluntary"><placeName key="PEN">Pennsyla.</placeName> Abolition Society</orgName> [...]</egXML>
   </exemplum>

--- a/P5/Source/Specs/origPlace.xml
+++ b/P5/Source/Specs/origPlace.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="ORIGPLACE" ident="origPlace">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="ORIGPLACE" ident="origPlace">
   <gloss versionDate="2007-07-04" xml:lang="en">origin place</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">생산 장소</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW"/>
   <gloss versionDate="2008-04-06" xml:lang="es">lugar de origen</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">lieu de création</gloss>
   <gloss versionDate="2007-11-06" xml:lang="it">luogo di origine</gloss>
-  <desc versionDate="2019-01-17" xml:lang="en" xml:id="origplace.desc">contains any form of place name, used to identify the
-place of origin for a manuscript, manuscript part, or other object.</desc>
+  <desc versionDate="2019-01-17" xml:lang="en" xml:id="origplace.desc">contains any form of place name, used to identify the place of origin for a manuscript, manuscript part, or other object.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">원고 또는 원고의 일부를 생산한 장소를 식별하는 장소 이름 형식을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含任何格式的地名，用以確認手稿或手稿部分的來源地點。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">手書き資料が生まれた場所を特定するための場所を示す。</desc>
-  <desc versionDate="2007-06-12" xml:lang="fr">contient un nom de lieu, dans une forme libre,
-      utilisé pour désigner l'endroit où a été produit un manuscrit ou une partie d'un
-    manuscrit.</desc>
+  <desc versionDate="2007-06-12" xml:lang="fr">contient un nom de lieu, dans une forme libre, utilisé pour désigner l'endroit où a été produit un manuscrit ou une partie d'un manuscrit.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">contiene cualquier tipo de nombre de lugar utilizado para indicar el lugar de origen de un manuscrito o de una de sus partes.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">contiene un qualsiasi nome di luogo utilizzato per indicare il luogo di origine di un manoscritto o di una sua parte</desc>
   <classes>
@@ -28,39 +26,6 @@ place of origin for a manuscript, manuscript part, or other object.</desc>
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-origPlace">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <origPlace>Birmingham</origPlace>

--- a/P5/Source/Specs/origin.xml
+++ b/P5/Source/Specs/origin.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="ORIGIN" ident="origin">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="ORIGIN" ident="origin">
   <gloss xml:lang="en" versionDate="2007-06-12">origin</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">origine</gloss>
-  <desc versionDate="2019-01-17" xml:lang="en" xml:id="origin.desc">contains any descriptive or other information
-concerning the origin of  a manuscript, manuscript part, or other object.</desc>
+  <desc versionDate="2019-01-17" xml:lang="en" xml:id="origin.desc">contains any descriptive or other information concerning the origin of  a manuscript, manuscript part, or other object.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">원고 또는 원고 일부의 기원에 관한 기술적 또는 그 외의 정보를 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含關於手稿或手稿部分的來源之任何描述性或其他資訊。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">手書き資料の出自に関する解説や情報を示す。</desc>
-  <desc versionDate="2007-06-12" xml:lang="fr">contient des informations sur l'origine du manuscrit
-      ou de la partie de manuscrit.</desc>
+  <desc versionDate="2007-06-12" xml:lang="fr">contient des informations sur l'origine du manuscrit ou de la partie de manuscrit.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">contiene informaciones relativas al orígen de un manuscrito o de una de sus partes.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">contiene informazioni relative all'origine di un manoscritto o di una sua parte</desc>
   <classes>
@@ -20,39 +19,6 @@ concerning the origin of  a manuscript, manuscript part, or other object.</desc>
   <content>
     <macroRef key="macro.specialPara"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-origin">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <origin notBefore="1802" notAfter="1845" evidence="internal" resp="#AMH">

--- a/P5/Source/Specs/persName.xml
+++ b/P5/Source/Specs/persName.xml
@@ -1,28 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="persName">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="persName">
   <gloss versionDate="2005-01-14" xml:lang="en">personal name</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">개인 이름</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">個人名稱</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">nom de personne</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">nombre propio de persona</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">nome proprio di persona</gloss>
-  <desc versionDate="2012-03-13" xml:lang="en">contains a proper noun or proper-noun phrase referring to a
-  person, possibly including one or more of
-  the person's forenames, surnames, honorifics, added names, etc.</desc>
-  <desc versionDate="2007-12-20" xml:lang="ko">개인의 이름, 성, 존칭어, 추가 명 등의 하나 또는 전부를 사용하여 개인을 지칭하는, 고유명사 또는
-    고유명사구를 포함한다.</desc>
+  <desc versionDate="2012-03-13" xml:lang="en">contains a proper noun or proper-noun phrase referring to a person, possibly including one or more of the person's forenames, surnames, honorifics, added names, etc.</desc>
+  <desc versionDate="2007-12-20" xml:lang="ko">개인의 이름, 성, 존칭어, 추가 명 등의 하나 또는 전부를 사용하여 개인을 지칭하는, 고유명사 또는 고유명사구를 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含一個人名，可能是任何或全部屬於該人物的名字、姓氏、敬稱、或附加名等。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">人物の固有名詞を示す。例えば、名、姓、敬称、追加名など。</desc>
-  <desc versionDate="2008-12-09" xml:lang="fr">contient un nom propre ou une expression nominale se
-    référant à une personne, pouvant inclure tout ou partie de ses prénoms, noms de famille, titres
-    honorifiques, noms ajoutés, etc.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene un nombre propio o un sintagma identificable
-    como un nombre propio, que se refiere a una persona y puede incluir cualquier o todos los
-    nombres de pila, apellidos, títulos honoríficos, o nombres añadidos de la persona en cuestión.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene un nome proprio o un sintagma identificabile
-    come nome proprio, che si riferisce a una persona e può includere qualsiasi o tutti i prenomi,
-    cognomi, titoli onorifici, o nomi aggiunti della persona in questione</desc>
+  <desc versionDate="2008-12-09" xml:lang="fr">contient un nom propre ou une expression nominale se référant à une personne, pouvant inclure tout ou partie de ses prénoms, noms de famille, titres honorifiques, noms ajoutés, etc.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene un nombre propio o un sintagma identificable como un nombre propio, que se refiere a una persona y puede incluir cualquier o todos los nombres de pila, apellidos, títulos honoríficos, o nombres añadidos de la persona en cuestión.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene un nome proprio o un sintagma identificabile come nome proprio, che si riferisce a una persona e può includere qualsiasi o tutti i prenomi, cognomi, titoli onorifici, o nomi aggiunti della persona in questione</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.persStateLike"/>
@@ -36,40 +28,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-persName">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
-
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <persName><forename>Edward</forename><forename>George</forename><surname type="linked">Bulwer-Lytton</surname>, <roleName>Baron Lytton of

--- a/P5/Source/Specs/persPronouns.xml
+++ b/P5/Source/Specs/persPronouns.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="persPronouns">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="persPronouns">
   <gloss versionDate="2020-12-10" xml:lang="en">personal pronouns</gloss>
   <desc versionDate="2020-12-10" xml:lang="en">indicates the personal pronouns used, or assumed to be used, by the individual being described.</desc>
   <classes>
@@ -16,40 +17,7 @@
     <macroRef key="macro.phraseSeq"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-persPronouns">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="instant" mode="delete"/>
+    <attDef ident="instant" mode="delete"/>
     <attDef ident="evidence" mode="replace" usage="rec">
       <gloss versionDate="2020-12-10" xml:lang="en">evidence</gloss>
       <desc versionDate="2020-12-10" xml:lang="en">indicates support

--- a/P5/Source/Specs/placeName.xml
+++ b/P5/Source/Specs/placeName.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="placeName">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="placeName">
   <gloss xml:lang="en" versionDate="2020-12-20">place name</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">nom de lieu</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">contains an absolute or relative place name.</desc>
@@ -23,39 +24,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-placeName">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <placeName>

--- a/P5/Source/Specs/population.xml
+++ b/P5/Source/Specs/population.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="population" module="namesdates">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="population" module="namesdates">
   <gloss xml:lang="en" versionDate="2008-12-09">population</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">population</gloss>
   <desc versionDate="2007-10-18" xml:lang="en">contains information about the population of a place.</desc>
@@ -8,8 +9,7 @@
   <desc versionDate="2007-12-20" xml:lang="ko">장소의 인구에 관한 정보를 포함한다.</desc>
   <desc versionDate="2008-04-06" xml:lang="es">contiene la información sobre la población de un lugar.</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">ある場所の人口に関する情報を示す。</desc>
-  <desc versionDate="2007-11-06" xml:lang="it">contiene informazioni relative alla popolazione di un
-    dato luogo</desc>
+  <desc versionDate="2007-11-06" xml:lang="it">contiene informazioni relative alla popolazione di un dato luogo</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.datable"/>
@@ -37,39 +37,6 @@
       <elementRef key="population" minOccurs="0" maxOccurs="unbounded"/>
     </sequence>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-population">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
    <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <population when="2001-04" resp="#UKCensus">

--- a/P5/Source/Specs/precision.xml
+++ b/P5/Source/Specs/precision.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="certainty" ident="precision">
-  <desc versionDate="2009-06-05" xml:lang="en">indicates the numerical accuracy or precision  associated
-  with some aspect of the text markup.</desc>
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="certainty" ident="precision">
+  <desc versionDate="2009-06-05" xml:lang="en">indicates the numerical accuracy or precision  associated with some aspect of the text markup.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.global.meta"/>
@@ -12,48 +12,13 @@
     <memberOf key="att.datable"/>
   </classes>
   <content>
-    
-      <alternate minOccurs="0" maxOccurs="unbounded">
-        <classRef key="model.descLike"/>
-        <classRef key="model.certLike"/>
-      </alternate>
-    
+    <alternate minOccurs="0" maxOccurs="unbounded">
+      <classRef key="model.descLike"/>
+      <classRef key="model.certLike"/>
+    </alternate>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-precision">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="precision">
+    <attDef ident="precision">
       <desc versionDate="2011-04-13" xml:lang="en">characterizes the precision of the element or attribute pointed 
         to by the <gi>precision</gi> element.</desc>
       <datatype><dataRef key="teidata.certainty"/></datatype>

--- a/P5/Source/Specs/principal.xml
+++ b/P5/Source/Specs/principal.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="principal">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="principal">
   <gloss versionDate="2005-01-14" xml:lang="en">principal researcher</gloss>
   <gloss versionDate="2009-01-05" xml:lang="fr">chercheur principal</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">책임 연구자</gloss>
@@ -14,8 +15,7 @@ creation of an electronic text.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">전자 텍스트 생성에 대한 책임을 지는 책임 연구자의 이름을 제시한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">提供負責電子文件製作的主導研究者的姓名。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">電子テキストの生成に責任のある中心的な研究者の名前を示す。</desc>
-    <desc versionDate="2016-11-17" xml:lang="de">gibt den Namen des Projektleiters an, der für die Erstellung eines 
-        elektronischen Textes verantwortlich ist.</desc>
+  <desc versionDate="2016-11-17" xml:lang="de">gibt den Namen des Projektleiters an, der für die Erstellung eines elektronischen Textes verantwortlich ist.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">proporciona el nombre del investigador principal de la creación de un texto electrónico.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">fornisce il nome del ricercatore principale responsabile della creazione di un documento elettronico.</desc>
   <classes>
@@ -27,39 +27,6 @@ creation of an electronic text.</desc>
   <content>
     <macroRef key="macro.phraseSeq.limited"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-principal">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <principal ref="http://viaf.org/viaf/105517912">Gary Taylor</principal>

--- a/P5/Source/Specs/provenance.xml
+++ b/P5/Source/Specs/provenance.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="PROVENANCE" ident="provenance">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="PROVENANCE" ident="provenance">
   <gloss xml:lang="en" versionDate="2007-06-12">provenance</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">provenance</gloss>
   <gloss versionDate="2023-08-08" xml:lang="de">Provenienz</gloss>
-  <desc versionDate="2019-01-17" xml:lang="en" xml:id="prov.desc">contains any descriptive or other information
-concerning a single identifiable episode during the history of a manuscript, manuscript part, or other object after its creation but before its acquisition.</desc>
+  <desc versionDate="2019-01-17" xml:lang="en" xml:id="prov.desc">contains any descriptive or other information concerning a single identifiable episode during the history of a manuscript, manuscript part, or other object after its creation but before its acquisition.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">생성된 후부터 획득되기 전까지 원고 또는 원고 일부의 이력에 대해 확인가능한 에피소드에 관련한 기술적 또는 기타 정보를 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含任何描述性或其他資訊，關於手稿或手稿部分的歷史中單一可確認的事件，發生在手稿產生之後、取得之前。</desc>
-  <desc versionDate="2008-04-05" xml:lang="ja">手書き資料を入手するまでの歴史に関する、特定可能なエピソードに関する
-  情報を示す。</desc>
-  <desc versionDate="2007-06-12" xml:lang="fr">contient des informations sur un épisode précis de
-      l'histoire du manuscrit ou de la partie du manuscrit, après sa création et avant son
-      acquisition</desc>
+  <desc versionDate="2008-04-05" xml:lang="ja">手書き資料を入手するまでの歴史に関する、特定可能なエピソードに関する 情報を示す。</desc>
+  <desc versionDate="2007-06-12" xml:lang="fr">contient des informations sur un épisode précis de l'histoire du manuscrit ou de la partie du manuscrit, après sa création et avant son acquisition</desc>
   <desc versionDate="2007-05-04" xml:lang="es">contiene descripciones o informaciones relativas a un único episodio identificable en la historia de un manuscrito o de una de sus partes que sea posterior al momento de su creación pero anterior al momento de su adquisición.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">contiene informazioni relative a un unico episodio rintracciabile nella storia di un manoscritto o di una sua parte che sia posteriore alla sua creazione ma anteriore rispetto alla sua acquisizione</desc>
   <classes>
@@ -23,39 +20,6 @@ concerning a single identifiable episode during the history of a manuscript, man
   <content>
     <macroRef key="macro.specialPara"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-provenance">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <provenance>Listed as the property of Lawrence Sterne in 1788.</provenance>

--- a/P5/Source/Specs/region.xml
+++ b/P5/Source/Specs/region.xml
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="region">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="region">
   <gloss xml:lang="en" versionDate="2008-12-09">region</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">région</gloss>
-  <desc versionDate="2006-01-22" xml:lang="en">contains the name of an administrative unit such as a state, province, or county, larger
-    than a settlement, but smaller than a country.</desc>
+  <desc versionDate="2006-01-22" xml:lang="en">contains the name of an administrative unit such as a state, province, or county, larger than a settlement, but smaller than a country.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">도보다는 작고 정착지보다는 큰 주, 성, 도와 같은 행정단위명을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含行政單位的名稱，例如州、省、或郡，範圍大於主政區，但小於國家。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">行政上の単位の名前を示す。例えば、地方、郡、居住地など。居住地よりも 広く、国家より狭い地域。</desc>
-  <desc versionDate="2009-01-05" xml:lang="fr">contient le nom d'une unité administrative comme un état,
-    une province ou un comté, plus grande qu'un lieu de peuplement, mais plus petite qu'un pays.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">&gt;contiene el nombre de una unidad administrativa,
-    como un estado, una región o una província, que sea mayor que un pequeño asentamiento, pero
-    menor a un país.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene il nome di un'unità amministrativa, come uno
-    stato o una provincia, che sia più ampia di un piccolo insediamento ma più piccola di un paese</desc>
+  <desc versionDate="2009-01-05" xml:lang="fr">contient le nom d'une unité administrative comme un état, une province ou un comté, plus grande qu'un lieu de peuplement, mais plus petite qu'un pays.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">&gt;contiene el nombre de una unidad administrativa, como un estado, una región o una província, que sea mayor que un pequeño asentamiento, pero menor a un país.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene il nome di un'unità amministrativa, come uno stato o una provincia, che sia più ampia di un piccolo insediamento ma più piccola di un paese</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.placeNamePart"/>
@@ -26,39 +22,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-region">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="mul">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <placeName>

--- a/P5/Source/Specs/relation.xml
+++ b/P5/Source/Specs/relation.xml
@@ -57,34 +57,7 @@
   <attList>
     <!-- removed local definition for @type since it is both vacuous
          and inconsistent with the text : see bug #680 -->
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-          <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-relation">
-          <constraint>
-            <sch:rule context="tei:*[@calendar]">
-              <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-              systems or calendars to which the date represented by the content of this element belongs,
-              but this <sch:name/> element has no textual content.</sch:assert>
-            </sch:rule>
-          </constraint>
-        </constraintSpec>
-      </attDef>
-      <attDef ident="name">
+    <attDef ident="name">
       <desc versionDate="2005-10-27" xml:lang="en">supplies a name for the kind of relationship of which this is an instance.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">이것이 실례인 관련성 종류에 대한 이름을 제공한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">提供該關係的確切名稱。</desc>

--- a/P5/Source/Specs/residence.xml
+++ b/P5/Source/Specs/residence.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="residence">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="residence">
   <gloss xml:lang="en" versionDate="2007-01-21">residence</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">거주</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">住所</gloss>
@@ -26,40 +27,7 @@
     <macroRef key="macro.phraseSeq"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-residence">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="type" usage="opt" mode="change">
+    <attDef ident="type" usage="opt" mode="change">
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>

--- a/P5/Source/Specs/resp.xml
+++ b/P5/Source/Specs/resp.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="core" ident="resp">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="core" ident="resp">
   <gloss versionDate="2007-07-04" xml:lang="en">responsibility</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">책임성</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW"/>
@@ -8,19 +9,14 @@
   <gloss versionDate="2007-06-12" xml:lang="fr">responsabilité</gloss>
   <gloss versionDate="2007-11-06" xml:lang="it">responsabilità</gloss>
   <gloss versionDate="2017-06-04" xml:lang="de">Verantwortlichkeit</gloss>
-  <desc versionDate="2011-11-16" xml:lang="en">contains a phrase describing the nature of a person's intellectual responsibility, or an organization's role 
-    in the production or distribution of a work.</desc>
+  <desc versionDate="2011-11-16" xml:lang="en">contains a phrase describing the nature of a person's intellectual responsibility, or an organization's role in the production or distribution of a work.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">개인의 지적 책임성에 관한 특성을 기술하는 구를 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含一個詞彙，來描述個人智慧責任的類型。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">人物の知的責任の性質を表す一節を示す。</desc>
-  <desc versionDate="2007-06-12" xml:lang="fr">contient une expression décrivant la nature de la
-    responsabilité intellectuelle d'une personne.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene un sintagma que describe la naturaleza de la
-    responsabilidad intelectual de una persona.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene una frase che descrive la natura della
-    responsabilità intellettuale di una persona.</desc>
-  <desc versionDate="2017-06-04" xml:lang="de">enthält eine Phrase, die die Art der intellektuellen Verantwortung einer Person oder die
-    Rolle einer Organisation bei der Herstellung oder Distribution eines Werkes beschreibt.</desc>
+  <desc versionDate="2007-06-12" xml:lang="fr">contient une expression décrivant la nature de la responsabilité intellectuelle d'une personne.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene un sintagma que describe la naturaleza de la responsabilidad intelectual de una persona.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene una frase che descrive la natura della responsabilità intellettuale di una persona.</desc>
+  <desc versionDate="2017-06-04" xml:lang="de">enthält eine Phrase, die die Art der intellektuellen Verantwortung einer Person oder die Rolle einer Organisation bei der Herstellung oder Distribution eines Werkes beschreibt.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.canonical"/>
@@ -29,39 +25,6 @@
   <content>
     <macroRef key="macro.phraseSeq.limited"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-resp">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <respStmt>

--- a/P5/Source/Specs/seal.xml
+++ b/P5/Source/Specs/seal.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="SEAL" ident="seal">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" xml:id="SEAL" ident="seal">
   <gloss xml:lang="en" versionDate="2007-06-12">seal</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">sceau</gloss>
   <desc versionDate="2018-07-17" xml:lang="en">contains a description of one seal or similar applied to the object described</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">원고에 적용된 봉인 또는 유사 부착물 기술을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">描述一個章印或其他附於手稿的類似項目</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">手書き資料にあるシールや付着物を示す。</desc>
-  <desc versionDate="2007-06-12" xml:lang="fr">contient la description d'un sceau ou d'un objet
-      similaire, attaché au manuscrit.</desc>
+  <desc versionDate="2007-06-12" xml:lang="fr">contient la description d'un sceau ou d'un objet similaire, attaché au manuscrit.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">contiene la descripción de un sello o de un elemento externo aplicado a un manuscrito.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">contiene la descrizione di un sigillo o altro oggetto applicato al manoscritto</desc>
   <classes>
@@ -17,48 +17,13 @@
     <memberOf key="att.datable"/>
   </classes>
   <content>
-    
-      <alternate minOccurs="1" maxOccurs="unbounded">
-        <classRef key="model.pLike"/>
-        <elementRef key="decoNote"/>
-      </alternate>
-    
+    <alternate minOccurs="1" maxOccurs="unbounded">
+      <classRef key="model.pLike"/>
+      <elementRef key="decoNote"/>
+    </alternate>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-seal">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="contemporary">
+    <attDef ident="contemporary">
       <gloss xml:lang="en" versionDate="2007-06-12">contemporary</gloss>
       <gloss versionDate="2007-06-12" xml:lang="fr">contemporain</gloss>
       <desc versionDate="2005-01-14" xml:lang="en">specifies whether or not the seal is contemporary with the

--- a/P5/Source/Specs/settlement.xml
+++ b/P5/Source/Specs/settlement.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="settlement">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="settlement">
   <gloss xml:lang="en" versionDate="2008-12-09">settlement</gloss>
   <gloss versionDate="2008-12-09" xml:lang="fr">lieu de peuplement</gloss>
   <desc versionDate="2006-01-22" xml:lang="en">contains the name of a settlement such as a city, town, or village identified as a single geo-political or administrative unit.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">하나의 지리-정치 또는 행정 단위로 식별되는 시, 읍, 마을과 같이 거주지명을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含主行政區的名稱，例如城市、鄉鎮、村莊等單一地理政治或行政單位。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">地政学上または行政上の単位としてある市、街、村などの居住地の名前を示 す。</desc>
-  <desc versionDate="2009-03-19" xml:lang="fr">contient le nom d'un lieu de peuplement comme une cité, une ville ou un village, identifié comme une
-        unité géo-politique ou administrative unique.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene el nombre de un asentamiento, del tipo ciudad, pueblo, villa etc. identificado como una unidad
-        geopolítica o administrativa.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene il nome di un insediamento quale una città o un comune considerati come unità geopolitica o
-        amministrativa</desc>
+  <desc versionDate="2009-03-19" xml:lang="fr">contient le nom d'un lieu de peuplement comme une cité, une ville ou un village, identifié comme une unité géo-politique ou administrative unique.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene el nombre de un asentamiento, del tipo ciudad, pueblo, villa etc. identificado como una unidad geopolítica o administrativa.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene il nome di un insediamento quale una città o un comune considerati come unità geopolitica o amministrativa</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="model.placeNamePart"/>
@@ -24,39 +22,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-settlement">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <placeName>

--- a/P5/Source/Specs/sex.xml
+++ b/P5/Source/Specs/sex.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="sex">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="sex">
   <gloss xml:lang="en" versionDate="2009-03-19">sex</gloss>
   <gloss versionDate="2009-03-19" xml:lang="fr">sexe</gloss>
   <desc versionDate="2022-05-10" xml:lang="en">specifies the sex of an organism.</desc>
@@ -21,40 +22,7 @@
     <macroRef key="macro.phraseSeq"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-sex">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="value" usage="opt">
+    <attDef ident="value" usage="opt">
       <desc versionDate="2012-10-07" xml:lang="en">supplies a coded value for sex</desc>
       <datatype minOccurs="1" maxOccurs="unbounded">
         <dataRef key="teidata.sex"/>

--- a/P5/Source/Specs/socecStatus.xml
+++ b/P5/Source/Specs/socecStatus.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="socecStatus">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="socecStatus">
   <gloss versionDate="2005-01-14" xml:lang="en">socio-economic status</gloss>
   <gloss versionDate="2009-01-05" xml:lang="fr">statut socio-économique</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">사회-경제적 지위</gloss>
@@ -26,40 +27,7 @@
     <macroRef key="macro.phraseSeq"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-socecStatus">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="scheme" usage="opt">
+    <attDef ident="scheme" usage="opt">
       <desc versionDate="2013-12-06" xml:lang="en">identifies the classification system or taxonomy in use, for example by pointing to a locally-defined <gi>taxonomy</gi> element or by supplying a URI for an externally-defined system.</desc>
       <desc versionDate="2009-03-19" xml:lang="fr">identifie le système de classification ou la taxinomie utilisés.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">사용 중인 분류 체계 또는 분류법을 식별한다.</desc>

--- a/P5/Source/Specs/sponsor.xml
+++ b/P5/Source/Specs/sponsor.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="sponsor">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="sponsor">
   <gloss xml:lang="en" versionDate="2007-06-12">sponsor</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">commanditaire</gloss>
   <gloss versionDate="2016-11-17" xml:lang="de">Förderer</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">specifies the name of a sponsoring organization or institution.</desc>
-  <desc versionDate="2009-01-05" xml:lang="fr">indique le nom d’une institution ou d’un organisme
-    partenaires.</desc>
+  <desc versionDate="2009-01-05" xml:lang="fr">indique le nom d’une institution ou d’un organisme partenaires.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">후원 조직 또는 기관의 이름을 명시한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">標明贊助的組織或機構名稱。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">支援を行う組織や団体の名前を示す。</desc>
     <desc versionDate="2016-11-17" xml:lang="de">gibt den Namen einer Organisation oder Institution an, die als Förderer auftritt.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">especifica el nombre de la organización o institución
-    responsable.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">indica il nome di un'organizzazione o istituzzione
-    finanziatrice.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">especifica el nombre de la organización o institución responsable.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">indica il nome di un'organizzazione o istituzzione finanziatrice.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.canonical"/>
@@ -24,39 +22,6 @@
   <content>
     <macroRef key="macro.phraseSeq.limited"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-sponsor">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <sponsor>Association for Computers and the Humanities</sponsor>

--- a/P5/Source/Specs/stamp.xml
+++ b/P5/Source/Specs/stamp.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" ident="stamp">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="msdescription" ident="stamp">
   <gloss xml:lang="en" versionDate="2007-06-12">stamp</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">cachet</gloss>
   <desc versionDate="2007-02-16" xml:lang="en">contains a word or phrase describing a stamp or similar device.</desc>
@@ -19,39 +20,6 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-stamp">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="mul">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <rubric>Apologyticu TTVLLIANI AC IGNORATIA IN XPO IHV<lb/>

--- a/P5/Source/Specs/state.xml
+++ b/P5/Source/Specs/state.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="state">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="state">
   <gloss xml:lang="en" versionDate="2009-03-19">state</gloss>
   <gloss versionDate="2009-03-19" xml:lang="fr">statut</gloss>
   <desc versionDate="2011-12-01" xml:lang="en">contains a description of some status or quality attributed to a person, place, or organization often at some specific time or for a specific date range.</desc>
-  <desc versionDate="2009-03-19" xml:lang="fr">contient la description d'un statut ou d'une qualité actuels attribués à une personne, un lieu ou une
-        organisation.</desc>
+  <desc versionDate="2009-03-19" xml:lang="fr">contient la description d'un statut ou d'une qualité actuels attribués à une personne, un lieu ou une organisation.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">개인, 장소, 또는 조직에 관련한 현재 지위 또는 특성 기술을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">標明分界方法所定義的權威參照標準裡其中ㄧ個組件。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">人物、場所、組織などの、現在の社会的状態や地位を示す。</desc>
-  <desc versionDate="2018-07-18" xml:lang="de">enthält eine Beschreibung eines Status oder einer Qualität, die einer Person, einem Ort oder einer Organisation 
-    oft zu einem bestimmten Zeitpunkt oder für einen bestimmten Zeitraum zugeordnet wird.</desc>
+  <desc versionDate="2018-07-18" xml:lang="de">enthält eine Beschreibung eines Status oder einer Qualität, die einer Person, einem Ort oder einer Organisation oft zu einem bestimmten Zeitpunkt oder für einen bestimmten Zeitraum zugeordnet wird.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">especifica un componente de una referencia canónica definida por el método milestone (hito).</desc>
   <desc versionDate="2007-01-21" xml:lang="it">specifica un componente di un riferimento canonico definito dal metodo milestone.</desc>
   <classes>
@@ -46,39 +45,6 @@
       </alternate>
     </sequence>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-state">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
         <state ref="#SCHOL" type="status">

--- a/P5/Source/Specs/terrain.xml
+++ b/P5/Source/Specs/terrain.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="terrain" module="namesdates">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="terrain" module="namesdates">
   <gloss xml:lang="en" versionDate="2009-03-19">terrain</gloss>
   <gloss versionDate="2009-03-19" xml:lang="fr">terrain</gloss>
   <desc versionDate="2007-10-18" xml:lang="en">contains information about the physical terrain of a place.</desc>
@@ -20,68 +21,19 @@
   </classes>
   <content>
     <sequence>
-      
-         <elementRef key="precision" minOccurs="0" maxOccurs="unbounded"/>
-      
-      
-        <classRef key="model.headLike" minOccurs="0" maxOccurs="unbounded"/>
-      
+      <elementRef key="precision" minOccurs="0" maxOccurs="unbounded"/>
+      <classRef key="model.headLike" minOccurs="0" maxOccurs="unbounded"/>
       <alternate>
-        
-          
-            <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>
-          
-        
-        
-          
-            <classRef key="model.labelLike" minOccurs="1" maxOccurs="unbounded"/>
-          
-        
+        <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>
+        <classRef key="model.labelLike" minOccurs="1" maxOccurs="unbounded"/>
+      </alternate>      
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.noteLike"/>
+        <classRef key="model.biblLike"/>
       </alternate>
-      
-        <alternate minOccurs="0" maxOccurs="unbounded">
-          <classRef key="model.noteLike"/>
-          <classRef key="model.biblLike"/>
-        </alternate>
-      
-      
-        <elementRef key="terrain" minOccurs="0" maxOccurs="unbounded"/>
-      
+      <elementRef key="terrain" minOccurs="0" maxOccurs="unbounded"/>      
     </sequence>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-terrain">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">
       <place xml:id="KERG">

--- a/P5/Source/Specs/title.xml
+++ b/P5/Source/Specs/title.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="core" ident="title">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="core" ident="title">
   <gloss xml:lang="en" versionDate="2007-06-12">title</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">titre</gloss>
   <gloss versionDate="2017-06-04" xml:lang="de">Titel</gloss>
   <desc versionDate="2008-10-25" xml:lang="en">contains a title for any kind of work.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">다양한 종류의 작업에 대한 전체 제목을 제공한다.</desc>
-  <desc versionDate="2007-05-02" xml:lang="zh-TW">包含任何種類作品的完整題名
-                    <!--,不論是文章、書籍、期刊或叢書，其他替代題名或副題名也包含在內-->。</desc>
+  <desc versionDate="2007-05-02" xml:lang="zh-TW">包含任何種類作品的完整題名 <!--,不論是文章、書籍、期刊或叢書，其他替代題名或副題名也包含在內-->。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">作品の完全なタイトルを示す。</desc>
   <desc versionDate="2007-06-12" xml:lang="fr">contient le titre complet d'une oeuvre quelconque</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene el título completo de una obra de
-                    cualquier tipo.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene el título completo de una obra de cualquier tipo.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">contiene il titolo completo di una qualsiaisi                    opera.</desc>
   <desc versionDate="2017-06-04" xml:lang="de">beinhaltet einen Titel eines beliebigen Werks.</desc>
   <classes>
@@ -27,60 +26,15 @@
     <macroRef key="macro.paraContent"/>
   </content>
   <attList>
-      <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-title">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-
-  
-      <attDef ident="level" usage="opt">
-      <desc versionDate="2005-03-05" xml:lang="en">indicates the bibliographic level for a title, that is, whether
-                                        it identifies an article, book, journal, series, or
-                                        unpublished material.</desc>
-      <desc versionDate="2007-12-20" xml:lang="ko">제목에 대한 서지적 층위를 나타내어, 논문, 책,
-                                        학술지, 총서, 미간행의 여부를 식별한다.</desc>
+    <attDef ident="level" usage="opt">
+      <desc versionDate="2005-03-05" xml:lang="en">indicates the bibliographic level for a title, that is, whether it identifies an article, book, journal, series, or unpublished material.</desc>
+      <desc versionDate="2007-12-20" xml:lang="ko">제목에 대한 서지적 층위를 나타내어, 논문, 책, 학술지, 총서, 미간행의 여부를 식별한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">指出題名的書目層次，即該題名之所指可以是文章、書籍、期刊、叢書或未出版的項目。</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">タイトルの書誌情報のレベルを示す。例えば、論文、書籍、雑誌、叢書、 非刊行物など。</desc>
-      <desc versionDate="2007-06-12" xml:lang="fr">indique le niveau
-                                        bibliographique d'un titre, c'est-à-dire si ce titre
-                                        identifie un article, un livre, une revue, une collection,
-                                        ou un document non publié</desc>
-      <desc versionDate="2007-05-04" xml:lang="es">indica el tipo bibliográfico
-                                        para un título, si este se identifica como un artículo,
-                                        libro, revista, colección o material inédito.</desc>
-      <desc versionDate="2007-01-21" xml:lang="it">indica il livello
-                                        bibliografico di un titolo, ovvero se indentifica un
-                                        articolo, un libro, una rivista, una collana, o materiale
-                                        non pubblicato.</desc>
-      <desc versionDate="2017-06-04" xml:lang="de">gibt den bibliografischen Typ eines Titels an, d.h. ob er einen Artikel, ein Buch, eine
-        Zeitschrift, eine Reihe oder unpubliziertes Material bezeichnet.</desc>
+      <desc versionDate="2007-06-12" xml:lang="fr">indique le niveau bibliographique d'un titre, c'est-à-dire si ce titre identifie un article, un livre, une revue, une collection, ou un document non publié</desc>
+      <desc versionDate="2007-05-04" xml:lang="es">indica el tipo bibliográfico para un título, si este se identifica como un artículo, libro, revista, colección o material inédito.</desc>
+      <desc versionDate="2007-01-21" xml:lang="it">indica il livello bibliografico di un titolo, ovvero se indentifica un articolo, un libro, una rivista, una collana, o materiale non pubblicato.</desc>
+      <desc versionDate="2017-06-04" xml:lang="de">gibt den bibliografischen Typ eines Titels an, d.h. ob er einen Artikel, ein Buch, eine Zeitschrift, eine Reihe oder unpubliziertes Material bezeichnet.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <valList type="closed">
         <valItem ident="a">
@@ -90,27 +44,14 @@
           <gloss versionDate="2007-11-06" xml:lang="it">analitico</gloss>
           <gloss versionDate="2007-05-04" xml:lang="es">analítico</gloss>
           <gloss versionDate="2017-06-04" xml:lang="de">unselbständig</gloss>
-          <desc versionDate="2013-04-29" xml:lang="en">the title applies to an analytic item, such as an
-	  article, poem, or other work published as part of a larger item.</desc>
-          <desc versionDate="2007-12-20" xml:lang="ko">분석적 제목(보다
-                                                  큰 항목의 일부로 출판된 논문, 시, 또는 기타 항목)</desc>
-          <desc versionDate="2007-05-02" xml:lang="zh-TW">分析層題名
-                                                  (文章、詩、或其他隸屬於一個較大作品的項目)</desc>
-          <desc versionDate="2008-04-06" xml:lang="es">título
-                                                  analítico (de artículo, de poema, o de
-                                                  otro elemento publicado como parte de un
-                                                  elemento más grande)</desc>
+          <desc versionDate="2013-04-29" xml:lang="en">the title applies to an analytic item, such as an article, poem, or other work published as part of a larger item.</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">분석적 제목(보다 큰 항목의 일부로 출판된 논문, 시, 또는 기타 항목)</desc>
+          <desc versionDate="2007-05-02" xml:lang="zh-TW">分析層題名 (文章、詩、或其他隸屬於一個較大作品的項目)</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">título analítico (de artículo, de poema, o de otro elemento publicado como parte de un elemento más grande)</desc>
           <desc versionDate="2008-04-05" xml:lang="ja">分析的タイトル(例えば、論文や詩など、大きめの刊行物の部分と なるもの)。</desc>
-          <desc versionDate="2008-03-30" xml:lang="fr">titre
-                                                  analytique (article, poème ou autre,
-                                                  publié comme partie d'un ensemble plus
-                                                  grand)</desc>
-          <desc versionDate="2007-01-21" xml:lang="it">titolo
-                                                  analitico (articolo, poesia o altra
-                                                  unità bibliografica pubblicata come
-                                                  parte di un'unità più grande)</desc>
-          <desc versionDate="2017-06-04" xml:lang="de">der Titel gehört zu einer unselbständigen Publikation, wie einem Artikel, Gedicht oder
-            einem anderen Werk, das als Teil einer umfangreicheren Einheit publiziert wurde.</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">titre analytique (article, poème ou autre, publié comme partie d'un ensemble plus grand)</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">titolo analitico (articolo, poesia o altra unità bibliografica pubblicata come parte di un'unità più grande)</desc>
+          <desc versionDate="2017-06-04" xml:lang="de">der Titel gehört zu einer unselbständigen Publikation, wie einem Artikel, Gedicht oder einem anderen Werk, das als Teil einer umfangreicheren Einheit publiziert wurde.</desc>
         </valItem>
         <valItem ident="m">
           <gloss versionDate="2007-07-04" xml:lang="en">monographic</gloss>
@@ -119,54 +60,29 @@
           <gloss versionDate="2007-11-06" xml:lang="it">monografico</gloss>
           <gloss versionDate="2007-05-04" xml:lang="es">monográfico</gloss>
           <gloss versionDate="2017-06-04" xml:lang="de">Monografie</gloss>
-          <desc versionDate="2013-04-29" xml:lang="en">the title applies to a monograph such as a book or
-          other item considered to be a distinct publication, including single
-          volumes of multi-volume works</desc>
-          <desc versionDate="2007-12-20" xml:lang="ko">단행본 제목(여러
-                                                  권 중 한 권으로 출판된 경우를 포함하여, 독립된 항목으로 출판된 책,
-                                                  모음집, 또는 기타 항목)</desc>
-          <desc versionDate="2007-05-02" xml:lang="zh-TW">專題層題名
-                                                  (書、選集、或其他獨立出版的項目，包含多冊作品的其中一冊)</desc>
-          <desc versionDate="2008-04-06" xml:lang="es">título
-                                                  monográfico (libro, colección, u otro
-                                                  elemento publicado como elemento
-                                                  distinto, incluído los volúmenes
-                                                  individuales de trabajos multivolúmenes)</desc>
-          <desc versionDate="2008-04-05" xml:lang="ja">単行物のタイトル(例えば、書籍や叢書など、複数の巻に別れる作
-                                                  品のうちのひとつや、独立してある出版物)。</desc>
-          <desc versionDate="2008-03-30" xml:lang="fr">titre de
-                                                  monographie (livre, ensemble ou autre,
-                                                  publié comme un document distinct, y
-                                                  compris les volumes isolés d'ouvrages en
-                                                  plusieurs volumes)</desc>
-          <desc versionDate="2007-01-21" xml:lang="it">titolo
-                                                  della monografia (libro, raccolta o
-                                                  altra unità bibliografica pubblicata
-                                                  indipendentemente, inculso il singolo
-                                                  volume di opere a più volumi)</desc>
-          <desc versionDate="2017-06-04" xml:lang="de">der Titel bezieht sich auf Monografien wie z.B. ein Bücher oder andere selbständige
-            Publikationen, also auch auf einzelne Bände in einem mehrbändigen Werk.</desc>
+          <desc versionDate="2013-04-29" xml:lang="en">the title applies to a monograph such as a book or other item considered to be a distinct publication, including single volumes of multi-volume works</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">단행본 제목(여러 권 중 한 권으로 출판된 경우를 포함하여, 독립된 항목으로 출판된 책, 모음집, 또는 기타 항목)</desc>
+          <desc versionDate="2007-05-02" xml:lang="zh-TW">專題層題名 (書、選集、或其他獨立出版的項目，包含多冊作品的其中一冊)</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">título monográfico (libro, colección, u otro elemento publicado como elemento distinto, incluído los volúmenes individuales de trabajos multivolúmenes)</desc>
+          <desc versionDate="2008-04-05" xml:lang="ja">単行物のタイトル(例えば、書籍や叢書など、複数の巻に別れる作 品のうちのひとつや、独立してある出版物)。</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">titre de monographie (livre, ensemble ou autre, publié comme un document distinct, y compris les volumes isolés d'ouvrages en plusieurs volumes)</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">titolo della monografia (libro, raccolta o altra unità bibliografica pubblicata indipendentemente, inculso il singolo volume di opere a più volumi)</desc>
+          <desc versionDate="2017-06-04" xml:lang="de">der Titel bezieht sich auf Monografien wie z.B. ein Bücher oder andere selbständige Publikationen, also auch auf einzelne Bände in einem mehrbändigen Werk.</desc>
         </valItem>
         <valItem ident="j">
           <gloss versionDate="2007-07-04" xml:lang="en">journal</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">학술지</gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">rivista</gloss>
-          <gloss versionDate="2007-05-04" xml:lang="es">título
-                                                  de revista.</gloss>
+          <gloss versionDate="2007-05-04" xml:lang="es">título de revista.</gloss>
           <gloss versionDate="2017-06-04" xml:lang="de">Zeitschrift</gloss>
-          <desc versionDate="2013-04-29" xml:lang="en">the title applies to any serial or periodical
-	  publication such as a journal, magazine, or newspaper</desc>
+          <desc versionDate="2013-04-29" xml:lang="en">the title applies to any serial or periodical publication such as a journal, magazine, or newspaper</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">학술지 제목</desc>
           <desc versionDate="2007-05-02" xml:lang="zh-TW">期刊層題名</desc>
-          <desc versionDate="2008-04-06" xml:lang="es">título de
-                                                  diario, periódico o revista</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">título de diario, periódico o revista</desc>
           <desc versionDate="2008-04-05" xml:lang="ja">雑誌のタイトル。</desc>
-          <desc versionDate="2008-03-30" xml:lang="fr">titre de
-                                                  revue</desc>
-          <desc versionDate="2007-01-21" xml:lang="it">titolo di
-                                                  rivista</desc>
-          <desc versionDate="2017-06-04" xml:lang="de">der Titel bezieht sich auf jede Art fortlaufender oder periodischer Veröffentlichungen wie
-            z. B. Zeitschriften, Magazine oder Zeitungen.</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">titre de revue</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">titolo di rivista</desc>
+          <desc versionDate="2017-06-04" xml:lang="de">der Titel bezieht sich auf jede Art fortlaufender oder periodischer Veröffentlichungen wie z. B. Zeitschriften, Magazine oder Zeitungen.</desc>
         </valItem>
         <valItem ident="s">
           <gloss versionDate="2007-07-04" xml:lang="en">series</gloss>
@@ -175,43 +91,27 @@
           <gloss versionDate="2007-11-06" xml:lang="it">serie</gloss>
           <gloss versionDate="2007-05-04" xml:lang="es">series</gloss>
           <gloss versionDate="2017-06-04" xml:lang="de">Reihe</gloss>
-          <desc versionDate="2013-04-29" xml:lang="en">the title applies to a series of otherwise distinct
-	  publications such as a collection</desc>
+          <desc versionDate="2013-04-29" xml:lang="en">the title applies to a series of otherwise distinct publications such as a collection</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">연간물 제목</desc>
           <desc versionDate="2007-05-02" xml:lang="zh-TW">叢書層題名</desc>
-          <desc versionDate="2008-04-06" xml:lang="es">título de
-                                                  serie</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">título de serie</desc>
           <desc versionDate="2008-04-05" xml:lang="ja">叢書のタイトル。</desc>
-          <desc versionDate="2008-03-30" xml:lang="fr">titre de
-                                                  publication en série</desc>
-          <desc versionDate="2007-01-21" xml:lang="it">titolo di
-                                                  collana</desc>
-          <desc versionDate="2017-06-04" xml:lang="de">der Titel bezeichnet eine Reihe von ansonsten selbständig publizierten Veröffentlichungen,
-            wie z. B. eine Buchreihe.</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">titre de publication en série</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">titolo di collana</desc>
+          <desc versionDate="2017-06-04" xml:lang="de">der Titel bezeichnet eine Reihe von ansonsten selbständig publizierten Veröffentlichungen, wie z. B. eine Buchreihe.</desc>
         </valItem>
         <valItem ident="u">
           <gloss versionDate="2007-07-04" xml:lang="en">unpublished</gloss>
           <gloss versionDate="2017-06-04" xml:lang="de">unveröffentlicht</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">미간행</gloss>
-          <desc versionDate="2013-04-29" xml:lang="en">the title applies to any unpublished material (including
-                                                  theses and dissertations unless
-                                                  published by a commercial press)</desc>
+          <desc versionDate="2013-04-29" xml:lang="en">the title applies to any unpublished material (including theses and dissertations unless published by a commercial press)</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">미간행물(출판사에서 출판되지 않은 석박사 논문을 포함하여)의 제목</desc>
           <desc versionDate="2007-05-02" xml:lang="zh-TW">未出版的項目題名 (包括未經商業刊物發表的專題論文)</desc>
-          <desc versionDate="2008-04-06" xml:lang="es">título de
-                                                  un material inédito (incluidas tesis y
-                                                  disertaciones que no sean publicadas por
-                                                  una editorial comercial)</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">título de un material inédito (incluidas tesis y disertaciones que no sean publicadas por una editorial comercial)</desc>
           <desc versionDate="2008-04-05" xml:lang="ja">非刊行物のタイトル(未刊の学位論文など)。</desc>
-          <desc versionDate="2008-03-30" xml:lang="fr">titre de
-                                                  matéria non publié (thèses et
-                                                  dissertations comprises, à l'exception
-                                                  de leurs éditions commerciales)</desc>
-          <desc versionDate="2007-01-21" xml:lang="it">titolo di
-                                                  materiale non pubblicato (incluse tesi
-                                                  non pubblicate da case editrici)</desc>
-          <desc versionDate="2017-06-04" xml:lang="de">der Titel bezieht sich auf unveröffentliches Material (incl. universitäre
-            Qualifikationsarbeiten, soweit sie nicht von einem Verlag veröffentlicht worden sind).</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">titre de matéria non publié (thèses et dissertations comprises, à l'exception de leurs éditions commerciales)</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">titolo di materiale non pubblicato (incluse tesi non pubblicate da case editrici)</desc>
+          <desc versionDate="2017-06-04" xml:lang="de">der Titel bezieht sich auf unveröffentliches Material (incl. universitäre Qualifikationsarbeiten, soweit sie nicht von einem Verlag veröffentlicht worden sind).</desc>
         </valItem>
       </valList>
       <remarks versionDate="2009-05-23" xml:lang="en">
@@ -222,41 +122,38 @@
         element of level <q>s</q>. For this reason, the
         <att>level</att> attribute is not required in contexts where
         its value can be unambiguously inferred. Where it is supplied
-	in such contexts,
+        in such contexts,
         its value should not contradict the value implied by its
-	parent element. 
-	<!--, the <att>level</att>, if given, must
+        parent element. 
+        <!--, the <att>level</att>, if given, must
         be<q>a</q>; if it appears directly enclosed within a
         <gi>monogr</gi> element, <att>level</att> must be <q>m</q>,
         <q>j</q>, or <q>u</q>; when <gi>title</gi> is directly
         enclosed by ,<att>level</att> must be . If it appears within a
         <gi>msItem</gi>, the <att>level</att> attribute should not be
         supplied.-->
-	</p>
+        </p>
       </remarks>
       <remarks xml:lang="fr" versionDate="2007-06-12">
         <p>Si le titre apparaît comme fils de l'élément
-<gi>analytic</gi>, l'attribut <att>level</att>,
-s'il est renseigné, doit avoir la valeur <q>a</q>
-; si le titre apparaît comme fils de l'élément
-<gi>monogr</gi>, l'attribut
-<att>level</att> doit avoir la valeur <q>m</q>,
-<q>j</q> ou <q>u</q> ; si le titre
-apparaît comme fils de l'élément <gi>series</gi>,
-l'attribut <att>level</att> doit avoir la valeur
-<q>s</q>. Si le titre apparaît dans
-l'élément <gi>msItem</gi>, l'attribut level ne
-doit pas être utilisé.</p>
+        <gi>analytic</gi>, l'attribut <att>level</att>, s'il est
+        renseigné, doit avoir la valeur <q>a</q> ; si le titre
+        apparaît comme fils de l'élément <gi>monogr</gi>, l'attribut
+        <att>level</att> doit avoir la valeur <q>m</q>, <q>j</q> ou
+        <q>u</q> ; si le titre apparaît comme fils de l'élément
+        <gi>series</gi>, l'attribut <att>level</att> doit avoir la
+        valeur <q>s</q>. Si le titre apparaît dans l'élément
+        <gi>msItem</gi>, l'attribut level ne doit pas être
+        utilisé.</p>
       </remarks>
       <remarks xml:lang="ja" versionDate="2008-04-05">
         <p> タイトルが要素<gi>analytic</gi>中にある場合、属性
-<att>level</att>があれば、値は必ず<q>a</q>となる。
-タイトルが要素<gi>monogr</gi>中にある場合、属性
-          <att>level</att>の値は、必ず<q>m</q>、<q>j</q>、<q>u</q>のいず
-れかになる。要素<gi>title</gi>が要素<gi>series</gi>中にある場
-合、属性<att>level</att>の値は必ず<q>s</q>となる。タイトルが要
-素<gi>msItem</gi>中にある場合、当該属性値は付与されない。
-                                        </p>
+        <att>level</att>があれば、値は必ず<q>a</q>となる。タイトルが要
+        素<gi>monogr</gi>中にある場合、属性<att>level</att>の値は、必
+        ず<q>m</q>、<q>j</q>、<q>u</q>のいずれかになる。要素
+        <gi>title</gi>が要素<gi>series</gi>中にある場合、属性
+        <att>level</att>の値は必ず<q>s</q>となる。タイトルが要素
+        <gi>msItem</gi>中にある場合、当該属性値は付与されない。</p>
       </remarks>
       <remarks versionDate="2017-06-04" xml:lang="de">
         <p>Der Typ eines Titels wird manchmal durch seinen Kontext bestimmt: wenn ein Titel z. B.
@@ -273,12 +170,9 @@ doit pas être utilisé.</p>
       <desc versionDate="2007-12-20" xml:lang="ko">어떤 편의적 유형에 따른 제목 분류</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">用合適的分類方法將題名分類。</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">当該タイトルを分類する。</desc>
-      <desc versionDate="2007-06-12" xml:lang="fr">caractérise le titre selon
-                                        une typologie adaptée.</desc>
-      <desc versionDate="2007-05-04" xml:lang="es">clasifica el título de
-                                        acuerdo con alguna tipología funcional.</desc>
-      <desc versionDate="2007-01-21" xml:lang="it">classifica il titolo seguendo
-                                        una tipologia conveniente.</desc>
+      <desc versionDate="2007-06-12" xml:lang="fr">caractérise le titre selon une typologie adaptée.</desc>
+      <desc versionDate="2007-05-04" xml:lang="es">clasifica el título de acuerdo con alguna tipología funcional.</desc>
+      <desc versionDate="2007-01-21" xml:lang="it">classifica il titolo seguendo una tipologia conveniente.</desc>
       <desc versionDate="2017-06-04" xml:lang="de">klassifiziert den Titel entsprechend einer geeigneten Typologie.</desc> 
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <valList type="open">
@@ -286,26 +180,21 @@ doit pas être utilisé.</p>
           <desc versionDate="2007-06-27" xml:lang="en">main title</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">(주)제목</desc>
           <desc versionDate="2007-05-02" xml:lang="zh-TW">主要題名</desc>
-          <desc versionDate="2008-04-06" xml:lang="es">título
-principal</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">título principal</desc>
           <desc versionDate="2008-04-05" xml:lang="ja">主タイトル。</desc>
-          <desc versionDate="2008-03-30" xml:lang="fr">titre
-principal</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">titre principal</desc>
           <desc versionDate="2007-01-21" xml:lang="it">titolo</desc>
           <desc versionDate="2017-06-04" xml:lang="de">Haupttitel</desc>
-          
         </valItem>
         <valItem ident="sub">
           <gloss versionDate="2007-07-04" xml:lang="en">subordinate</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">부</gloss>
-          <gloss versionDate="2007-06-12" xml:lang="fr">titre de
-niveau inférieur, titre de partie</gloss>
+          <gloss versionDate="2007-06-12" xml:lang="fr">titre de niveau inférieur, titre de partie</gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">subordinato</gloss>
           <gloss versionDate="2007-05-04" xml:lang="es">subtítulo, título de una parte</gloss>
           <gloss versionDate="2017-06-04" xml:lang="de">untergeordnet</gloss>
           <desc versionDate="2007-06-27" xml:lang="en">subtitle, title of part</desc>
-          <desc versionDate="2007-12-20" xml:lang="ko">부분의 제목인
-부제목</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">부분의 제목인 부제목</desc>
           <desc versionDate="2007-05-02" xml:lang="zh-TW">副題名、部分題名</desc>
           <desc versionDate="2008-04-06" xml:lang="es">subtítulo, título de una parte</desc>
           <desc versionDate="2008-04-05" xml:lang="ja">副タイトル、部分タイトル。</desc>
@@ -316,70 +205,43 @@ niveau inférieur, titre de partie</gloss>
         <valItem ident="alt">
           <gloss versionDate="2007-07-04" xml:lang="en">alternate</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">이명</gloss>
-          <gloss versionDate="2007-06-12" xml:lang="fr">titre
-alternatif, souvent dans une autre
-langue, par lequel l'oeuvre est
-également connu</gloss>
+          <gloss versionDate="2007-06-12" xml:lang="fr">titre alternatif, souvent dans une autre langue, par lequel l'oeuvre est également connu</gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">alternativo</gloss>
-          <gloss versionDate="2007-05-04" xml:lang="es">título
-alternativo, a menudo en otra lengua por
-la cual la obra es también conocida.</gloss>
+          <gloss versionDate="2007-05-04" xml:lang="es">título alternativo, a menudo en otra lengua por la cual la obra es también conocida.</gloss>
           <gloss versionDate="2017-06-04" xml:lang="de">alternativ</gloss>
-          <desc versionDate="2007-06-27" xml:lang="en">alternate title, often in another language,
-by which the work is also known</desc>
-          <desc versionDate="2007-12-20" xml:lang="ko">다른 언어에서
-알려진 작품의 다른 이름</desc>
+          <desc versionDate="2007-06-27" xml:lang="en">alternate title, often in another language, by which the work is also known</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">다른 언어에서 알려진 작품의 다른 이름</desc>
           <desc versionDate="2007-05-02" xml:lang="zh-TW">替代題名，通常以該作品著名的另一種語言呈現</desc>
-          <desc versionDate="2008-04-06" xml:lang="es">título
-alternativo, a menudo en otro idioma,
-por el cual el trabajo también es
-conocido</desc>
-          <desc versionDate="2008-04-05" xml:lang="ja">別タイトル。多くは他言語によるタイトル。当該作品は、このタイ
-トルで知られている。</desc>
-          <desc versionDate="2008-03-30" xml:lang="fr">autre
-titre, souvent exprimé dans une autre
-langue, par lequel l'ouvrage est aussi
-connu</desc>
-          <desc versionDate="2007-01-21" xml:lang="it">titolo
-alternativo, spesso in altra lingua, con
-il quale è anche conosciuta
-l'opera</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">título alternativo, a menudo en otro idioma, por el cual el trabajo también es conocido</desc>
+          <desc versionDate="2008-04-05" xml:lang="ja">別タイトル。多くは他言語によるタイトル。当該作品は、このタイ トルで知られている。</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">autre titre, souvent exprimé dans une autre langue, par lequel l'ouvrage est aussi connu</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">titolo alternativo, spesso in altra lingua, con il quale è anche conosciuta l'opera</desc>
           <desc versionDate="2017-06-04" xml:lang="de">alternativer Titel, oft in einer anderen Sprache, unter dem das Werk auch bekannt ist.</desc>
         </valItem>
         <valItem ident="short">
           <desc versionDate="2007-06-27" xml:lang="en">abbreviated form of title</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">제목의 축약형</desc>
           <desc versionDate="2007-05-02" xml:lang="zh-TW">題名的縮寫形式</desc>
-          <desc versionDate="2008-04-06" xml:lang="es">forma
-abreviada del título</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">forma abreviada del título</desc>
           <desc versionDate="2008-04-05" xml:lang="ja">タイトルの省略形。</desc>
-          <desc versionDate="2008-03-30" xml:lang="fr">forme
-abrégée du titre</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">forme abrégée du titre</desc>
           <desc versionDate="2007-01-21" xml:lang="it">abbreviazione del titolo</desc>
           <desc versionDate="2017-06-04" xml:lang="de">Kurztitel</desc>
         </valItem>
         <valItem ident="desc">
           <gloss versionDate="2007-07-04" xml:lang="en">descriptive</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">기술적</gloss>
-          <gloss versionDate="2007-06-12" xml:lang="fr">paraphrase descriptive de l'oeuvre
-ayant les fonctions d'un titre</gloss>
+          <gloss versionDate="2007-06-12" xml:lang="fr">paraphrase descriptive de l'oeuvre ayant les fonctions d'un titre</gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">descrittivo</gloss>
-          <gloss versionDate="2007-05-04" xml:lang="es">paráfrasis descriptiva que funciona
-como el título de una obra.</gloss>
+          <gloss versionDate="2007-05-04" xml:lang="es">paráfrasis descriptiva que funciona como el título de una obra.</gloss>
           <gloss versionDate="2017-06-04" xml:lang="de">beschreibend</gloss>
-          <desc versionDate="2007-06-27" xml:lang="en">descriptive paraphrase of the work
-functioning as a title</desc>
-          <desc versionDate="2007-12-20" xml:lang="ko">제목으로 기능하는
-작품의 기술적 바꿔쓰기</desc>
+          <desc versionDate="2007-06-27" xml:lang="en">descriptive paraphrase of the work functioning as a title</desc>
+          <desc versionDate="2007-12-20" xml:lang="ko">제목으로 기능하는 작품의 기술적 바꿔쓰기</desc>
           <desc versionDate="2007-05-02" xml:lang="zh-TW">該作品的描述性改述，可作為題名</desc>
-          <desc versionDate="2008-04-06" xml:lang="es">paráfrasis descriptiva del trabajo que
-funciona como título</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">paráfrasis descriptiva del trabajo que funciona como título</desc>
           <desc versionDate="2008-04-05" xml:lang="ja">タイトルのように当該作品を解説する言い換え。</desc>
-          <desc versionDate="2008-03-30" xml:lang="fr">paraphrase descriptive de l'oeuvre
-fonctionnant comme un titre</desc>
-          <desc versionDate="2007-01-21" xml:lang="it">parafrasi
-descrittiva dell'opera che funge da
-titolo</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">paraphrase descriptive de l'oeuvre fonctionnant comme un titre</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">parafrasi descrittiva dell'opera che funge da titolo</desc>
           <desc versionDate="2017-06-04" xml:lang="de">Umschreibung des Werks, die als Titel fungiert.</desc>
         </valItem>
       </valList>
@@ -393,18 +255,17 @@ titolo</desc>
       </remarks>
       <remarks xml:lang="fr" versionDate="2007-06-12">
         <p>Cet attribut est utile pour analyser les titres et les
-traiter en fonction de leur type ; lorsqu'un tel
-traitement spécifique n'est pas nécessaire, il
-n'est pas utile de donner une telle analyse, et le
-titre entier, sous-titres et titres parallèles
-inclus, peuvent être encodés dans un élément
-<gi>title</gi>.</p>
+        traiter en fonction de leur type ; lorsqu'un tel traitement
+        spécifique n'est pas nécessaire, il n'est pas utile de donner
+        une telle analyse, et le titre entier, sous-titres et titres
+        parallèles inclus, peuvent être encodés dans un élément
+        <gi>title</gi>.</p>
       </remarks>
       <remarks xml:lang="ja" versionDate="2008-04-05">
-        <p> 当該属性は、タイトルを分析し、処理する際に使用されるものである。
-このような処理を必要としない場合、タイトルを分析する必要はなく、
-副タイトルなどは全て要素<gi>title</gi>の中に入れてしまうことが
-できる。 </p>
+        <p> 当該属性は、タイトルを分析し、処理する際に使用されるもので
+        ある。このような処理を必要としない場合、タイトルを分析する必要
+        はなく、副タイトルなどは全て要素<gi>title</gi>の中に入れてしま
+        うことができる。 </p>
       </remarks>
       <remarks versionDate="2017-06-04" xml:lang="de">
         <p>Dieses Attribut wird bereitgestellt, um die Analyse und die Verarbeitung von Titeln auf

--- a/P5/Source/Specs/trait.xml
+++ b/P5/Source/Specs/trait.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="trait">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="namesdates" ident="trait">
   <gloss xml:lang="en" versionDate="2009-03-19">trait</gloss>
   <gloss versionDate="2009-03-19" xml:lang="fr">trait distinctif</gloss>
-  <desc versionDate="2011-12-01" xml:lang="en">contains a description of some status or quality attributed to a person, place, or organization typically, but not necessarily, 
-    independent of the volition or action of the holder and usually not at some specific time or for a specific date range.</desc>
-  <desc versionDate="2009-01-05" xml:lang="fr">contient la description d'une caractéristique culturelle
-    et en principe permanente, attribuée à une personne ou à un lieu.</desc>
+  <desc versionDate="2011-12-01" xml:lang="en">contains a description of some status or quality attributed to a person, place, or organization typically, but not necessarily, independent of the volition or action of the holder and usually not at some specific time or for a specific date range.</desc>
+  <desc versionDate="2009-01-05" xml:lang="fr">contient la description d'une caractéristique culturelle et en principe permanente, attribuée à une personne ou à un lieu.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">사람 또는 장소에 관한, 문화적으로 결정된 특성 기술을 포함한다.</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">人物や場所の文化的な特性を示す。</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene la descripción de una característica personal o
-    cultural determinada atribuida a una persona.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene la descrizione di una caratteristica personale o
-    legata alla cultura di appartenenza di una determinata persona</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene la descripción de una característica personal o cultural determinada atribuida a una persona.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene la descrizione di una caratteristica personale o legata alla cultura di appartenenza di una determinata persona</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.datable"/>
@@ -45,39 +42,6 @@
       </alternate>
     </sequence>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-trait">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <!--    <exemplum xml:lang="en">
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
             <trait cert="high" type="social" from="1987-01-01" to="1997-12-31">

--- a/P5/Source/Specs/unitDecl.xml
+++ b/P5/Source/Specs/unitDecl.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="unitDecl">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="unitDecl">
   <gloss versionDate="2018-07-18" xml:lang="en">unit declarations</gloss>
   <desc versionDate="2018-07-18" xml:lang="en">provides information about units of measurement that are not members of the International System of Units.</desc>
   <classes>
@@ -12,39 +13,6 @@
   <content>
     <elementRef key="unitDef" minOccurs="1" maxOccurs="unbounded"/>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-unitDecl">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#ja-ritsuryo-weights">
         <unitDecl>

--- a/P5/Source/Specs/unitDef.xml
+++ b/P5/Source/Specs/unitDef.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
-<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?><elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="unitDef">
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="header" ident="unitDef">
   <gloss versionDate="2018-07-18" xml:lang="en">unit definition</gloss>
   <desc versionDate="2018-07-18" xml:lang="en">contains descriptive information related to a specific unit of measurement.</desc>
   <classes>
@@ -17,39 +18,6 @@
        <elementRef key="unit" minOccurs="0"/>     
      </alternate>
   </content>
-  <attList>
-    <attDef ident="calendar" usage="opt" validUntil="2024-11-11">
-        <desc type="deprecationInfo" versionDate="2023-05-11" xml:lang="en">The <att>calendar</att> attribute will be removed from this element
-            as it will only be allowed on elements that represent dates with their content. This is because the <att>calendar</att> attribute
-            (unlike <att>datingMethod</att> defined in
-            <ident type="class">att.datable.custom</ident>) defines the calendar system of the date
-            in the original material defined by the parent element, <emph>not</emph> the calendar to
-            which the date is normalized.</desc>
-        <desc versionDate="2021-04-26" xml:lang="en">indicates one or more systems or calendars to which the
-            date represented by the content of this element belongs.</desc>
-        <desc versionDate="2007-12-20" xml:lang="ko">날짜 표현 시스템 또는 달력 표시 형식을 표시한다.</desc>
-        <desc versionDate="2007-05-02" xml:lang="zh-TW">指明該日期表示所使用的曆法計算系統。</desc>
-        <desc xml:lang="ja" versionDate="2019-02-03">この要素を含むコンテントにおける日付の暦やシステムを示す。</desc>
-        <desc versionDate="2009-01-06" xml:lang="fr">indique le système ou le calendrier auquel
-            appartient la date exprimée dans le contenu de l'élément.</desc>
-        <desc versionDate="2007-05-04" xml:lang="es">indica el sistema o calendario en que se muestra
-            una fecha.</desc>
-        <desc versionDate="2007-01-21" xml:lang="it">indica il sistema o calendario al quale la data
-            appartiene.</desc>
-        <datatype minOccurs="1" maxOccurs="unbounded">
-            <dataRef key="teidata.pointer"/>
-        </datatype>
-        <constraintSpec scheme="schematron" ident="calendar-check-unitDef">
-            <constraint>
-                <sch:rule context="tei:*[@calendar]">
-                    <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <sch:name/> element has no textual content.</sch:assert>
-                </sch:rule>
-            </constraint>
-        </constraintSpec>
-    </attDef>
-  </attList>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#NONE">
       <unitDecl>

--- a/P5/Test/expected-results/detest_xml_schematron.log
+++ b/P5/Test/expected-results/detest_xml_schematron.log
@@ -14,62 +14,11 @@ The element indicated by @spanTo (notMeaningful) must follow the current element
  @calendar indicates one or more
               systems or calendars to which the date represented by the content of this element belongs,
               but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
 The content of a "gloss" list should include a sequence of one or more pairs of a label element followed by an item element (tei:label)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
 An lg element must contain at least one child l, lg, or gap element. (count(descendant::tei:lg|descendant::tei:l|descendant::tei:gap) &gt; 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
 
           On quotation, either the @marks attribute should be used, or a paragraph of description provided
          (not( @marks ) and not( tei:p ))
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
 You may not nest one s element within another: use seg instead (tei:s)
 
           Only one of the attributes @target and @from may be supplied on span
@@ -132,33 +81,6 @@ subst must have at least one child add and at least one child del or surplus (ch
 
           Only one additional is allowed as a child of msDesc.
          (preceding-sibling::*[ name(.) eq $gi ] and not( following-sibling::*[ name(.) eq $gi ] ))
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
- @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
 In the context of tagset documentation, the listRef element must not self-nest. (tei:listRef)
 In the context of tagset documentation, each ptr or ref element inside a listRef must have a target attribute with only 1 pointer as its value. (@target and not( matches( @target,'\s') ))
 In the context of tagset documentation, each ptr or ref element inside a listRef must have a target attribute with only 1 pointer as its value. (@target and not( matches( @target,'\s') ))


### PR DESCRIPTION
Went through all ~64 spec files that had their own declaration for `@calendar` (so that it could have a deprecation warning) and removed them.