### PR TITLE
Emergency fix: return removed mode=add due to missing value lists

### DIFF
--- a/P5/Source/Specs/abbr.xml
+++ b/P5/Source/Specs/abbr.xml
@@ -45,7 +45,7 @@
                 l'abbreviazione secondo una tipologia funzionale.</desc>
       <desc versionDate="2016-11-25" xml:lang="de">erlaubt es, die Abkürzung nach einer geeigneten Typologie zu klassifizieren.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="suspension">
           <gloss xml:lang="en" versionDate="2017-06-25">suspension</gloss>
           <gloss versionDate="2017-06-25" xml:lang="de">Suspension</gloss>

--- a/P5/Source/Specs/affiliation.xml
+++ b/P5/Source/Specs/affiliation.xml
@@ -30,7 +30,7 @@
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="sponsor"/>
         <valItem ident="recommend"/>
         <valItem ident="discredit"/>

--- a/P5/Source/Specs/age.xml
+++ b/P5/Source/Specs/age.xml
@@ -26,7 +26,7 @@
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="western"/>
         <valItem ident="sui"/>
         <valItem ident="subjective"/>

--- a/P5/Source/Specs/birth.xml
+++ b/P5/Source/Specs/birth.xml
@@ -28,7 +28,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
 	<valItem ident="caesarean">
 	  <gloss xml:lang="en" versionDate="2017-06-23">caesarean section</gloss>
 	  <gloss xml:lang="ja" versionDate="2023-09-27">帝王切開</gloss>

--- a/P5/Source/Specs/castItem.xml
+++ b/P5/Source/Specs/castItem.xml
@@ -42,7 +42,7 @@ either a single role or a list of non-speaking roles.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">indica la voce della lista dei personaggi</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <defaultVal>role</defaultVal>
-      <valList type="closed">
+      <valList mode="add" type="closed">
         <valItem ident="role">
           <desc versionDate="2007-06-27" xml:lang="en">the item describes a single role.</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">항목이 하나의 배역을 기술한다.</desc>

--- a/P5/Source/Specs/certainty.xml
+++ b/P5/Source/Specs/certainty.xml
@@ -28,7 +28,7 @@
     <attDef ident="type" usage="opt" mode="change">
       <desc versionDate="2021-01-28" xml:lang="en">characterizes the element in some sense, using any convenient
          classification scheme or typology; sample categorization of annotations of uncertainty might use following values:</desc>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="ignorance"/>
         <valItem ident="incompleteness"/>
         <valItem ident="credibility"/>

--- a/P5/Source/Specs/classSpec.xml
+++ b/P5/Source/Specs/classSpec.xml
@@ -53,7 +53,7 @@ that is a group of
       <desc versionDate="2007-05-04" xml:lang="es">indica si se trata de una clase de modelos o de atributos.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">indica se si tratta di una classe di modelli o di attributi</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="closed">
+      <valList mode="add" type="closed">
         <valItem ident="model">
           <gloss versionDate="2007-07-04" xml:lang="en">content model</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">내용 모델</gloss>

--- a/P5/Source/Specs/constitution.xml
+++ b/P5/Source/Specs/constitution.xml
@@ -32,7 +32,7 @@ as fragmentary, complete, etc.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica come era costituito il testo.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <defaultVal>single</defaultVal>
-      <valList type="closed">
+      <valList mode="add" type="closed">
         <valItem ident="single">
           <desc versionDate="2007-06-27" xml:lang="en">a single complete text</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">단일 완전 텍스트</desc>

--- a/P5/Source/Specs/constraintSpec.xml
+++ b/P5/Source/Specs/constraintSpec.xml
@@ -144,7 +144,7 @@
       when a <gi>constraintSpec</gi> warns about a deprecated
       construct.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="deprecationWarning">
           <desc xml:lang="en" versionDate="2018-09-17">Indicates that
           this constraint specification warns that some other

