### PR TITLE
Fix build by passing $lang to schematron extraction

### DIFF
--- a/P5/Test/antruntest.xml
+++ b/P5/Test/antruntest.xml
@@ -216,6 +216,7 @@
     <echo level="info">XSLT generate ISO schematron ${outputname}.isosch from compiled ODD </echo>
     <xslt processor="trax" force="yes" style="${odd2isosch}" in="${outputname}.odd.processed" out="${outputname}.isosch">
       <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <param name="lang" expression="${lang}"/>
     </xslt>
     <xslt processor="trax" force="yes" style="../Utilities/iso_schematron_message_xslt2.xsl" in="${outputname}.isosch" out="${outputname}.xsl">
       <factory name="net.sf.saxon.TransformerFactoryImpl"/>

--- a/P5/Test/expected-results/detest_odd_schematron.log
+++ b/P5/Test/expected-results/detest_odd_schematron.log
@@ -1,60 +1,33 @@
-Buildfile: /Users/syd/Documents/TEI_gitHub/P5/Test/antruntest.xml
+Buildfile: /TEI/P5/Test/antruntest.xml
 
 validateodd:
      [echo] Validate detest.odd as ODD ...
      [echo]  ... against RelaxNG (../p5odds.rng) with jing ...
      [echo]  ... against Schematron (../p5odds.message.isosch.xsl) with Saaxon via trax
-     [xslt] Processing /Users/syd/Documents/TEI_gitHub/P5/Test/detest.odd to /dev/null
-     [xslt] Loading stylesheet /Users/syd/Documents/TEI_gitHub/P5/p5odds.message.isosch.xsl
-     [xslt] 
-     [xslt]                   Error: both the versionDate and xml:lang attributes on "remarks" are required when it is a child of "elementSpec".
-     [xslt]                  (@xml:lang and @versionDate)
-     [xslt] 
-     [xslt]                   Error: both the versionDate and xml:lang attributes on "gloss" are required when it is a child of "elementSpec".
-     [xslt]                  (@xml:lang and @versionDate)
-     [xslt] 
-     [xslt]                   Error: both the versionDate and xml:lang attributes on "desc" are required when it is a child of "elementSpec".
-     [xslt]                  (@xml:lang and @versionDate)
-     [xslt] 
-     [xslt]                   Error: both the versionDate and xml:lang attributes on "gloss" are required when it is a child of "attDef".
-     [xslt]                  (@xml:lang and @versionDate)
-     [xslt] 
-     [xslt]                   Error: both the versionDate and xml:lang attributes on "remarks" are required when it is a child of "elementSpec".
-     [xslt]                  (@xml:lang and @versionDate)
+     [xslt] Processing /TEI/P5/Test/detest.odd to /dev/null
+     [xslt] Loading stylesheet /TEI/P5/p5odds.message.isosch.xsl
+     [xslt]  Error: both the versionDate and xml:lang attributes on "remarks" are required when it is a child of "elementSpec". (@xml:lang and @versionDate)
+     [xslt]  Error: both the versionDate and xml:lang attributes on "gloss" are required when it is a child of "elementSpec". (@xml:lang and @versionDate)
+     [xslt]  Error: both the versionDate and xml:lang attributes on "desc" are required when it is a child of "elementSpec". (@xml:lang and @versionDate)
+     [xslt]  Error: both the versionDate and xml:lang attributes on "gloss" are required when it is a child of "attDef". (@xml:lang and @versionDate)
+     [xslt]  Error: both the versionDate and xml:lang attributes on "remarks" are required when it is a child of "elementSpec". (@xml:lang and @versionDate)
      [xslt] An element reference is not repeatable when part of a schema specification (and thus this &lt;elementRef&gt; should not have @minOccurs or @maxOccurs). (@minOccurs | @maxOccurs / error)
      [xslt] An element reference within a content model must refer to a locally defined element specification (and thus this &lt;elementRef&gt; should not have @source). (@source / error)
      [xslt] In the context of tagset documentation, the listRef element must not self-nest. (tei:listRef)
      [xslt] In the context of tagset documentation, each ptr or ref element inside a listRef must have a target attribute with only 1 pointer as its value. (@target and not( matches( @target,'\s') ))
      [xslt] In the context of tagset documentation, each ptr or ref element inside a listRef must have a target attribute with only 1 pointer as its value. (@target and not( matches( @target,'\s') ))
