### PR TITLE
Created constraintDecl

### DIFF
--- a/P5/Source/Guidelines/en/TD-DocumentationElements.xml
+++ b/P5/Source/Guidelines/en/TD-DocumentationElements.xml
@@ -931,6 +931,22 @@ to mark any technical term, thus:
           </constraintSpec>
         </egXML>
       </p>
+      <p>Schematron schemas can use a variety of query languages for its expressions, such as XSLT or XQuery.
+        To declare which query language binding is in use, you may add a <gi>constraintDecl</gi> to 
+        <gi>encodingDesc</gi> or <gi>schemaSpec</gi>.
+        <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/constraintDecl.xml"/>  
+        <specList><specDesc key="constraintDecl" atts="scheme queryBinding"/></specList>
+      </p>
+      <p>This element can also be used to provide additional declarations pertaining to formal constraints
+      expressed <gi>constraintSpec</gi> elements, such as the declaration of a namespace and its prefix.</p>
+      <egXML xmlns="http://www.tei-c.org/ns/Examples">
+          <encodingDesc>
+            <p>Some information about the encoding</p>
+            <constraintDecl scheme="schematron" queryBinding="xslt3">
+              <sch:ns prefix="wwp" uri="http://www.wwp.northeastern.edu/ns/textbase"/>
+            </constraintDecl>
+          </encodingDesc>
+        </egXML>
       <p>Constraints can be expressed using any convenient language.
       The following example uses a pattern matching language called
       SPITBOL to express the requirement that title and author should

--- a/P5/Source/Specs/constraintDecl.xml
+++ b/P5/Source/Specs/constraintDecl.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright TEI Consortium. 
+Dual-licensed under CC-by and BSD2 licences 
+See the file COPYING.txt for details
+$Date$
+$Id$
+-->
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" ident="constraintDecl">
+  <gloss versionDate="2023-03-09" xml:lang="en">constraint declaration</gloss>
+  <desc versionDate="2023-03-09" xml:lang="en">contains declarations pertaining to formal constraints expressed elsewhere in <gi>constraintSpec</gi> elements</desc>
+  <classes>
+    <memberOf key="att.global"/>
+  </classes>
+  <content>
+    <sequence>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.identEquiv"/>
+        <classRef key="model.descLike"/>
+      </alternate>
+      <anyElement minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </content>
+  <attList>
+    <attDef ident="scheme" usage="req">
+      <desc versionDate="2023-03-09" xml:lang="en">supplies the name of the language to which the declarations herein apply</desc>
+      <datatype><dataRef key="teidata.enumerated"/></datatype>
+      <valList type="semi">
+        <valItem ident="schematron">
+          <gloss versionDate="2016-09-27" xml:lang="en">ISO Schematron</gloss>
+        </valItem>
+      </valList>
+      <remarks versionDate="2023-03-09" xml:lang="en">
+        <p>The declarations contained in a particular
+        <gi>constraintDecl</gi> apply to the <gi>constraintSpec</gi>
+        elements whose <att>scheme</att> matches the <att>scheme</att>
+        of the <gi>constraintDecl</gi>.</p>
+      </remarks>
+    </attDef>
+    <attDef ident="queryBinding" usage="rec">
+      <gloss xml:lang="en" versionDate="2023-03-09">query language binding</gloss>
+      <desc xml:lang="en" versionDate="2023-03-09">specifies the query
+      language binding for rule-based schema expressions in
+      <gi>constraintSpec</gi> elements that have a matching
+      <att>scheme</att> attribute</desc>
+      <datatype><dataRef key="teidata.enumerated"/></datatype>
+      <valList type="semi">
+        <valItem ident="exslt"/>
+        <valItem ident="stx"/>
+        <valItem ident="xslt"/>
+        <valItem ident="xslt2"/>
+        <valItem ident="xslt3"/>
+        <valItem ident="xpath"/>
+        <valItem ident="xpath2"/>
+        <valItem ident="xpath3"/>
+        <valItem ident="xpath31"/>
+        <valItem ident="xquery"/>
+        <valItem ident="xquery3"/>
+        <valItem ident="xquery31"/>
+      </valList>
+      <remarks versionDate="2023-03-09" xml:lang="en">
+        <p>The suggested values above are the values reserved by the
+        Schematron specification. Only <val>exslt</val>,
+        <val>stx</val>, <val>xslt</val>, <val>xslt2</val>,
+        <val>xslt3</val>, <val>xpath2</val>, and <val>xpath3</val> are
+        defined by the specification. Most processors only support a
+        subset of <val>xslt</val>, <val>xslt2</val>, and
+        <val>xslt3</val>.</p>
+      </remarks>
+    </attDef>
+  </attList>
+  <exemplum xml:lang="en">
+    <egXML xmlns="http://www.tei-c.org/ns/Examples">
+      <constraintDecl scheme="schematron" queryBinding="xslt3">
+        <sch:ns prefix="wwp" uri="http://www.wwp.northeastern.edu/ns/textbase"/>
+      </constraintDecl>
+    </egXML>
+  </exemplum>
+  <listRef>
+    <ptr target="#TDTAGCONS"/>
+  </listRef>
+</elementSpec>

--- a/P5/Source/Specs/encodingDesc.xml
+++ b/P5/Source/Specs/encodingDesc.xml
@@ -23,14 +23,13 @@ source or sources from which it was derived.</desc>
     <memberOf key="model.teiHeaderPart"/>
   </classes>
   <content>
-    
-      
-        <alternate minOccurs="1" maxOccurs="unbounded">
-          <classRef key="model.encodingDescPart"/>
-          <classRef key="model.pLike"/>
-        </alternate>
-      
-    
+    <sequence preserveOrder="false">
+      <alternate minOccurs="1" maxOccurs="unbounded">
+        <classRef key="model.encodingDescPart"/>
+        <classRef key="model.pLike"/>
+      </alternate>
+      <elementRef key="constraintDecl" minOccurs="0" maxOccurs="1"/>
+    </sequence>
   </content>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples">

--- a/P5/Source/Specs/schemaSpec.xml
+++ b/P5/Source/Specs/schemaSpec.xml
@@ -30,10 +30,11 @@
         <classRef key="model.identEquiv"/>
         <classRef key="model.descLike"/>
       </alternate>
+      <elementRef key="constraintDecl" minOccurs="0" maxOccurs="1"/>
       <alternate minOccurs="0" maxOccurs="unbounded">
         <classRef key="model.oddRef"/>
         <classRef key="model.oddDecl"/>
-	<elementRef key="listRef"/>
+	      <elementRef key="listRef"/>
       </alternate>      
     </sequence>
   </content>


### PR DESCRIPTION
This is an initial implementation to address #2330. I would like some input on a couple of things.

* I made `<anyElement/>` optional in the content of `constraintDecl`. I think the element can be empty if all that's needed is specifying the query language binding.
* I allowed `constraintDecl` in `encodingDesc`  to interleave with other elements. OK?
* `schemaSpec` has a `<sequence>` content model, so I couldn't interleave `constraintDecl`. Instead, I placed if after elements that typically go first (`equiv`, `desc`), but before spec / ref elements. Thoughts?
* I would appreciate feedback on the text I added to Chap 22 and whether it's in the right place.