--- a/P5/Source/Specs/correspAction.xml
+++ b/P5/Source/Specs/correspAction.xml
@@ -28,7 +28,7 @@
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="sent">
           <desc versionDate="2015-02-09" xml:lang="en">information concerning the sending or dispatch of a message.</desc>
 		<desc versionDate="2022-06-02" xml:lang="ja">メッセージの送信や発送に関する情報。</desc>

--- a/P5/Source/Specs/death.xml
+++ b/P5/Source/Specs/death.xml
@@ -28,7 +28,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
 	<valItem ident="proclaimed"/>
 	<valItem ident="assumed"/>
 	<valItem ident="verified"/>

--- a/P5/Source/Specs/derivation.xml
+++ b/P5/Source/Specs/derivation.xml
@@ -30,7 +30,7 @@
       <desc versionDate="2007-05-04" xml:lang="es">caracteriza la derivación del texto</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica la provenienza del testo.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="original">
           <desc versionDate="2007-06-27" xml:lang="en">text is original</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">텍스트가 원본이다.</desc>

--- a/P5/Source/Specs/desc.xml
+++ b/P5/Source/Specs/desc.xml
@@ -58,7 +58,7 @@
   </constraintSpec>
   <attList>
     <attDef ident="type" mode="change">
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="deprecationInfo">
           <gloss versionDate="2018-09-14" xml:lang="en">deprecation
           information</gloss>

--- a/P5/Source/Specs/dimensions.xml
+++ b/P5/Source/Specs/dimensions.xml
@@ -52,7 +52,7 @@
       <desc versionDate="2007-05-04" xml:lang="es">indica que aspecto del objeto se mide.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">indica quale aspetto dell'oggetto viene misurato</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="leaves">
           <desc versionDate="2007-06-27" xml:lang="en">dimensions relate to one or more leaves (e.g. a single leaf, a gathering, or a separately bound part)</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">하나 이상의 종이의 장과 관련된 차원(예, 한 장, 접지 모음, 또는 각각 분리되어 엮여진 부분)</desc>

--- a/P5/Source/Specs/divGen.xml
+++ b/P5/Source/Specs/divGen.xml
@@ -40,7 +40,7 @@
       <desc versionDate="2007-05-04" xml:lang="es">especifica que tipo de divisón de texto generada aparece (p.ej. índice, tabla de contenidos, etc.)</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica quale tipo di partizione testuale generata (ad esempio indice, sommario, ecc.) apparirà</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="index">
           <desc versionDate="2007-06-27" xml:lang="en">an index is to be generated and inserted at this point.</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">색인은 이 지점에서 생성되고 삽입된다.</desc>

--- a/P5/Source/Specs/domain.xml
+++ b/P5/Source/Specs/domain.xml
@@ -38,7 +38,7 @@ education, religion, etc.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">clasifica el campo de uso.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica l'ambito di uso.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="art">
           <desc versionDate="2007-06-27" xml:lang="en">art and entertainment</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">예술과 연예</desc>

--- a/P5/Source/Specs/education.xml
+++ b/P5/Source/Specs/education.xml
@@ -27,7 +27,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
 	<valItem ident="primary"/>
 	<valItem ident="secondary"/>
 	<valItem ident="undergraduate"/>

--- a/P5/Source/Specs/factuality.xml
+++ b/P5/Source/Specs/factuality.xml
@@ -32,7 +32,7 @@ or a non-fictional world.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">clasifica la objetividad de un texto</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica la fattualità del testo.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="closed">
+      <valList mode="add" type="closed">
         <valItem ident="fiction">
           <desc versionDate="2007-06-27" xml:lang="en">the text is to be regarded as entirely imaginative</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">텍스트가 전적으로 상상적이라 간주된다.</desc>

--- a/P5/Source/Specs/faith.xml
+++ b/P5/Source/Specs/faith.xml
@@ -27,7 +27,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
 	<valItem ident="practicing"/>
 	<valItem ident="clandestine"/>
 	<valItem ident="patrilineal"/>