-     [xslt] 
-     [xslt]                   class membership (in this case of l) should be specified in sorted order, except att.global goes first.
-     [xslt]                  (string-join( $keys_as_specified ) eq string-join( $keys_in_order ))
-     [xslt] Rules
-     [xslt]           in the ISO Schematron language must be inside a constraintSpec
-     [xslt]           with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
-     [xslt] Rules
-     [xslt]           in the ISO Schematron language must be inside a constraintSpec
-     [xslt]           with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
-     [xslt] Rules
-     [xslt]           in the ISO Schematron language must be inside a constraintSpec
-     [xslt]           with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
+     [xslt]  class membership (in this case of l) should be specified in sorted order, except att.global goes first. (string-join( $keys_as_specified ) eq string-join( $keys_in_order ))
+     [xslt] Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
+     [xslt] Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
+     [xslt] Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
      [xslt] The use of an &lt;sch:assert&gt; or &lt;sch:report&gt; that does not have a context (i.e., does not have an ancestor &lt;sch:rule&gt; with a @context attribute) in an ISO Schematron constraint specification is deprecated, and will become invalid after 2025-03-15. (( $assertsHaveContext, $reportsHaveContext ) = false() / warning)
      [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified. (@scheme)
      [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is "replace". (@scheme)
      [xslt] Since the @default-is-in-list-req attribute is required, it will always be specified. Thus the default value (of "ONE") will never be used. Either change the definition of the attribute so it is not required ("rec" or "opt"), or remove the defaultVal element. (tei:defaultVal)
      [xslt] Since the @default-NOT-in-list-req attribute is required, it will always be specified. Thus the default value (of "ONE") will never be used. Either change the definition of the attribute so it is not required ("rec" or "opt"), or remove the defaultVal element. (tei:defaultVal)
-     [xslt] In the elementSpec defining
-     [xslt]         blort2 the default value of the
-     [xslt]         @default-NOT-in-list-opt attribute is not among the closed list of possible
-     [xslt]         values (string(tei:defaultVal) = tei:valList/tei:valItem/@ident)
-     [xslt] In the elementSpec defining
-     [xslt]         blort2 the default value of the
-     [xslt]         @default-NOT-in-list-rec attribute is not among the closed list of possible
-     [xslt]         values (string(tei:defaultVal) = tei:valList/tei:valItem/@ident)
-     [xslt] In the elementSpec defining
-     [xslt]         blort2 the default value of the
-     [xslt]         @default-NOT-in-list-req attribute is not among the closed list of possible
-     [xslt]         values (string(tei:defaultVal) = tei:valList/tei:valItem/@ident)
+     [xslt] In the elementSpec defining blort2 the default value of the @default-NOT-in-list-opt attribute is not among the closed list of possible values (string(tei:defaultVal) = tei:valList/tei:valItem/@ident)
+     [xslt] In the elementSpec defining blort2 the default value of the @default-NOT-in-list-rec attribute is not among the closed list of possible values (string(tei:defaultVal) = tei:valList/tei:valItem/@ident)
+     [xslt] In the elementSpec defining blort2 the default value of the @default-NOT-in-list-req attribute is not among the closed list of possible values (string(tei:defaultVal) = tei:valList/tei:valItem/@ident)
 
 BUILD SUCCESSFUL
-Total time: 2 seconds
+Total time: 0 seconds

--- a/P5/Test/expected-results/detest_xml_schematron.log
+++ b/P5/Test/expected-results/detest_xml_schematron.log
@@ -2,68 +2,30 @@ The @generatedBy attribute is for use within a &lt;post&gt; element. (ancestor-o
 The @generatedBy attribute is for use within a &lt;post&gt; element. (ancestor-or-self::tei:post)
 The abbr element should not be categorized in detail with @subtype unless also categorized in general with @type (@type)
 The div element should not be categorized in detail with @subtype unless also categorized in general with @type (@type)
-
-The element indicated by @spanTo (#ds2) must follow the current element delSpan
+ The element indicated by @spanTo (#ds2) must follow the current element delSpan
           (id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)])
-
-The element indicated by @spanTo (notMeaningful) must follow the current element delSpan
+ The element indicated by @spanTo (notMeaningful) must follow the current element delSpan
           (id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)])
-
-              @schemeVersion can only be used if @scheme is specified.
-             (@scheme and not(@scheme = 'free'))
- @calendar indicates one or more
-              systems or calendars to which the date represented by the content of this element belongs,
-              but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
+ @schemeVersion can only be used if @scheme is specified. (@scheme and not(@scheme = 'free'))
+ @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this date element has no textual content. (string-length( normalize-space(.) ) gt 0)
 The content of a "gloss" list should include a sequence of one or more pairs of a label element followed by an item element (tei:label)
 An lg element must contain at least one child l, lg, or gap element. (count(descendant::tei:lg|descendant::tei:l|descendant::tei:gap) &gt; 0)
-
-          On quotation, either the @marks attribute should be used, or a paragraph of description provided
-         (not( @marks ) and not( tei:p ))
+ On quotation, either the @marks attribute should be used, or a paragraph of description provided (not( @marks ) and not( tei:p ))
 You may not nest one s element within another: use seg instead (tei:s)
-
-          Only one of the attributes @target and @from may be supplied on span
+ Only one of the attributes @target and @from may be supplied on span
           (@from and @target)
-
-          Only one of the attributes @target and @to may be supplied on span
+ Only one of the attributes @target and @to may be supplied on span
           (@to and @target)
-
-          If @to is supplied on span, @from must be supplied as well
-         (@to and not(@from))
-
-              The @location value "external" is inconsistent with the
-              parallel-segmentation method of apparatus markup. (@location eq 'external' and @method eq 'parallel-segmentation')
-
-          A facsimile element represents a text with images, thus
-          transcribed text should not be present within it.
-         (child::text()[ normalize-space(.) ne ''])
-
-          A facsimile element represents a text with images, thus
-          transcribed text should not be present within it.
-         (child::text()[ normalize-space(.) ne ''])
-
-          A facsimile element represents a text with images, thus
-          transcribed text should not be present within it.
-         (child::text()[ normalize-space(.) ne ''])
-
-          A facsimile element represents a text with images, thus
-          transcribed text should not be present within it.
-         (child::text()[ normalize-space(.) ne ''])
-
-          A facsimile element represents a text with images, thus
-          transcribed text should not be present within it.
-         (child::text()[ normalize-space(.) ne ''])
-
-          A facsimile element represents a text with images, thus
-          transcribed text should not be present within it.
-         (child::text()[ normalize-space(.) ne ''])
-
-          A facsimile element represents a text with images, thus
-          transcribed text should not be present within it.
-         (child::text()[ normalize-space(.) ne ''])
-
-          A facsimile element represents a text with images, thus
-          transcribed text should not be present within it.
-         (child::text()[ normalize-space(.) ne ''])
+ If @to is supplied on span, @from must be supplied as well (@to and not(@from))
+ The @location value "external" is inconsistent with the parallel-segmentation method of apparatus markup. (@location eq 'external' and @method eq 'parallel-segmentation')
+ A facsimile element represents a text with images, thus transcribed text should not be present within it. (child::text()[ normalize-space(.) ne ''])
+ A facsimile element represents a text with images, thus transcribed text should not be present within it. (child::text()[ normalize-space(.) ne ''])
+ A facsimile element represents a text with images, thus transcribed text should not be present within it. (child::text()[ normalize-space(.) ne ''])
+ A facsimile element represents a text with images, thus transcribed text should not be present within it. (child::text()[ normalize-space(.) ne ''])
+ A facsimile element represents a text with images, thus transcribed text should not be present within it. (child::text()[ normalize-space(.) ne ''])
+ A facsimile element represents a text with images, thus transcribed text should not be present within it. (child::text()[ normalize-space(.) ne ''])
+ A facsimile element represents a text with images, thus transcribed text should not be present within it. (child::text()[ normalize-space(.) ne ''])
+ A facsimile element represents a text with images, thus transcribed text should not be present within it. (child::text()[ normalize-space(.) ne ''])
 The @spanTo attribute of delSpan is required. (@spanTo)
 The @spanTo attribute of delSpan is required. (@spanTo)
 subst must have at least one child add and at least one child del or surplus (child::tei:add and (child::tei:del or child::tei:surplus))
@@ -72,20 +34,10 @@ subst must have at least one child add and at least one child del or surplus (ch
 subst must have at least one child add and at least one child del or surplus (child::tei:add and (child::tei:del or child::tei:surplus))
 subst must have at least one child add and at least one child del or surplus (child::tei:add and (child::tei:del or child::tei:surplus))
 subst must have at least one child add and at least one child del or surplus (child::tei:add and (child::tei:del or child::tei:surplus))
-
-          Only one physDesc is allowed as a child of msDesc.
-         (preceding-sibling::*[ name(.) eq $gi ] and not( following-sibling::*[ name(.) eq $gi ] ))
-
-          Only one history is allowed as a child of msDesc.
-         (preceding-sibling::*[ name(.) eq $gi ] and not( following-sibling::*[ name(.) eq $gi ] ))
-
-          Only one additional is allowed as a child of msDesc.
-         (preceding-sibling::*[ name(.) eq $gi ] and not( following-sibling::*[ name(.) eq $gi ] ))
+ Only one physDesc is allowed as a child of msDesc. (preceding-sibling::*[ name(.) eq $gi ] and not( following-sibling::*[ name(.) eq $gi ] ))
+ Only one history is allowed as a child of msDesc. (preceding-sibling::*[ name(.) eq $gi ] and not( following-sibling::*[ name(.) eq $gi ] ))
+ Only one additional is allowed as a child of msDesc. (preceding-sibling::*[ name(.) eq $gi ] and not( following-sibling::*[ name(.) eq $gi ] ))
 In the context of tagset documentation, the listRef element must not self-nest. (tei:listRef)
 In the context of tagset documentation, each ptr or ref element inside a listRef must have a target attribute with only 1 pointer as its value. (@target and not( matches( @target,'\s') ))
 In the context of tagset documentation, each ptr or ref element inside a listRef must have a target attribute with only 1 pointer as its value. (@target and not( matches( @target,'\s') ))
-              
-          The @new attribute should always be supplied; use the special value
-          "normal" to indicate that the feature concerned ceases to be
-          remarkable at this point.
-         (@new / warning)
+ The @new attribute should always be supplied; use the special value "normal" to indicate that the feature concerned ceases to be remarkable at this point. (@new / warning)

--- a/P5/antbuilder.xml
+++ b/P5/antbuilder.xml
@@ -126,6 +126,7 @@
     <echo>step 7: p5.xml → p5.isosch</echo>    
     <xslt processor="trax" force="yes" style="${XSL}/odds/extract-isosch.xsl" in="${inputDir}/p5.xml" out="p5.isosch">
       <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <param name="lang" expression="${lang}"/>
     </xslt>
     <echo>step 8: p5.isosch → p5.isosch.xsl</echo>
     <xslt processor="trax" force="yes" style="Utilities/iso_svrl_for_xslt2.xsl" in="p5.isosch" out="p5.isosch.xsl">


### PR DESCRIPTION
The fix for Stylesheets [#702](https://github.com/TEIC/Stylesheets/issues/702) (i.e., [PR 704](https://github.com/TEIC/Stylesheets/pull/704)) caused the TEI build to break, because the natural language being processed was not being handed to extract-isosch.xsl, which it now needs to know. This fixes said problem. It passed all tests in Docker on my system.