--- a/P5/Source/Specs/form.xml
+++ b/P5/Source/Specs/form.xml
@@ -48,7 +48,7 @@
       <desc versionDate="2007-05-04" xml:lang="es">clasifica la forma como simple, compuesta, etc.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica la forma in simplice, composta, ecc.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="simple">
           <desc versionDate="2007-06-27" xml:lang="en">single free lexical item</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">단일 자립 어휘 항목</desc>

--- a/P5/Source/Specs/fw.xml
+++ b/P5/Source/Specs/fw.xml
@@ -36,7 +36,7 @@
       <desc versionDate="2007-05-04" xml:lang="es">clasifica las convenciones usadas según una tipología funcional.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica le convenzioni usate secondo una tipologia funzionale</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="header">
           <desc versionDate="2007-04-02" xml:lang="en">a running title at the top of the page</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">페이지 상단의 현 제목</desc>

--- a/P5/Source/Specs/gram.xml
+++ b/P5/Source/Specs/gram.xml
@@ -56,7 +56,7 @@
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="pos">
           <gloss versionDate="2007-08-25" xml:lang="en">part of speech</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">품사</gloss>

--- a/P5/Source/Specs/graph.xml
+++ b/P5/Source/Specs/graph.xml
@@ -59,7 +59,7 @@ connect the nodes.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">describe el tipo de gráfico</desc>
       <desc versionDate="2007-01-21" xml:lang="it">descrive il tipo di grafo</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="undirected">
           <desc versionDate="2007-06-27" xml:lang="en">undirected graph</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">무방향 그래프</desc>

--- a/P5/Source/Specs/iType.xml
+++ b/P5/Source/Specs/iType.xml
@@ -51,7 +51,7 @@
         abbreviate solite (ad esempio <mentioned>inv</mentioned>)e altri tipi di indicatori, quali
         codici speciali per fare riferimento al tipo di coniugazione, ecc.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="abbrev">
           <desc versionDate="2007-06-27" xml:lang="en">abbreviated indicator</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">축약 지시자</desc>

--- a/P5/Source/Specs/idno.xml
+++ b/P5/Source/Specs/idno.xml
@@ -48,7 +48,7 @@
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="ISBN">
           <desc versionDate="2016-07-02" xml:lang="en">International Standard Book Number: a 13- or
             (if assigned prior to 2007) 10-digit identifying number assigned by the publishing

--- a/P5/Source/Specs/interaction.xml
+++ b/P5/Source/Specs/interaction.xml
@@ -37,7 +37,7 @@ form of response or interjection, commentary, etc.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">describe el grado de interacción entre los participantes activos y pasivos en un texto.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica il grado di interazione tra partecipanti attivi e passivi all'interno del testo.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="closed">
+      <valList mode="add" type="closed">
         <valItem ident="none">
           <desc versionDate="2007-06-27" xml:lang="en">no interaction of any kind, e.g. a monologue</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">종류의 상호작용이 없다. 예, 독백.</desc>

--- a/P5/Source/Specs/langKnowledge.xml
+++ b/P5/Source/Specs/langKnowledge.xml
@@ -35,7 +35,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
 	<valItem ident="listening"/>
 	<valItem ident="speaking"/>
 	<valItem ident="reading"/>

--- a/P5/Source/Specs/list.xml
+++ b/P5/Source/Specs/list.xml
@@ -103,7 +103,7 @@
       <desc versionDate="2014-07-29" xml:lang="en">describes the nature of the items in the list.</desc>
       <desc versionDate="2016-11-25" xml:lang="de">beschreibt die Art der Listenpunkte.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="gloss">
           <gloss xml:lang="en" versionDate="2017-06-25">gloss</gloss>
           <gloss versionDate="2017-06-25" xml:lang="de">Gloss</gloss>

--- a/P5/Source/Specs/move.xml
+++ b/P5/Source/Specs/move.xml
@@ -37,7 +37,7 @@
       <desc versionDate="2007-01-21" xml:lang="it">indica il tipo di movimento, ad esempio come entrata
         o uscita.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="entrance">
           <desc versionDate="2007-06-27" xml:lang="en">character is entering the stage.</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">등장인물이 무대에 등장하고 있다.</desc>

--- a/P5/Source/Specs/nationality.xml
+++ b/P5/Source/Specs/nationality.xml
@@ -27,7 +27,7 @@
       <datatype>
 	<dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
 	<valItem ident="birth"/>
 	<valItem ident="naturalised"/>
 	<valItem ident="self-assigned"/>

--- a/P5/Source/Specs/node.xml
+++ b/P5/Source/Specs/node.xml
@@ -42,7 +42,7 @@ other analytic element.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">define un tipo de nodo.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">definisce un tipo di nodo</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="initial">
           <desc versionDate="2007-06-27" xml:lang="en">initial node in a transition network</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">전이망에서 시작 노드</desc>

--- a/P5/Source/Specs/num.xml
+++ b/P5/Source/Specs/num.xml
@@ -38,7 +38,7 @@
       <desc versionDate="2007-01-21" xml:lang="it">indica il tipo di valore numerico</desc>
       <desc versionDate="2016-11-25" xml:lang="de">bestimmt die Art des numerischen Wertes.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="cardinal">
           <desc versionDate="2007-06-27" xml:lang="en">absolute number, e.g. 21, 21.5</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">예를 들어, 21, 21.5와 같은 절대값</desc>

--- a/P5/Source/Specs/oRef.xml
+++ b/P5/Source/Specs/oRef.xml
@@ -46,7 +46,7 @@
       <desc versionDate="2007-01-21" xml:lang="it">indica il tipo di modifica tipografica del lemma in
         un riferimento.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="cap">
           <gloss versionDate="2007-07-04" xml:lang="en">capital</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">대문자</gloss>

--- a/P5/Source/Specs/occupation.xml
+++ b/P5/Source/Specs/occupation.xml
@@ -27,7 +27,7 @@
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="primary"/>
         <valItem ident="other"/>
         <valItem ident="paid"/>

--- a/P5/Source/Specs/preparedness.xml
+++ b/P5/Source/Specs/preparedness.xml
@@ -31,7 +31,7 @@ prepared or spontaneous.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">una palabra clave que caracteriza el tipo de preparación.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">una parola chiava che caratterizza il grado di spontaneità</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="none">
           <desc versionDate="2007-06-27" xml:lang="en">spontaneous or unprepared</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">자발적 또는 준비되지 않은</desc>

--- a/P5/Source/Specs/purpose.xml
+++ b/P5/Source/Specs/purpose.xml
@@ -28,7 +28,7 @@ text.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">especifica un tipo particular de finalidad</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica un tipo particolare di scopo.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="persuade">
           <desc versionDate="2007-06-27" xml:lang="en">didactic, advertising, propaganda, etc.</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">설교, 광고, 선전 등</desc>

--- a/P5/Source/Specs/recording.xml
+++ b/P5/Source/Specs/recording.xml
@@ -49,7 +49,7 @@ a public broadcast.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">tipo di registrazione.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <defaultVal>audio</defaultVal>
-      <valList type="closed">
+      <valList mode="add" type="closed">
         <valItem ident="audio">
           <desc versionDate="2007-06-27" xml:lang="en">audio recording</desc>
           <desc versionDate="2009-01-05" xml:lang="fr">enregistrement audio</desc>

--- a/P5/Source/Specs/residence.xml
+++ b/P5/Source/Specs/residence.xml
@@ -31,7 +31,7 @@
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="primary"/>
         <valItem ident="secondary"/>
         <valItem ident="temporary"/>

--- a/P5/Source/Specs/socecStatus.xml
+++ b/P5/Source/Specs/socecStatus.xml
@@ -54,7 +54,7 @@
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="atBirth"/>
         <valItem ident="atDeath"/>
         <valItem ident="dependent"/>

--- a/P5/Source/Specs/tag.xml
+++ b/P5/Source/Specs/tag.xml
@@ -34,7 +34,7 @@
       <desc versionDate="2009-01-23" xml:lang="fr">indique quel type de balise XML est prévu.</desc>
       <desc versionDate="2008-04-08" xml:lang="it">indica di quale tipo di marcatore XML si tratta</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="closed">
+      <valList mode="add" type="closed">
         <valItem ident="start">
           <desc versionDate="2008-04-05" xml:lang="en">a start-tag, with delimiters &lt; and &gt; is intended</desc>
           <desc versionDate="2009-01-23" xml:lang="fr">une balise de début, délimitée par les signes

--- a/P5/Source/Specs/tech.xml
+++ b/P5/Source/Specs/tech.xml
@@ -36,7 +36,7 @@ meant for the actors.</desc>
           scène.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica l'indicazione di scena tecnica.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="light">
           <desc versionDate="2007-06-27" xml:lang="en">a lighting cue</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">조명 신호</desc>

--- a/P5/Source/Specs/title.xml
+++ b/P5/Source/Specs/title.xml
@@ -175,7 +175,7 @@
       <desc versionDate="2007-01-21" xml:lang="it">classifica il titolo seguendo una tipologia conveniente.</desc>
       <desc versionDate="2017-06-04" xml:lang="de">klassifiziert den Titel entsprechend einer geeigneten Typologie.</desc> 
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="main">
           <desc versionDate="2007-06-27" xml:lang="en">main title</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">(주)제목</desc>

--- a/P5/Source/Specs/titlePart.xml
+++ b/P5/Source/Specs/titlePart.xml
@@ -38,7 +38,7 @@ indicated on a title page.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">specifica il ruolo di tale sezione o partizione all'interno del titolo</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <defaultVal>main</defaultVal>
-      <valList type="semi">
+      <valList mode="add" type="semi">
         <valItem ident="main">
           <gloss xml:lang="en" versionDate="2017-06-19">main</gloss>
           <gloss versionDate="2017-06-19" xml:lang="de">Haupttitel</gloss>

--- a/P5/Source/Specs/usg.xml
+++ b/P5/Source/Specs/usg.xml
@@ -38,7 +38,7 @@
       <desc versionDate="2007-05-04" xml:lang="es">clasifica la información sobre el uso aplicando una tipología funcional.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">classifica le informazioni sull'uso secondo una tipologia funzionale.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="geo">
           <gloss versionDate="2007-07-04" xml:lang="en">geographic</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">지리적</gloss>

--- a/P5/Source/Specs/xr.xml
+++ b/P5/Source/Specs/xr.xml
@@ -52,7 +52,7 @@
       <desc versionDate="2007-01-21" xml:lang="it">indica il tipo di riferimento incrociato secondo una
         tipologia funzionale</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <valList type="open">
+      <valList mode="add" type="open">
         <valItem ident="syn">
           <gloss versionDate="2007-07-04" xml:lang="en">synonym</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">유의어</gloss>


### PR DESCRIPTION
Put mode="add" back on valList elements per #2597.

### What I did
- Looked up when change that removed the mode=add occurred. (It was 2024-01-26).
- Checked out dev branch as of the day before.
- Copied P5/Source/Specs/ directory to a temporary location A/.
- Checked out dev branch as of the day after.
- Compared all files in P5/Source/Specs/ tree to the corresponding file in A/.
- Using a little Emacs macro, repeatedly
  - searched the `diff` output from above for `<valList .*mode="a`
  - from that spot searched backwards for filename
  - opened that file
  - searched for `<valList`
- Checked that it was the right `<valList>`, and if not found right one.
- Inserted `mode="add"`

Did this to 45 files.
I have tested the result in that it builds on my local laptop, passing the tests.
I have not tested in that I have not looked to see if it worked, i.e. to see if it fixes the problem. Too tired right now. G’night.