### PR TITLE
add xml:lang to constraint specifications

### DIFF
--- a/P5/Exemplars/isofs.odd
+++ b/P5/Exemplars/isofs.odd
@@ -38,7 +38,7 @@
 	 <moduleRef key="tei"/>
 	 <moduleRef key="iso-fs"/>
 	 <elementSpec ident="fLib" mode="change">
-	   <constraintSpec ident="c1" scheme="schematron" mode="add">
+	   <constraintSpec ident="c1" scheme="schematron" mode="add" xml:lang="zxx">
 	     <constraint>
 	       <ns xmlns="http://purl.oclc.org/dsdl/schematron" prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
 	     </constraint>

--- a/P5/Exemplars/tei_enrich.odd
+++ b/P5/Exemplars/tei_enrich.odd
@@ -3451,7 +3451,7 @@ which should be supported by a more detailed description using the
           <!-- constrain date attributes -->
 
           <elementSpec ident="date" mode="change" module="core">
-            <constraintSpec scheme="schematron" ident="dates">
+            <constraintSpec scheme="schematron" ident="dates" xml:lang="en">
               <constraint>
 		<sch:rule context="tei:date">
                   <sch:assert test="@when  or  (@notAfter and @notBefore)  or  (@from and @to)">

--- a/P5/Exemplars/tei_jtei.odd
+++ b/P5/Exemplars/tei_jtei.odd
@@ -1905,7 +1905,7 @@
                 <elementRef key="author" minOccurs="1" maxOccurs="unbounded"/>
               </sequence>              
             </content>
-            <constraintSpec ident="jtei.sch-title" scheme="schematron">
+            <constraintSpec ident="jtei.sch-title" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:titleStmt">
                   <sch:assert test="tei:title[@type = 'main']" sqf:fix="type.add">
@@ -1922,7 +1922,7 @@
             </constraintSpec>
           </elementSpec>
           <elementSpec ident="respStmt" module="header" mode="change">
-            <constraintSpec ident="jtei.sch-respSmt" scheme="schematron">
+            <constraintSpec ident="jtei.sch-respSmt" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:respStmt">
                   <sch:assert test="ancestor::tei:sourceDesc">
@@ -1959,7 +1959,7 @@
             </attList>
           </elementSpec>
           <elementSpec ident="att" module="tagdocs" mode="change">
-            <constraintSpec ident="jtei.sch-att" scheme="schematron">
+            <constraintSpec ident="jtei.sch-att" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:att">
                   <sch:assert test="not(matches(., '^@'))">
@@ -2154,7 +2154,7 @@
             </attList>
           </classSpec>
           <elementSpec ident="author" mode="change" module="core">
-            <constraintSpec ident="jtei.sch-author" scheme="schematron">
+            <constraintSpec ident="jtei.sch-author" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:titleStmt/tei:author">
                   <sch:assert test="tei:name and tei:affiliation and tei:email" see="https://tei-c.org/release/doc/tei-p5-exemplars/html/tei_jtei.doc.html#structure">
@@ -2174,7 +2174,7 @@
             </attList>
           </elementSpec>
           <elementSpec ident="bibl" mode="change" module="core">
-            <constraintSpec ident="jtei.sch-bibl-id" scheme="schematron">
+            <constraintSpec ident="jtei.sch-bibl-id" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:back/tei:div[@type eq 'bibliography']//tei:bibl"
                   see="https://tei-c.org/release/doc/tei-p5-exemplars/html/tei_jtei.doc.html#back"
@@ -2185,7 +2185,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-bibl-orphan" scheme="schematron">
+            <constraintSpec ident="jtei.sch-bibl-orphan" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:back/tei:div[@type eq 'bibliography']//tei:bibl"
                   role="warning">
@@ -2196,7 +2196,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-bibl-endpunctuation" scheme="schematron">
+            <constraintSpec ident="jtei.sch-bibl-endpunctuation" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:back/tei:div[@type eq 'bibliography']//tei:bibl"
                   see="https://tei-c.org/release/doc/tei-p5-exemplars/html/tei_jtei.doc.html#back"
@@ -2211,7 +2211,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-title-journal-CMOS" scheme="schematron">
+            <constraintSpec ident="jtei.sch-title-journal-CMOS" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:bibl/tei:title[@level='j']"
                   role="warning">
@@ -2258,7 +2258,7 @@
                 <classRef key="model.ptrLike"/>
               </alternate>
             </content>
-            <constraintSpec ident="jtei.sch-cit" scheme="schematron">
+            <constraintSpec ident="jtei.sch-cit" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:cit" role="warning">
                   <sch:assert test="tei:ref"
@@ -2283,7 +2283,7 @@
             </attList>
           </elementSpec>
           <elementSpec ident="div" mode="change">
-            <constraintSpec ident="jtei.sch-divtypes-front" scheme="schematron">
+            <constraintSpec ident="jtei.sch-divtypes-front" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:div[@type = $div.types.front]">
                   <sch:assert test="parent::tei:front"
@@ -2292,7 +2292,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-divtypes-front2" scheme="schematron">
+            <constraintSpec ident="jtei.sch-divtypes-front2" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:front/tei:div">
                   <sch:assert test="@type = $div.types.front"
@@ -2302,7 +2302,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-divtypes-back" scheme="schematron">
+            <constraintSpec ident="jtei.sch-divtypes-back" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:div[@type = ('bibliography', 'appendix')]"
                   see="https://tei-c.org/release/doc/tei-p5-exemplars/html/tei_jtei.doc.html#back">
@@ -2311,7 +2311,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-divtypes-body" scheme="schematron">
+            <constraintSpec ident="jtei.sch-divtypes-body" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:div[@type = ('editorialIntroduction')]">
                   <sch:assert test="parent::tei:body"
@@ -2321,7 +2321,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-div-head" scheme="schematron">
+            <constraintSpec ident="jtei.sch-div-head" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:body//tei:div[not(@type = ('editorialIntroduction'))]">
                   <sch:assert test="tei:head"
@@ -2578,7 +2578,7 @@
             </attList>
           </elementSpec>
           <elementSpec ident="note" mode="change">
-            <constraintSpec ident="jtei.sch-note-punctuation" scheme="schematron">
+            <constraintSpec ident="jtei.sch-note-punctuation" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:note">
                   <sch:assert
@@ -2622,7 +2622,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-note-blocks" scheme="schematron">
+            <constraintSpec ident="jtei.sch-note-blocks" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:note">
                   <sch:report
@@ -2642,7 +2642,7 @@
           </elementSpec>
           
           <elementSpec ident="head" module="core" mode="change">
-            <constraintSpec ident="jtei.sch-head-number" scheme="schematron">
+            <constraintSpec ident="jtei.sch-head-number" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:head">
                   <sch:report
@@ -2654,7 +2654,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-figure-head" scheme="schematron">
+            <constraintSpec ident="jtei.sch-figure-head" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:figure/tei:head">
                   <sch:assert test="@type = ('legend', 'license')"
@@ -2731,7 +2731,7 @@
             </attList>
           </elementSpec>
           <elementSpec ident="ptr" mode="change">
-            <constraintSpec ident="jtei.sch-ptr-multipleTargets" scheme="schematron">
+            <constraintSpec ident="jtei.sch-ptr-multipleTargets" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:ptr[not(@type='crossref')]">
                   <sch:report test="count(tokenize(normalize-space(@target), '\s+')) > 1"
@@ -2763,7 +2763,7 @@
             </attList>
           </elementSpec>
           <elementSpec ident="quote" mode="change" module="core">
-            <constraintSpec ident="jtei.sch-core" scheme="schematron">
+            <constraintSpec ident="jtei.sch-core" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:quote">
                   <sch:assert
@@ -2779,7 +2779,7 @@
             </attList>
           </elementSpec>
           <elementSpec ident="ref" mode="change" module="core">
-            <constraintSpec ident="jtei.sch-ref-multipleTargets" scheme="schematron">
+            <constraintSpec ident="jtei.sch-ref-multipleTargets" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:ref">
                   <sch:report test="count(tokenize(normalize-space(@target), '\s+')) > 1"
@@ -2788,7 +2788,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-biblref-parentheses" scheme="schematron">
+            <constraintSpec ident="jtei.sch-biblref-parentheses" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:ref[@type eq 'bibl']">
                   <sch:assert test="not(matches(., '^\(.*\)$'))"
@@ -2798,7 +2798,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-biblref-target" scheme="schematron">
+            <constraintSpec ident="jtei.sch-biblref-target" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:ref[@type eq 'bibl']">
                   <sch:assert
@@ -2809,7 +2809,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-biblref-type" scheme="schematron">
+            <constraintSpec ident="jtei.sch-biblref-type" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:ref[id(substring-after(@target, '#'))/self::tei:bibl]">
                   <sch:assert test="@type eq 'bibl'"
@@ -2847,7 +2847,7 @@
             </attList>
           </elementSpec>
           <elementSpec ident="rendition" mode="change" module="header">
-            <constraintSpec ident="jtei.sch-rendition" scheme="schematron">
+            <constraintSpec ident="jtei.sch-rendition" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:rendition">
                   <sch:assert test="key('idrefs', @xml:id)[. instance of attribute(rendition)]">
@@ -2893,7 +2893,7 @@
             <desc xml:lang="en" versionDate="2015-03-03">contains the complete text of the article. Must include a 
             <gi>front</gi> containing an abstract, a <gi>body</gi> containing the main 
             text, and a <gi>back</gi> containing the bibliography and any appendices.</desc>
-            <constraintSpec ident="jtei.sch-article-keywords" scheme="schematron">
+            <constraintSpec ident="jtei.sch-article-keywords" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:text[not(tei:body/tei:div[@type = ('editorialIntroduction')])]">
                   <sch:assert
@@ -2904,7 +2904,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-article-abstract" scheme="schematron">
+            <constraintSpec ident="jtei.sch-article-abstract" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:text[not(tei:body/tei:div[@type = ('editorialIntroduction')])]">
                   <sch:assert test="tei:front/tei:div[@type='abstract']"
@@ -2913,7 +2913,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-article-back" scheme="schematron">
+            <constraintSpec ident="jtei.sch-article-back" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:text[not(tei:body/tei:div[@type = ('editorialIntroduction')])]">
                   <sch:assert test="tei:back/tei:div[@type='bibliography']/tei:listBibl"
@@ -3024,7 +3024,7 @@
 -->              
               <!--</alternate>-->
             </content>
-            <constraintSpec ident="jtei.sch-body" scheme="schematron">
+            <constraintSpec ident="jtei.sch-body" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:body[child::tei:div[not(@type=('editorialIntroduction'))]]">
                   <sch:assert test="count(child::tei:div) gt 1"
@@ -3038,7 +3038,7 @@
             </constraintSpec>
           </elementSpec>
           <elementSpec ident="back" module="textstructure" mode="change">
-            <constraintSpec ident="jtei.sch-back" scheme="schematron">
+            <constraintSpec ident="jtei.sch-back" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:back">
                   <sch:assert test="tei:div[@type='bibliography']/tei:listBibl"
@@ -3050,7 +3050,7 @@
             </constraintSpec>
           </elementSpec>
           
-          <constraintSpec ident="jtei.sch-ns" scheme="schematron">
+          <constraintSpec ident="jtei.sch-ns" scheme="schematron" xml:lang="zxx">
             <constraint>
               <sch:ns prefix="sch" uri="http://purl.oclc.org/dsdl/schematron"/>
               <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
@@ -3059,7 +3059,7 @@
               <sch:ns prefix="eg" uri="http://www.tei-c.org/ns/Examples"/>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-variables" scheme="schematron">
+          <constraintSpec ident="jtei.sch-variables" scheme="schematron" xml:lang="zxx">
             <constraint>
               <sch:pattern>
                 <xsl:key name="idrefs" match="@target[starts-with(normalize-space(.), '#')]|@rendition[starts-with(normalize-space(.), '#')]" use="for $i in tokenize(., '\s+') return substring-after($i, '#')"/>
@@ -3076,7 +3076,7 @@
             </constraint>
           </constraintSpec>
           <elementSpec ident="tag" module="tagdocs" mode="change">
-            <constraintSpec ident="jtei.sch-tag" scheme="schematron">
+            <constraintSpec ident="jtei.sch-tag" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:tag">
                   <sch:assert test="not(matches(., '^[&lt;!?-]|[&gt;/?\-]$'))"
@@ -3089,7 +3089,7 @@
           </elementSpec>
           
           <elementSpec ident="val" module="tagdocs" mode="change">
-            <constraintSpec ident="jtei.sch-val" scheme="schematron">
+            <constraintSpec ident="jtei.sch-val" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:val">
                   <sch:assert test="not(matches(., concat('^', $quotes, '|', $quotes, '$')))"
@@ -3101,7 +3101,7 @@
             </constraintSpec>
           </elementSpec>
           <elementSpec ident="supplied" module="transcr" mode="change">
-            <constraintSpec ident="jtei.sch-supplied" scheme="schematron">
+            <constraintSpec ident="jtei.sch-supplied" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:supplied">
                   <sch:assert test="not(matches(., '^\[|\]$'))"
@@ -3114,7 +3114,7 @@
           </elementSpec>
           
           <elementSpec ident="idno" module="header" mode="change">
-            <constraintSpec ident="jtei.sch-doi-order" scheme="schematron">
+            <constraintSpec ident="jtei.sch-doi-order" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:back/tei:div[@type eq 'bibliography']//tei:idno[@type eq 'doi']">
                   <sch:report test="following-sibling::tei:ref"
@@ -3129,7 +3129,7 @@
 	    </attList> <!-- remove 2024-11-11 when @calender removed from <idno> -->
           </elementSpec>
           <elementSpec ident="graphic" module="core" mode="change">
-            <constraintSpec ident="jtei.sch-graphic-dimensions" scheme="schematron">
+            <constraintSpec ident="jtei.sch-graphic-dimensions" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:graphic">
                   <sch:assert test="matches(@width, '\d+px') and matches(@height, '\d+px')"
@@ -3139,7 +3139,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-graphic-context" scheme="schematron">
+            <constraintSpec ident="jtei.sch-graphic-context" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:graphic">
                   <sch:assert test="parent::tei:figure" see="https://tei-c.org/release/doc/tei-p5-exemplars/html/tei_jtei.doc.html#figures">
@@ -3149,7 +3149,7 @@
             </constraintSpec>
           </elementSpec>
           <elementSpec ident="front" module="textstructure" mode="change">
-            <constraintSpec ident="jtei.sch-front-abstract" scheme="schematron">
+            <constraintSpec ident="jtei.sch-front-abstract" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:front">
                   <sch:assert test="tei:div[@type='abstract']"
@@ -3161,7 +3161,7 @@
             </constraintSpec>            
           </elementSpec>
           <elementSpec ident="table" module="figures" mode="change">
-            <constraintSpec ident="jtei.sch-table" scheme="schematron">
+            <constraintSpec ident="jtei.sch-table" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:table">
                   <sch:assert test="not(ancestor::tei:list)"
@@ -3172,7 +3172,7 @@
             </constraintSpec>
           </elementSpec>
           <elementSpec ident="gap" module="core" mode="change">
-            <constraintSpec ident="jtei.sch-gap" scheme="schematron">
+            <constraintSpec ident="jtei.sch-gap" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:gap">
                   <sch:report
@@ -3184,7 +3184,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="jtei.sch-gap-ws" scheme="schematron">
+            <constraintSpec ident="jtei.sch-gap-ws" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:gap">
                   <sch:report
@@ -3197,7 +3197,7 @@
             </constraintSpec>
           </elementSpec>
           
-          <constraintSpec ident="jtei.sch-straightApos" scheme="schematron">
+          <constraintSpec ident="jtei.sch-straightApos" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag|ancestor::tei:mentioned)]">
                 <sch:report test="matches(., $apos.straight)" 
@@ -3218,7 +3218,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-LRquotes" scheme="schematron">
+          <constraintSpec ident="jtei.sch-LRquotes" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag)][matches(., $apos.typographic)]" role="warning">
                 <sch:report test="matches(., '\W[’]\D') or matches(., '[‘](\W|$)') or matches(., '\w[‘]\w')"
@@ -3230,7 +3230,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-quotationMarks" scheme="schematron">
+          <constraintSpec ident="jtei.sch-quotationMarks" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag)]">
                 <sch:report
@@ -3241,7 +3241,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-doubleHyphens" scheme="schematron">
+          <constraintSpec ident="jtei.sch-doubleHyphens" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag|ancestor::tei:ref)]">
                 <sch:assert test="not(contains(., '--'))" sqf:fix="dash.replace">
@@ -3257,7 +3257,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-rangeHyphen" scheme="schematron">
+          <constraintSpec ident="jtei.sch-rangeHyphen" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag|ancestor::tei:idno|ancestor::tei:date)]">
                 <sch:assert test="not(matches(., '(^|[\W-[-]])\d+-\d+([\W-[-]]|$)'))" sqf:fix="hyphen.replace">
@@ -3273,7 +3273,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-ieEg" scheme="schematron">
+          <constraintSpec ident="jtei.sch-ieEg" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag)]">
                 <sch:report test="matches(., '(i\.e\.|e\.g\.)[^,]', 'i')" sqf:fix="comma.add">
@@ -3288,7 +3288,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-nonbreakingspace" scheme="schematron">
+          <constraintSpec ident="jtei.sch-nonbreakingspace" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule role="warning" context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag)]">
                 <sch:report test="matches(., '&#160;')" sqf:fix="nonbreakingspace.remove">
@@ -3304,7 +3304,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-localLinkTarget" scheme="schematron">
+          <constraintSpec ident="jtei.sch-localLinkTarget" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="@*[self::attribute(corresp)|self::attribute(target)|self::attribute(from)|self::attribute(to)|self::attribute(ref)|self::attribute(rendition)|self::attribute(resp)|self::attribute(source)][not(ancestor::eg:egXML)][some $i in tokenize(., '\s+') satisfies starts-with($i, '#')]">
                 <sch:let name="orphan.pointers"
@@ -3315,7 +3315,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-renditionTarget" scheme="schematron">
+          <constraintSpec ident="jtei.sch-renditionTarget" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="@rendition">
                 <sch:let name="orphan.pointers"
@@ -3326,7 +3326,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-quoteDelim" scheme="schematron">
+          <constraintSpec ident="jtei.sch-quoteDelim" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="tei:title[@level eq 'a']|tei:mentioned|tei:soCalled|tei:quote|tei:q">
                 <sch:assert test="not(matches(., concat('^', $double.quotes, '|', $double.quotes, '$')))" sqf:fix="quotation.remove">
@@ -3341,7 +3341,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-crossref-id" scheme="schematron">
+          <constraintSpec ident="jtei.sch-crossref-id" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="tei:body//tei:div[not(@type='editorialIntroduction')]|tei:figure|tei:table"
                 role="warning">
@@ -3352,7 +3352,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-formalCrossref" scheme="schematron">
+          <constraintSpec ident="jtei.sch-formalCrossref" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="text()[not(ancestor::tei:eg|ancestor::eg:egXML|ancestor::tei:code|ancestor::tei:tag|ancestor::tei:ref[not(@type='crossref')])]"
                 role="warning">
@@ -3363,7 +3363,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-crossrefTargetType" scheme="schematron">
+          <constraintSpec ident="jtei.sch-crossrefTargetType" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="tei:ptr[@type='crossref']|tei:ref[@type='crossref']">
                 <sch:let name="orphan.pointers"
@@ -3375,7 +3375,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-crossrefType" scheme="schematron">
+          <constraintSpec ident="jtei.sch-crossrefType" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="tei:ptr[not(@type='crossref')]|tei:ref[not(@type='crossref')]">
                 <sch:report test="id(substring-after(@target, '#'))/(self::tei:div|self::tei:figure|self::tei:table)" sqf:fix="crossreftype.add">
@@ -3390,7 +3390,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-centuries" scheme="schematron">
+          <constraintSpec ident="jtei.sch-centuries" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="text()[not(ancestor::tei:quote or ancestor::tei:title)]">
                 <sch:assert test="not(matches(., '\d\d?((th)|(st)|(rd)|(nd))[- ]centur((y)|(ies))', 'i'))">
@@ -3399,7 +3399,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.sch-teiVersion" scheme="schematron">
+          <constraintSpec ident="jtei.sch-teiVersion" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="@target[matches(., '^https?://(www\.)?tei-c\.org/release/doc/tei-p5-doc')]">
                 <sch:assert test="false()" sqf:fix="teiURL.fix">
@@ -3418,7 +3418,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="jtei.jtei-url" scheme="schematron">
+          <constraintSpec ident="jtei.jtei-url" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="@target[matches(., '^https?://(www\.)?jtei\.revues\.org/?')]" role="warning">
                 <sch:let name="URL.fixed" value="replace(., '^https?://(www\.)?jtei\.revues\.org/?', 'https://journals.openedition.org/jtei/')"/>

--- a/P5/Exemplars/tei_simplePrint.odd
+++ b/P5/Exemplars/tei_simplePrint.odd
@@ -3481,7 +3481,7 @@ live without God in the world, and only mind earthly things.
             <classSpec type="atts" ident="att.pointing" mode="change">
               <attList>
                 <attDef ident="target" mode="change">
-                  <constraintSpec ident="validtarget" scheme="schematron">
+                  <constraintSpec ident="validtarget" scheme="schematron" xml:lang="en">
                     <constraint>
                       <sch:rule context="tei:*[@target]">
 			<!-- If & when we are confident the processor
@@ -3501,7 +3501,7 @@ live without God in the world, and only mind earthly things.
               </attList>
             </classSpec>
             <classSpec type="atts" ident="att.global.rendition" mode="change">
-              <constraintSpec ident="renditionpointer" scheme="schematron">
+              <constraintSpec ident="renditionpointer" scheme="schematron" xml:lang="en">
                 <constraint>
                   <sch:rule context="tei:*[@rendition]">
                     <sch:let name="results"
@@ -3516,7 +3516,7 @@ live without God in the world, and only mind earthly things.
                   </sch:rule>
                 </constraint>
               </constraintSpec>
-              <constraintSpec ident="corresppointer" scheme="schematron">
+              <constraintSpec ident="corresppointer" scheme="schematron" xml:lang="en">
                 <constraint>
                   <sch:rule context="tei:*[@corresp]">
                     <sch:let name="results"
@@ -4000,7 +4000,7 @@ live without God in the world, and only mind earthly things.
             </elementSpec>
 
             <elementSpec ident="bibl" mode="change">
-              <constraintSpec mode="add" ident="noEmptyBibl" scheme="schematron">
+              <constraintSpec mode="add" ident="noEmptyBibl" scheme="schematron" xml:lang="en">
                 <constraint>
 		   <sch:rule context="tei:bibl">		   		  
                      <sch:assert test="child::* or child::text()[normalize-space()]" role="ERROR">
@@ -4118,7 +4118,7 @@ live without God in the world, and only mind earthly things.
               </model>
             </elementSpec>
             <elementSpec ident="choice" mode="change">
-              <constraintSpec ident="choiceContent" scheme="schematron" mode="add">
+              <constraintSpec ident="choiceContent" scheme="schematron" mode="add" xml:lang="en">
                 <constraint>
 		  <sch:rule context="tei:choice">
 		    <sch:assert test="( tei:corr and tei:sic )
@@ -5092,7 +5092,7 @@ live without God in the world, and only mind earthly things.
 
             </elementSpec>
             <elementSpec ident="text" mode="change">
-              <constraintSpec ident="headeronlyelement" scheme="schematron">
+              <constraintSpec ident="headeronlyelement" scheme="schematron" xml:lang="en">
                 <constraint>
                   <!-- <sch:rule
                     context="tei:att | tei:biblFull | tei:biblStruct | tei:change | tei:charDecl | tei:charProp | tei:editor

--- a/P5/Source/Specs/TEI.xml
+++ b/P5/Source/Specs/TEI.xml
@@ -42,19 +42,19 @@
       </alternate>
     </sequence>
   </content>
-  <constraintSpec ident="c1" scheme="schematron">
+  <constraintSpec ident="c1" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
       <sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="c2" scheme="schematron">
+  <constraintSpec ident="c2" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:ns prefix="rng" uri="http://relaxng.org/ns/structure/1.0"/>
       <sch:ns prefix="rna" uri="http://relaxng.org/ns/compatibility/annotations/1.0"/>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="c3" scheme="schematron">
+  <constraintSpec ident="c3" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:ns prefix="sch" uri="http://purl.oclc.org/dsdl/schematron"/>
       <sch:ns prefix="sch1x" uri="http://www.ascc.net/xml/schematron"/>

--- a/P5/Source/Specs/ab.xml
+++ b/P5/Source/Specs/ab.xml
@@ -28,7 +28,7 @@
   <content>
     <macroRef key="macro.abContent"/>
   </content>
-  <constraintSpec ident="abstractModel-structure-ab-in-l-or-lg" scheme="schematron">
+  <constraintSpec ident="abstractModel-structure-ab-in-l-or-lg" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:ab">
         <sch:report test="(ancestor::tei:l or ancestor::tei:lg) and not( ancestor::tei:floatingText |parent::tei:figure |parent::tei:note )">

--- a/P5/Source/Specs/addSpan.xml
+++ b/P5/Source/Specs/addSpan.xml
@@ -27,7 +27,7 @@
     <memberOf key="model.global.edit"/>
   </classes>
   <content><empty/></content>
-  <constraintSpec ident="addSpan-requires-spanTo" scheme="schematron">
+  <constraintSpec ident="addSpan-requires-spanTo" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:addSpan">
         <sch:assert test="@spanTo">The @spanTo attribute of <sch:name/> is required.</sch:assert>

--- a/P5/Source/Specs/alternate.xml
+++ b/P5/Source/Specs/alternate.xml
@@ -15,7 +15,7 @@
       <classRef key="model.contentPart"/>
     </alternate>
   </content>
-  <constraintSpec ident="alternatechilden" scheme="schematron">
+  <constraintSpec ident="alternatechilden" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:alternate">
         <sch:assert test="count(*) gt 1">The alternate element must have at least two child elements</sch:assert>

--- a/P5/Source/Specs/att.calendarSystem.xml
+++ b/P5/Source/Specs/att.calendarSystem.xml
@@ -20,7 +20,7 @@
       <datatype minOccurs="1" maxOccurs="unbounded">
         <dataRef key="teidata.pointer"/>
       </datatype>
-      <constraintSpec ident="calendar_attr_on_empty_element" scheme="schematron">
+      <constraintSpec ident="calendar_attr_on_empty_element" scheme="schematron" xml:lang="en">
         <constraint>
           <sch:rule context="tei:*[@calendar]">
             <sch:assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more

--- a/P5/Source/Specs/att.cmc.xml
+++ b/P5/Source/Specs/att.cmc.xml
@@ -11,7 +11,7 @@
       <datatype minOccurs="1" maxOccurs="1">
         <dataRef key="teidata.enumerated"/>
       </datatype>
-      <constraintSpec scheme="schematron" ident="CMC_generatedBy_within_post">
+      <constraintSpec scheme="schematron" ident="CMC_generatedBy_within_post" xml:lang="en">
         <constraint>
           <sch:rule context="tei:*[@generatedBy]">
             <sch:assert test="ancestor-or-self::tei:post">The @generatedBy attribute is for use within a &lt;post&gt; element.</sch:assert>

--- a/P5/Source/Specs/att.datable.w3c.xml
+++ b/P5/Source/Specs/att.datable.w3c.xml
@@ -13,21 +13,21 @@
   d'événements datés ou susceptibles de l'être.</desc>
   <desc versionDate="2007-11-06" xml:lang="it">indica degli attributi per la normalizzazione di elementi che contengono eventi databili utilizzando i tipi di dati del W3C</desc>
   <desc versionDate="2007-05-04" xml:lang="es">proporciona atributos para la normalización de elementos que contienen eventos datables.</desc>
-  <constraintSpec ident="att-datable-w3c-when" scheme="schematron">
+  <constraintSpec ident="att-datable-w3c-when" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:*[@when]">
         <sch:report test="@notBefore|@notAfter|@from|@to" role="nonfatal">The @when attribute cannot be used with any other att.datable.w3c attributes.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="att-datable-w3c-from" scheme="schematron">
+  <constraintSpec ident="att-datable-w3c-from" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:*[@from]">
         <sch:report test="@notBefore" role="nonfatal">The @from and @notBefore attributes cannot be used together.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="att-datable-w3c-to" scheme="schematron">
+  <constraintSpec ident="att-datable-w3c-to" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:*[@to]">
         <sch:report test="@notAfter" role="nonfatal">The @to and @notAfter attributes cannot be used together.</sch:report>

--- a/P5/Source/Specs/att.datcat.xml
+++ b/P5/Source/Specs/att.datcat.xml
@@ -52,7 +52,7 @@
     <p>The <att>datcat</att> attribute relates the feature <hi rend="italic">name</hi> (i.e., the key) to the data
       category <q>part of speech</q>, while the attribute <att>valueDatcat</att> relates the feature <hi rend="italic">value</hi> to the data category <term>common noun</term>. Both these data categories
       should be defined in an external and preferably open reference taxonomy or ontology.</p>
-    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="DATCAT-egXML-lh"> xmlns="http://www.tei-c.org/ns/Examples" xml:id="DATCAT-egXML-xk">
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="DATCAT-egXML-lh"> xmlns="http://www.tei-c.org/ns/Examples" xml:id="DATCAT-egXML-xk"&gt;
       <fs>
         <f name="POS" datcat="http://hdl.handle.net/11459/CCR_C-396_5a972b93-2294-ab5c-a541-7c344c5f26c3">
           <symbol valueDatcat="http://hdl.handle.net/11459/CCR_C-1256_7ec6083c-23d4-224d-6f94-eecbe6861545" value="NN"/>

--- a/P5/Source/Specs/att.deprecated.xml
+++ b/P5/Source/Specs/att.deprecated.xml
@@ -20,7 +20,7 @@
         -->
         <dataRef name="date"/>
       </datatype>
-      <constraintSpec scheme="schematron" ident="deprecation-two-month-warning">
+      <constraintSpec scheme="schematron" ident="deprecation-two-month-warning" xml:lang="en">
         <constraint>
           <sch:rule context="tei:*[@validUntil]">
             <sch:let name="advance_warning_period" value="current-date() + xs:dayTimeDuration('P60D')"/>
@@ -33,7 +33,7 @@
           </sch:rule>
         </constraint>
       </constraintSpec>
-      <constraintSpec scheme="schematron" ident="deprecation-should-be-explained">
+      <constraintSpec scheme="schematron" ident="deprecation-should-be-explained" xml:lang="en">
         <constraint>
           <sch:rule context="tei:*[@validUntil][ not( self::tei:valDesc | self::tei:valList | self::tei:defaultVal | self::tei:remarks )]">
             <sch:assert test="child::tei:desc[ @type eq 'deprecationInfo']">

--- a/P5/Source/Specs/att.gaijiProp.xml
+++ b/P5/Source/Specs/att.gaijiProp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<classSpec ident="att.gaijiProp" module="gaiji" type="atts" xml:id="class-attr-gaijiProp" xmlns="http://www.tei-c.org/ns/1.0">
+<classSpec xmlns="http://www.tei-c.org/ns/1.0" ident="att.gaijiProp" module="gaiji" type="atts" xml:id="class-attr-gaijiProp">
   <desc versionDate="2020-01-28" xml:lang="en">provides attributes for defining the properties of non-standard characters or glyphs.</desc>
   <desc versionDate="2020-01-28" xml:lang="de">liefert Attribute zur Definition der Eigenschaften von nicht standardisierten Zeichen und Glyphen.</desc>
   <desc versionDate="2020-02-05" xml:lang="it">fornisce attributi per definire le proprietà di caratteri o glifi non standard</desc>

--- a/P5/Source/Specs/att.global.source.xml
+++ b/P5/Source/Specs/att.global.source.xml
@@ -13,7 +13,7 @@
       <datatype maxOccurs="unbounded">
         <dataRef key="teidata.pointer"/>
       </datatype>
-      <constraintSpec scheme="schematron" ident="only_1_ODD_source">
+      <constraintSpec scheme="schematron" ident="only_1_ODD_source" xml:lang="en">
         <constraint>
           <sch:rule context="tei:*[@source]">
             <sch:let name="srcs" value="tokenize( normalize-space(@source),'&#x20;')"/>

--- a/P5/Source/Specs/att.identified.xml
+++ b/P5/Source/Specs/att.identified.xml
@@ -12,7 +12,7 @@
     
     <memberOf key="att.combinable"/>
   </classes>
-  <constraintSpec ident="spec-in-module" scheme="schematron">
+  <constraintSpec ident="spec-in-module" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:elementSpec[@module]|tei:classSpec[@module]|tei:macroSpec[@module]">
         <sch:assert test="(not(ancestor::tei:schemaSpec | ancestor::tei:TEI | ancestor::tei:teiCorpus)) or (not(@module) or (not(//tei:moduleSpec) and not(//tei:moduleRef)) or (//tei:moduleSpec[@ident = current()/@module]) or (//tei:moduleRef[@key = current()/@module]))">

--- a/P5/Source/Specs/att.lexicographic.normalized.xml
+++ b/P5/Source/Specs/att.lexicographic.normalized.xml
@@ -69,12 +69,12 @@
 
       <exemplum xml:lang="en">
         <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="ATTNORM-egXML-xv">
-          <w norm="Teil" xmlns="">Theyll</w>
+          <w xmlns="" norm="Teil">Theyll</w>
         </egXML>
       </exemplum>
       <exemplum xml:lang="en">
         <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="ATTNORM-egXML-le">
-          <w norm="Freude" xmlns="">Frewde</w>
+          <w xmlns="" norm="Freude">Frewde</w>
         </egXML>
       </exemplum>
     </attDef>

--- a/P5/Source/Specs/att.measurement.xml
+++ b/P5/Source/Specs/att.measurement.xml
@@ -10,7 +10,7 @@
       régularisée ou normalisée.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">proporciona atributos que representen una medición regularizada o normalizada.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">assegna degli attributi che rappresentano una misurazione regolarizzata o normalizzata</desc>
-  <constraintSpec ident="att-measurement-unitRef" scheme="schematron">
+  <constraintSpec ident="att-measurement-unitRef" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:*[@unitRef]">
         <sch:report test="@unit" role="info">The @unit attribute may be unnecessary when @unitRef is present.</sch:report>

--- a/P5/Source/Specs/att.pointing.xml
+++ b/P5/Source/Specs/att.pointing.xml
@@ -16,7 +16,7 @@
         according to <ref target="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</ref>.</desc>
       <desc versionDate="2023-09-27" xml:lang="ja"><ref target="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</ref>に従って生成された<soCalled>言語タグ</soCalled>を使用することで、<att>target</att>の参照先にあるコンテンツの言語を特定する。</desc>
       <datatype><dataRef key="teidata.language"/></datatype>
-      <constraintSpec ident="targetLang" scheme="schematron">
+      <constraintSpec ident="targetLang" scheme="schematron" xml:lang="en">
         <constraint>
           <sch:rule context="tei:*[not(self::tei:schemaSpec)][@targetLang]">
             <sch:assert test="@target">@targetLang should only be used on <sch:name/> if @target is specified.</sch:assert>

--- a/P5/Source/Specs/att.repeatable.xml
+++ b/P5/Source/Specs/att.repeatable.xml
@@ -8,7 +8,7 @@
   <!-- we know that @minOccurs is castable as an integer, and we know that -->
   <!-- @maxOccurs is either "unbounded" or castable as an integer, because -->
   <!-- they have passed standard grammar-based validation. -->
-  <constraintSpec ident="MINandMAXoccurs" scheme="schematron">
+  <constraintSpec ident="MINandMAXoccurs" scheme="schematron" xml:lang="en">
     <!-- <desc>The value of <att>minOccurs</att> should always be less than or
          equal to that of <att>maxOccurs</att>. Since the default value of
          <att>maxOccurs</att> is 1, when <att>maxOccurs</att> is not specified

--- a/P5/Source/Specs/att.spanning.xml
+++ b/P5/Source/Specs/att.spanning.xml
@@ -21,7 +21,7 @@
       <desc versionDate="2007-05-04" xml:lang="es">indica el final de un fragmento de texto iniciado con el elemento al cual es asignaado el atributo.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">indica la fine della porzione di testo che ha inizio con l'elemento a cui è assegnato l'attributo</desc>
       <datatype><dataRef key="teidata.pointer"/></datatype>
-      <constraintSpec ident="spanTo-points-to-following" scheme="schematron">
+      <constraintSpec ident="spanTo-points-to-following" scheme="schematron" xml:lang="en">
         <desc versionDate="2018-07-06" xml:lang="en">The @spanTo attribute must point to an element following the
         current element</desc>
         <constraint>

--- a/P5/Source/Specs/att.styleDef.xml
+++ b/P5/Source/Specs/att.styleDef.xml
@@ -62,7 +62,7 @@ If no value for the @scheme attribute is provided, then the default assumption s
     <attDef ident="schemeVersion" usage="opt">
       <desc versionDate="2013-04-12" xml:lang="en">supplies a version number for the style language provided in <att>scheme</att>.</desc>
       <datatype><dataRef key="teidata.versionNumber"/></datatype>
-      <constraintSpec ident="schemeVersionRequiresScheme" scheme="schematron">
+      <constraintSpec ident="schemeVersionRequiresScheme" scheme="schematron" xml:lang="en">
         <constraint>
           <sch:rule context="tei:*[@schemeVersion]">
             <sch:assert test="@scheme and not(@scheme = 'free')">

--- a/P5/Source/Specs/att.typed.xml
+++ b/P5/Source/Specs/att.typed.xml
@@ -10,7 +10,7 @@
       utilisés pour classer ou interclasser des éléments de n'importe quelle façon.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">proporciona atributos genéricos utilizables para cualquier clasificación o subclasificación de elementos.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">assegna degli attributi generici utilizzabili per qualsiasi classificazione e sottoclassificazione di elementi</desc>
-  <constraintSpec scheme="schematron" ident="subtypeTyped">
+  <constraintSpec scheme="schematron" ident="subtypeTyped" xml:lang="en">
     <constraint>
       <sch:rule context="tei:*[@subtype]">
         <sch:assert test="@type">The <sch:name/> element should not be categorized in detail with @subtype unless also categorized in general with @type</sch:assert>

--- a/P5/Source/Specs/attDef.xml
+++ b/P5/Source/Specs/attDef.xml
@@ -37,7 +37,7 @@
         <elementRef key="remarks" minOccurs="0" maxOccurs="unbounded"/>
     </sequence>
   </content>
-  <constraintSpec ident="attDefContents" scheme="schematron">
+  <constraintSpec ident="attDefContents" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:ns prefix="teix" uri="http://www.tei-c.org/ns/Examples"/>
       <sch:rule context="tei:attDef">
@@ -55,7 +55,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="noDefault4Required" scheme="schematron">
+  <constraintSpec ident="noDefault4Required" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:attDef[@usage eq 'req']">
         <sch:report test="tei:defaultVal">Since the @<sch:value-of select="@ident"/> attribute is required, it will always be specified. Thus the default value (of "<sch:value-of select="normalize-space(tei:defaultVal)"/>") will never be used. Either change the definition of the attribute so it is not required ("rec" or "opt"), or remove the defaultVal element.</sch:report>
@@ -68,7 +68,7 @@
   <!-- made them separate for now to make debugging easier. After we're -->
   <!-- confident these work properly, could condense them to one. -->
   <!-- -Syd, 2015-03-29 -->
-  <constraintSpec ident="defaultIsInClosedList-twoOrMore" scheme="schematron">
+  <constraintSpec ident="defaultIsInClosedList-twoOrMore" scheme="schematron" xml:lang="en">
     <!-- The use of the '>' operator (expressed as "&gt;"), below, is
          not needed for comparison of a sequence, but seems to
          automatically handle a left hand operand that is an
@@ -86,7 +86,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="defaultIsInClosedList-one" scheme="schematron">
+  <constraintSpec ident="defaultIsInClosedList-one" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:attDef[     tei:defaultVal
                                      and tei:valList[ @type eq 'closed']

--- a/P5/Source/Specs/catchwords.xml
+++ b/P5/Source/Specs/catchwords.xml
@@ -18,7 +18,7 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <constraintSpec ident="catchword_in_msDesc" scheme="schematron">
+  <constraintSpec ident="catchword_in_msDesc" scheme="schematron" xml:lang="en">
     <!-- 
          The <egXML> referred to in the constraint below is, of
          course, in the teix: namespace, not the tei: namespace.

--- a/P5/Source/Specs/citeStructure.xml
+++ b/P5/Source/Specs/citeStructure.xml
@@ -36,14 +36,14 @@
       <datatype>
         <dataRef key="teidata.xpath"/>
       </datatype>
-      <constraintSpec ident="citestructure-outer-match" scheme="schematron">
+      <constraintSpec ident="citestructure-outer-match" scheme="schematron" xml:lang="en">
         <constraint>
           <sch:rule context="tei:citeStructure[not(parent::tei:citeStructure)]">
             <sch:assert test="starts-with(@match,'/')">An XPath in @match on the outer <sch:name/> must start with '/'.</sch:assert>
           </sch:rule>
         </constraint>
       </constraintSpec>
-      <constraintSpec ident="citestructure-inner-match" scheme="schematron">
+      <constraintSpec ident="citestructure-inner-match" scheme="schematron" xml:lang="en">
         <constraint>
           <sch:rule context="tei:citeStructure[parent::tei:citeStructure]">
             <sch:assert test="not(starts-with(@match,'/'))">An XPath in @match must not start with '/' except on the outer <sch:name/>.</sch:assert>

--- a/P5/Source/Specs/constraintSpec.xml
+++ b/P5/Source/Specs/constraintSpec.xml
@@ -109,7 +109,7 @@
       <constraintSpec scheme="schematron" ident="usage_based_on_mode" xml:lang="en">
         <constraint>
           <sch:rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]">
-            <sch:assert test="@scheme">The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is <sch:value-of select="if (@mode) then concat('&quot;',@mode,'&quot;') else 'not specified'"/>.</sch:assert>
+            <sch:assert test="@scheme">The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is <sch:value-of select="if (@mode) then concat('&quot;',@mode,'&quot;') else 'not specified'"/> (here on "<sch:value-of select="@ident"/>")</sch:assert>
           </sch:rule>
         </constraint>
       </constraintSpec>

--- a/P5/Source/Specs/constraintSpec.xml
+++ b/P5/Source/Specs/constraintSpec.xml
@@ -23,7 +23,7 @@
       <elementRef key="constraint" minOccurs="0" maxOccurs="1"/>
     </sequence>
   </content>
-  <constraintSpec scheme="schematron" ident="empty-based-on-mode">
+  <constraintSpec scheme="schematron" ident="empty-based-on-mode" xml:lang="en">
     <!-- 
          This constraint specification is much like the
          "child-constraint-based-on-mode" for <elementSpec>, which
@@ -42,7 +42,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="sch_no_more" scheme="schematron">
+  <constraintSpec ident="sch_no_more" scheme="schematron" xml:lang="en">
     <desc versionDate="2018-07-06" xml:lang="en">Relationship between scheme attribute and contents: Schematron 1.x</desc>
     <constraint>
       <sch:rule context="tei:constraintSpec">
@@ -53,7 +53,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="isosch" scheme="schematron">
+  <constraintSpec ident="isosch" scheme="schematron" xml:lang="en">
     <desc versionDate="2018-07-06" xml:lang="en">Relationship between scheme attribute and contents: ISO Schematron</desc>
     <constraint>
       <sch:rule context="tei:constraintSpec[ @mode = ('add','replace') or not( @mode ) ]">
@@ -63,7 +63,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="context-required" scheme="schematron" type="deprecationWarning" validUntil="2025-03-15">
+  <constraintSpec ident="context-required" scheme="schematron" type="deprecationWarning" validUntil="2025-03-15" xml:lang="en">
     <desc type="deprecationInfo" versionDate="2024-03-15" xml:lang="en">
       The use of ISO Schematron <gi>sch:assert</gi> and
       <gi>sch:report</gi> elements without a parent <gi>sch:rule</gi>
@@ -80,11 +80,11 @@
       <sch:rule context="tei:constraintSpec[ @scheme eq 'schematron']/tei:constraint[ .//sch:assert | .//sch:report ]">
         <sch:let name="assertsHaveContext" value="for $a in .//sch:assert return exists( $a/ancestor::sch:rule/@context )"/>
         <sch:let name="reportsHaveContext" value="for $r in .//sch:report return exists( $r/ancestor::sch:rule/@context )"/>
-        <sch:report test="( $assertsHaveContext, $reportsHaveContext ) = false()" role="warning">The use of an &lt;sch:assert> or &lt;sch:report> that does not have a context (i.e., does not have an ancestor &lt;sch:rule> with a @context attribute) in an ISO Schematron constraint specification is deprecated, and will become invalid after 2025-03-15.</sch:report>
+        <sch:report test="( $assertsHaveContext, $reportsHaveContext ) = false()" role="warning">The use of an &lt;sch:assert&gt; or &lt;sch:report&gt; that does not have a context (i.e., does not have an ancestor &lt;sch:rule&gt; with a @context attribute) in an ISO Schematron constraint specification is deprecated, and will become invalid after 2025-03-15.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="unique-constraintSpec-ident" scheme="schematron">
+  <constraintSpec ident="unique-constraintSpec-ident" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:constraintSpec[ @mode eq 'add' or not( @mode ) ]">
         <sch:let name="myIdent" value="normalize-space(@ident)"/>
@@ -106,10 +106,10 @@
       <desc versionDate="2009-06-10" xml:lang="en">supplies the name of the language in which the constraints are defined</desc>
       <desc versionDate="2024-02-28" xml:lang="ja">制約を定義する言語名を示す。</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <constraintSpec scheme="schematron" ident="usage_based_on_mode">
+      <constraintSpec scheme="schematron" ident="usage_based_on_mode" xml:lang="en">
         <constraint>
           <sch:rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]">
-            <sch:assert test="@scheme">The @scheme attribute of &lt;constraintSpec> is required when the @mode is <sch:value-of select="if (@mode) then concat('&quot;',@mode,'&quot;') else 'not specified'"/>.</sch:assert>
+            <sch:assert test="@scheme">The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is <sch:value-of select="if (@mode) then concat('&quot;',@mode,'&quot;') else 'not specified'"/>.</sch:assert>
           </sch:rule>
         </constraint>
       </constraintSpec>

--- a/P5/Source/Specs/damageSpan.xml
+++ b/P5/Source/Specs/damageSpan.xml
@@ -21,7 +21,7 @@
     <memberOf key="model.global.edit"/>
   </classes>
   <content><empty/></content>
-  <constraintSpec ident="damageSpan-requires-spanTo" scheme="schematron">
+  <constraintSpec ident="damageSpan-requires-spanTo" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:damageSpan">
         <sch:assert test="@spanTo">The @spanTo attribute of <sch:name/> is required.</sch:assert>

--- a/P5/Source/Specs/dataRef.xml
+++ b/P5/Source/Specs/dataRef.xml
@@ -12,7 +12,7 @@
   <content>
     <elementRef minOccurs="0" maxOccurs="unbounded" key="dataFacet"/>
   </content>
-  <constraintSpec ident="restrictDataFacet" scheme="schematron">
+  <constraintSpec ident="restrictDataFacet" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:dataRef[tei:dataFacet]">
         <sch:assert test="@name" role="nonfatal">Data facets can only be specified for references to datatypes specified by
@@ -21,7 +21,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="restrictAttResctrictionName" scheme="schematron">
+  <constraintSpec ident="restrictAttResctrictionName" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:dataRef[@restriction]">
         <sch:assert test="@name" role="nonfatal">Restrictions can only be specified for references to datatypes specified by

--- a/P5/Source/Specs/dataSpec.xml
+++ b/P5/Source/Specs/dataSpec.xml
@@ -25,7 +25,7 @@
       <elementRef key="listRef" minOccurs="0" maxOccurs="unbounded"/>
     </sequence>
   </content>
-  <constraintSpec scheme="schematron" ident="no_elements_in_data_content">
+  <constraintSpec scheme="schematron" ident="no_elements_in_data_content" xml:lang="en">
     <constraint>
       <sch:rule role="warn" context="tei:dataSpec/tei:content">
         <sch:report test=".//tei:anyElement | .//tei:classRef | .//tei:elementRef">

--- a/P5/Source/Specs/delSpan.xml
+++ b/P5/Source/Specs/delSpan.xml
@@ -24,7 +24,7 @@
     <memberOf key="model.global.edit"/>
   </classes>
   <content><empty/></content>
-  <constraintSpec ident="delSpan-requires-spanTo" scheme="schematron">
+  <constraintSpec ident="delSpan-requires-spanTo" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:delSpan">
         <sch:assert test="@spanTo">The @spanTo attribute of <sch:name/> is required.</sch:assert>

--- a/P5/Source/Specs/desc.xml
+++ b/P5/Source/Specs/desc.xml
@@ -40,7 +40,7 @@
   <content>
     <macroRef key="macro.limitedContent"/>
   </content>
-  <constraintSpec ident="deprecationInfo-only-in-deprecated" scheme="schematron">
+  <constraintSpec ident="deprecationInfo-only-in-deprecated" scheme="schematron" xml:lang="en">
     <desc versionDate="2018-09-13" xml:lang="en">A <gi>desc</gi> with
     a <att>type</att> of <val>deprecationInfo</val> should only occur
     when its parent element is being deprecated. Furthermore, it

--- a/P5/Source/Specs/dimensions.xml
+++ b/P5/Source/Specs/dimensions.xml
@@ -23,7 +23,7 @@
       <classRef key="model.dimLike"/>
     </alternate>
   </content>
-  <constraintSpec scheme="schematron" ident="duplicateDim">
+  <constraintSpec scheme="schematron" ident="duplicateDim" xml:lang="en">
     <!-- It would be simpler to use just
          "( count(tei:width), count(tei:height), count(tei:depth) ) > 1",
          but then we would not be able to tell the user which element

--- a/P5/Source/Specs/div.xml
+++ b/P5/Source/Specs/div.xml
@@ -65,7 +65,7 @@
       </sequence>
     </sequence>
   </content>
-  <constraintSpec ident="abstractModel-structure-div-in-l-or-lg" scheme="schematron">
+  <constraintSpec ident="abstractModel-structure-div-in-l-or-lg" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:div">
         <sch:report test="(ancestor::tei:l or ancestor::tei:lg) and not(ancestor::tei:floatingText)">
@@ -74,7 +74,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="abstractModel-structure-div-in-ab-or-p" scheme="schematron">
+  <constraintSpec ident="abstractModel-structure-div-in-ab-or-p" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:div">
         <sch:report test="(ancestor::tei:p or ancestor::tei:ab) and not(ancestor::tei:floatingText)">

--- a/P5/Source/Specs/elementRef.xml
+++ b/P5/Source/Specs/elementRef.xml
@@ -10,7 +10,7 @@
     <memberOf key="model.oddRef"/>
   </classes>
   <content><empty/></content>
-  <constraintSpec ident="only_sensible_attrs" scheme="schematron">
+  <constraintSpec ident="only_sensible_attrs" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:pattern>
         <sch:rule context="tei:elementRef[ parent::tei:schemaSpec | parent::tei:specGrp ]">

--- a/P5/Source/Specs/elementSpec.xml
+++ b/P5/Source/Specs/elementSpec.xml
@@ -46,7 +46,7 @@
       <elementRef key="listRef" minOccurs="0" maxOccurs="unbounded"/>
     </sequence>
   </content>
-  <constraintSpec scheme="schematron" ident="child-constraint-based-on-mode">
+  <constraintSpec scheme="schematron" ident="child-constraint-based-on-mode" xml:lang="en">
     <!-- 
          This constraint specification is much like the
          "empty-based-on-mode" for <constraintSpec> itself, which does

--- a/P5/Source/Specs/facsimile.xml
+++ b/P5/Source/Specs/facsimile.xml
@@ -28,7 +28,7 @@ ou encodé.</desc>
       <elementRef key="back" minOccurs="0"/>
     </sequence>
   </content>
-  <constraintSpec scheme="schematron" ident="no_facsimile_text_nodes">
+  <constraintSpec scheme="schematron" ident="no_facsimile_text_nodes" xml:lang="en">
     <constraint>
       <sch:rule context="tei:facsimile//tei:line | tei:facsimile//tei:zone">
         <sch:report test="child::text()[ normalize-space(.) ne '']">

--- a/P5/Source/Specs/join.xml
+++ b/P5/Source/Specs/join.xml
@@ -24,7 +24,7 @@
       <classRef key="model.certLike"/>
     </alternate>
   </content>
-  <constraintSpec ident="joinTargets3" scheme="schematron">
+  <constraintSpec ident="joinTargets3" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:join">
         <sch:assert test="contains( normalize-space( @target ),' ')">

--- a/P5/Source/Specs/l.xml
+++ b/P5/Source/Specs/l.xml
@@ -34,7 +34,7 @@
       <classRef key="model.global"/>
     </alternate>
   </content>
-  <constraintSpec ident="abstractModel-structure-l-in-l" scheme="schematron">
+  <constraintSpec ident="abstractModel-structure-l-in-l" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:l">
         <sch:report test="ancestor::tei:l[not(.//tei:note//tei:l[. = current()])]">Abstract model violation: Lines may not contain lines or lg elements.</sch:report>

--- a/P5/Source/Specs/lg.xml
+++ b/P5/Source/Specs/lg.xml
@@ -53,14 +53,14 @@
       </sequence>
     </sequence>
   </content>
-  <constraintSpec scheme="schematron" ident="atleast1oflggapl">
+  <constraintSpec scheme="schematron" ident="atleast1oflggapl" xml:lang="en">
     <constraint>
       <sch:rule context="tei:lg">
         <sch:assert test="count(descendant::tei:lg|descendant::tei:l|descendant::tei:gap) &gt; 0">An lg element must contain at least one child l, lg, or gap element.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="abstractModel-structure-lg-in-l" scheme="schematron">
+  <constraintSpec ident="abstractModel-structure-lg-in-l" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:lg">
         <sch:report test="ancestor::tei:l[not(.//tei:note//tei:lg[. = current()])]">Abstract model violation: Lines may not contain line groups.</sch:report>

--- a/P5/Source/Specs/link.xml
+++ b/P5/Source/Specs/link.xml
@@ -19,7 +19,7 @@
     <memberOf key="model.global.meta"/>
   </classes>
   <content><empty/></content>
-  <constraintSpec ident="linkTargets3" scheme="schematron">
+  <constraintSpec ident="linkTargets3" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:link">
         <sch:assert test="contains(normalize-space(@target),' ')">You must supply at least two values for @target or  on <sch:name/></sch:assert>

--- a/P5/Source/Specs/list.xml
+++ b/P5/Source/Specs/list.xml
@@ -83,7 +83,7 @@
       
     </sequence>
   </content>
-  <constraintSpec xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="gloss-list-must-have-labels" scheme="schematron">
+  <constraintSpec xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="gloss-list-must-have-labels" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:list[@type='gloss']">
 	<sch:assert test="tei:label">The content of a "gloss" list should include a sequence of one or more pairs of a label element followed by an item element</sch:assert>

--- a/P5/Source/Specs/listRef.xml
+++ b/P5/Source/Specs/listRef.xml
@@ -28,14 +28,14 @@
       <classRef key="model.ptrLike" minOccurs="1" maxOccurs="unbounded"/>
     </sequence>
   </content>
- <constraintSpec ident="TagDocsNestinglistRef" scheme="schematron">
+ <constraintSpec ident="TagDocsNestinglistRef" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="( tei:classSpec | tei:dataSpec | tei:elementSpec | tei:macroSpec | tei:moduleSpec | tei:schemaSpec | tei:specGrp )/tei:listRef">
         <sch:report test="tei:listRef">In the context of tagset documentation, the listRef element must not self-nest.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="TagDocslistRefChildren" scheme="schematron">
+  <constraintSpec ident="TagDocslistRefChildren" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="( tei:classSpec | tei:dataSpec | tei:elementSpec | tei:macroSpec | tei:moduleSpec | tei:schemaSpec | tei:specGrp )/tei:listRef/tei:ptr | ( tei:classSpec | tei:dataSpec | tei:elementSpec | tei:macroSpec | tei:moduleSpec | tei:schemaSpec | tei:specGrp )/tei:listRef/tei:ref">
         <sch:assert test="@target and not( matches( @target,'\s') )">In the context of tagset documentation, each ptr or ref element inside a listRef must have a target attribute with only 1 pointer as its value.</sch:assert>

--- a/P5/Source/Specs/model.xml
+++ b/P5/Source/Specs/model.xml
@@ -18,7 +18,7 @@
       <elementRef key="outputRendition" minOccurs="0" maxOccurs="unbounded"/>
     </sequence>
   </content>
-  <constraintSpec scheme="schematron" ident="no_dup_default_models">
+  <constraintSpec scheme="schematron" ident="no_dup_default_models" xml:lang="en">
     <desc versionDate="2016-10-01" xml:lang="en">It is ambigous to have 2 <gi>model</gi>s
       that have both the same <att>output</att> and have no <att>predicate</att>
       (and thus select the same set of nodes).</desc>
@@ -37,7 +37,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec scheme="schematron" ident="no_dup_models">
+  <constraintSpec scheme="schematron" ident="no_dup_models" xml:lang="en">
     <desc versionDate="2016-10-01" xml:lang="en">It is ambigous to have 2 <gi>model</gi>s
       that have both the same <att>output</att> and the same <att>predicate</att>
       (and thus select the same set of nodes).</desc>

--- a/P5/Source/Specs/modelSequence.xml
+++ b/P5/Source/Specs/modelSequence.xml
@@ -15,7 +15,7 @@
       <elementRef key="model" minOccurs="2" maxOccurs="unbounded"/>
     </sequence>
   </content>
-  <constraintSpec scheme="schematron" ident="no_outputs_nor_predicates_4_my_kids">
+  <constraintSpec scheme="schematron" ident="no_outputs_nor_predicates_4_my_kids" xml:lang="en">
     <constraint>
       <sch:rule context="tei:modelSequence">
         <sch:report test="tei:model[@output]" role="warning">The 'model' children

--- a/P5/Source/Specs/moduleRef.xml
+++ b/P5/Source/Specs/moduleRef.xml
@@ -21,7 +21,7 @@
   <content>
     <elementRef key="content" minOccurs="0"/>
   </content>
-  <constraintSpec ident="modref" scheme="schematron">
+  <constraintSpec ident="modref" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:moduleRef">
         <sch:report test="* and @key">
@@ -34,7 +34,7 @@
     <attDef ident="prefix" usage="opt">
       <desc versionDate="2011-09-21" xml:lang="en">specifies a default prefix which will be prepended to all patterns from the imported module.</desc>
       <datatype minOccurs="0" maxOccurs="1"><dataRef key="teidata.xmlName"/></datatype>
-      <constraintSpec scheme="schematron" ident="not-same-prefix">
+      <constraintSpec scheme="schematron" ident="not-same-prefix" xml:lang="en">
         <constraint>
           <sch:rule context="tei:moduleRef">
             <sch:report test="//*[ not( generate-id(.) eq generate-id( current() ) ) ]/@prefix = @prefix">The prefix attribute
@@ -43,7 +43,7 @@
           </sch:rule>
         </constraint>
       </constraintSpec>
-      <constraintSpec scheme="schematron" ident="not-except-and-include">
+      <constraintSpec scheme="schematron" ident="not-except-and-include" xml:lang="en">
         <constraint>
           <sch:rule context="tei:moduleRef">
             <sch:report test="@except and @include">It is an error to supply both the @include and @except attributes</sch:report>

--- a/P5/Source/Specs/msDesc.xml
+++ b/P5/Source/Specs/msDesc.xml
@@ -47,7 +47,7 @@
       </alternate>
     </sequence>
   </content>
-  <constraintSpec scheme="schematron" ident="one_ms_singleton_max">
+  <constraintSpec scheme="schematron" ident="one_ms_singleton_max" xml:lang="en">
     <constraint>
       <sch:rule context="tei:msContents|tei:physDesc|tei:history|tei:additional">
         <!-- Note: This rule applies to <msContents>, <physDesc>,

--- a/P5/Source/Specs/msIdentifier.xml
+++ b/P5/Source/Specs/msIdentifier.xml
@@ -35,7 +35,7 @@
       </alternate>
     </sequence>
   </content>
-  <constraintSpec scheme="schematron" ident="msId_minimal">
+  <constraintSpec scheme="schematron" ident="msId_minimal" xml:lang="en">
     <constraint>
       <sch:rule context="tei:msIdentifier">
         <sch:report test="not( parent::tei:msPart )

--- a/P5/Source/Specs/p.xml
+++ b/P5/Source/Specs/p.xml
@@ -28,7 +28,7 @@
   <content>
     <macroRef key="macro.paraContent"/>
   </content>
-  <constraintSpec ident="abstractModel-structure-p-in-ab-or-p" scheme="schematron">
+  <constraintSpec ident="abstractModel-structure-p-in-ab-or-p" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:p">
         <sch:report test="(ancestor::tei:ab or ancestor::tei:p) and
@@ -49,7 +49,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="abstractModel-structure-p-in-l-or-lg" scheme="schematron">
+  <constraintSpec ident="abstractModel-structure-p-in-l-or-lg" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:p">
         <sch:report test="( ancestor::tei:l  or  ancestor::tei:lg ) and

--- a/P5/Source/Specs/path.xml
+++ b/P5/Source/Specs/path.xml
@@ -18,7 +18,7 @@ element.</desc>
     <empty/>
   </content>
   
-  <constraintSpec ident="pathmustnotbeclosed" scheme="schematron">
+  <constraintSpec ident="pathmustnotbeclosed" scheme="schematron" xml:lang="en">
     <desc versionDate="2023-04-11" xml:lang="en">
       Since a <gi>path</gi> represents a line with distinct start and
       end points, the last coordinate should not be the same as the

--- a/P5/Source/Specs/ptr.xml
+++ b/P5/Source/Specs/ptr.xml
@@ -27,7 +27,7 @@
     <memberOf key="model.ptrLike"/>
   </classes>
   <content><empty/></content>
-  <constraintSpec scheme="schematron" ident="ptrAtts">
+  <constraintSpec scheme="schematron" ident="ptrAtts" xml:lang="en">
     <constraint>
       <sch:rule context="tei:ptr">
         <sch:report test="@target and @cRef">Only one of the attributes @target and @cRef may be supplied on <sch:name/>.</sch:report>

--- a/P5/Source/Specs/quotation.xml
+++ b/P5/Source/Specs/quotation.xml
@@ -20,7 +20,7 @@
   <content>
     <classRef key="model.pLike" minOccurs="0" maxOccurs="unbounded"/>
   </content>
-  <constraintSpec ident="quotationContents" scheme="schematron">
+  <constraintSpec ident="quotationContents" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:quotation">
         <sch:report test="not( @marks )  and  not( tei:p )">

--- a/P5/Source/Specs/rdgGrp.xml
+++ b/P5/Source/Specs/rdgGrp.xml
@@ -32,7 +32,7 @@
     </alternate>
     </sequence>
   </content>
-  <constraintSpec scheme="schematron" ident="only1lem">
+  <constraintSpec scheme="schematron" ident="only1lem" xml:lang="en">
     <constraint xmlns:sch="http://purl.oclc.org/dsdl/schematron">
       <sch:rule context="tei:rdgGrp">
         <sch:assert test="count(tei:lem) lt 2">Only one &lt;lem&gt; element may appear within a &lt;rdgGrp&gt;</sch:assert>

--- a/P5/Source/Specs/re.xml
+++ b/P5/Source/Specs/re.xml
@@ -246,11 +246,8 @@
           Inglés-Español y Español-Inglés</title> / <title>The University of Chicago Spanish
           Dictionary</title>, Fourth Edition, compiled by Carlos Castillo and Otto F. Bond (Chicago:
         University of Chicago Press, 1987)</bibl> shows a number of related entries embedded in the
-      main entry. The original entry resembles the following:<q rend="display"><hi rend="bold"
-          >abeja</hi> [a·bé·xa]<hi rend="it">f.</hi> bee;<hi rend="bold">abejera</hi>
-          [a·be·xé·ra]<hi rend="it">f.</hi> beehive;<hi rend="bold">abejón</hi> [a·be·xóon]<hi
-          rend="it">m.</hi> drone; bumblebee;<hi rend="bold">abejorro</hi> [a·be·xó·rro]<hi
-          rend="it">m.</hi> bumble bee.</q> One encoding for this entry would be:</p>
+      main entry. The original entry resembles the following:<q rend="display"><hi rend="bold">abeja</hi> [a·bé·xa]<hi rend="it">f.</hi> bee;<hi rend="bold">abejera</hi>
+          [a·be·xé·ra]<hi rend="it">f.</hi> beehive;<hi rend="bold">abejón</hi> [a·be·xóon]<hi rend="it">m.</hi> drone; bumblebee;<hi rend="bold">abejorro</hi> [a·be·xó·rro]<hi rend="it">m.</hi> bumble bee.</q> One encoding for this entry would be:</p>
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-re-egXML-xi">
       <entry>
         <form>

--- a/P5/Source/Specs/ref.xml
+++ b/P5/Source/Specs/ref.xml
@@ -31,7 +31,7 @@
   <content>
     <macroRef key="macro.paraContent"/>
   </content>
-  <constraintSpec scheme="schematron" ident="refAtts">
+  <constraintSpec scheme="schematron" ident="refAtts" xml:lang="en">
     <constraint>
       <sch:rule context="tei:ref">
         <sch:report test="@target and @cRef">Only one of the attributes @target' and @cRef' may be supplied on <sch:name/></sch:report>

--- a/P5/Source/Specs/relatedItem.xml
+++ b/P5/Source/Specs/relatedItem.xml
@@ -21,7 +21,7 @@
       <classRef key="model.ptrLike"/>
     </alternate>
   </content>
-  <constraintSpec ident="targetorcontent1" scheme="schematron">
+  <constraintSpec ident="targetorcontent1" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:relatedItem">
         <sch:report test="@target and count( child::* ) &gt; 0">If the @target attribute on <sch:name/> is used, the relatedItem element must be empty</sch:report>

--- a/P5/Source/Specs/relation.xml
+++ b/P5/Source/Specs/relation.xml
@@ -26,14 +26,14 @@
   <content>
     <elementRef key="desc" minOccurs="0"/>
   </content>
-  <constraintSpec ident="ref-or-key-or-name" scheme="schematron">
+  <constraintSpec ident="ref-or-key-or-name" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:relation">
         <sch:assert test="@ref or @key or @name">One of the attributes @name, @ref or @key must be supplied</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="active-mutual" scheme="schematron">
+  <constraintSpec ident="active-mutual" scheme="schematron" xml:lang="en">
     <!-- Note: this constraint is pointless in RELAX NG land, where
          the org=choice works. It is useful in DTD land, where the
          attList/@org has no effect. It looks to me like it is useful
@@ -47,7 +47,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="active-passive" scheme="schematron">
+  <constraintSpec ident="active-passive" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:relation">
         <sch:report test="@passive and not(@active)">the attribute @passive may be supplied only if the attribute @active is supplied</sch:report>

--- a/P5/Source/Specs/rt.xml
+++ b/P5/Source/Specs/rt.xml
@@ -23,7 +23,7 @@
         base being glossed by this ruby text.</desc>
       <desc versionDate="2021-01-31" xml:lang="ja">ルビテキストの対象へのポインタを示す。</desc>
       <datatype><dataRef key="teidata.pointer"/></datatype>
-      <constraintSpec scheme="schematron" ident="rt-target-not-span">
+      <constraintSpec scheme="schematron" ident="rt-target-not-span" xml:lang="en">
         <!-- Note: this constraint should not be necessary, as the
              desired semantics should be something we could describe
              in PureODD using attList/@org. But I don’t think we
@@ -53,7 +53,7 @@
       <datatype>
         <dataRef key="teidata.pointer"/>
       </datatype>
-      <constraintSpec scheme="schematron" ident="rt-from">
+      <constraintSpec scheme="schematron" ident="rt-from" xml:lang="en">
         <!-- Note: this constraint should not be necessary, as the
              desired semantics should be something we could describe
              in PureODD using attList/@org. But I don’t think we
@@ -74,7 +74,7 @@
       <datatype>
         <dataRef key="teidata.pointer"/>
       </datatype>
-      <constraintSpec scheme="schematron" ident="rt-to">
+      <constraintSpec scheme="schematron" ident="rt-to" xml:lang="en">
         <!-- Note: this constraint should not be necessary, as the
              desired semantics should be something we could describe
              in PureODD using attList/@org. But I don’t think we

--- a/P5/Source/Specs/s.xml
+++ b/P5/Source/Specs/s.xml
@@ -32,7 +32,7 @@
          original macro.phraseSet content model. -->
     <macroRef key="macro.phraseSeq"/> 
   </content>
-  <constraintSpec ident="noNestedS" scheme="schematron">
+  <constraintSpec ident="noNestedS" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:s">
         <sch:report test="tei:s">You may not nest one s element within another: use seg instead</sch:report>

--- a/P5/Source/Specs/secFol.xml
+++ b/P5/Source/Specs/secFol.xml
@@ -22,7 +22,7 @@
   <content>
     <macroRef key="macro.phraseSeq"/>
   </content>
-  <constraintSpec ident="secFol_in_msDesc" scheme="schematron">
+  <constraintSpec ident="secFol_in_msDesc" scheme="schematron" xml:lang="en">
     <!-- 
          The <egXML> referred to in the constraint below is, of
          course, in the teix: namespace, not the tei: namespace.

--- a/P5/Source/Specs/sequence.xml
+++ b/P5/Source/Specs/sequence.xml
@@ -11,7 +11,7 @@
   <content>
     <classRef key="model.contentPart" maxOccurs="unbounded"/>
   </content>
-  <constraintSpec ident="sequencechilden" scheme="schematron">
+  <constraintSpec ident="sequencechilden" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:sequence">
         <sch:assert test="count(*) gt 1">The sequence element must have at least two child elements</sch:assert>

--- a/P5/Source/Specs/shift.xml
+++ b/P5/Source/Specs/shift.xml
@@ -20,7 +20,7 @@ utterances by any one speaker changes.</desc>
     <memberOf key="model.global.spoken"/>
   </classes>
   <content><empty/></content>
-  <constraintSpec ident="shiftNew" scheme="schematron">
+  <constraintSpec ident="shiftNew" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:shift">
         <sch:assert test="@new" role="warning">              

--- a/P5/Source/Specs/signatures.xml
+++ b/P5/Source/Specs/signatures.xml
@@ -18,7 +18,7 @@
   <content>
     <macroRef key="macro.specialPara"/>
   </content>
-  <constraintSpec ident="signatures_in_msDesc" scheme="schematron">
+  <constraintSpec ident="signatures_in_msDesc" scheme="schematron" xml:lang="en">
     <!-- 
          The <egXML> referred to in the constraint below is, of
          course, in the teix: namespace, not the tei: namespace.

--- a/P5/Source/Specs/span.xml
+++ b/P5/Source/Specs/span.xml
@@ -19,7 +19,7 @@
   <content>
     <macroRef key="macro.phraseSeq.limited"/>
   </content>
-  <constraintSpec ident="target-from" scheme="schematron">
+  <constraintSpec ident="target-from" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:span">
         <sch:report test="@from and @target">
@@ -28,7 +28,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="targetto" scheme="schematron">
+  <constraintSpec ident="targetto" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:span">
         <sch:report test="@to and @target">
@@ -37,7 +37,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="tonotfrom" scheme="schematron">
+  <constraintSpec ident="tonotfrom" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:span">
         <sch:report test="@to and not(@from)">
@@ -46,7 +46,7 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="tofrom" scheme="schematron">
+  <constraintSpec ident="tofrom" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:span">
         <sch:report test="contains(normalize-space(@to),' ') or contains(normalize-space(@from),' ')">

--- a/P5/Source/Specs/standOff.xml
+++ b/P5/Source/Specs/standOff.xml
@@ -13,7 +13,7 @@
   <content>
     <classRef key="model.standOffPart" minOccurs="1" maxOccurs="unbounded"/>
   </content>
-  <constraintSpec ident="nested_standOff_should_be_typed" scheme="schematron">
+  <constraintSpec ident="nested_standOff_should_be_typed" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:standOff">
         <sch:assert test="@type or not(ancestor::tei:standOff)">This

--- a/P5/Source/Specs/subst.xml
+++ b/P5/Source/Specs/subst.xml
@@ -27,7 +27,7 @@
       <classRef key="model.milestoneLike"/>
     </alternate>
   </content>
-  <constraintSpec ident="substContents1" scheme="schematron">
+  <constraintSpec ident="substContents1" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:subst">
         <sch:assert test="child::tei:add and (child::tei:del or child::tei:surplus)"><sch:name/> must have at least one child add and at least one child del or surplus</sch:assert>

--- a/P5/Source/Specs/unicodeProp.xml
+++ b/P5/Source/Specs/unicodeProp.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<elementSpec ident="unicodeProp" module="gaiji" xml:id="UNICODEPROP"
-    xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0"
-    xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="unicodeProp" module="gaiji" xml:id="UNICODEPROP">
     <gloss versionDate="2018-08-22" xml:lang="en">unicode property</gloss>
-    <desc versionDate="2020-01-28" xml:lang="en">provides a Unicode property for a character (or
-        glyph).</desc>
+    <desc versionDate="2020-01-28" xml:lang="en">provides a Unicode property for a character (or glyph).</desc>
     <classes>
         <memberOf key="att.global"/>
         <memberOf key="att.gaijiProp"/>
@@ -17,8 +14,7 @@
     <!-- TODO duncrum Phase 4 #1805 add and test value constraint checks see unihanProp-->
     <attList>
         <attDef ident="name" mode="replace" usage="req">
-            <desc versionDate="2020-01-28" xml:lang="en">specifies the normalized name of a Unicode
-                property.</desc>
+            <desc versionDate="2020-01-28" xml:lang="en">specifies the normalized name of a Unicode property.</desc>
             <datatype>
                 <dataRef key="teidata.xmlName"/>
             </datatype>
@@ -246,8 +242,7 @@
             </valList>
         </attDef>
         <attDef ident="value" mode="replace" usage="req">
-            <desc versionDate="2020-01-28" xml:lang="en">specifies the value of a named Unicode
-                property.</desc>
+            <desc versionDate="2020-01-28" xml:lang="en">specifies the value of a named Unicode property.</desc>
             <datatype>
                 <dataRef key="teidata.text"/>
             </datatype>

--- a/P5/Source/Specs/variantEncoding.xml
+++ b/P5/Source/Specs/variantEncoding.xml
@@ -92,7 +92,7 @@ or external to it.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">indica si el aparato aparece al interno o al externo del texto.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">indica se l'apparato compare all'interno del testo, o esternamente.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-      <constraintSpec ident="variantEncodingLocation" scheme="schematron">
+      <constraintSpec ident="variantEncodingLocation" scheme="schematron" xml:lang="en">
         <constraint>
           <sch:rule context="tei:variantEncoding">
             <sch:report test="@location eq 'external' and @method eq 'parallel-segmentation'">

--- a/P5/Test/antruntest.xml
+++ b/P5/Test/antruntest.xml
@@ -176,7 +176,7 @@
     <echo level="info">Validate ${oddFile} as ODD ...</echo>
     <echo level="info"> ... against RelaxNG (../p5odds.rng) with jing ...</echo>
     <runjing rngfile="../p5odds.rng" file="${oddFile}" checkid="${DTDcompat}"/>
-    <echo level="info"> ... against Schematron (../p5odds.message.isosch.xsl) with Saaxon via trax</echo>
+    <echo level="info"> ... against Schematron (../p5odds.message.isosch.xsl) with Saxon via trax</echo>
     <xslt processor="trax" 
           force="yes" 
           style="../p5odds.message.isosch.xsl"

--- a/P5/Test/detest.odd
+++ b/P5/Test/detest.odd
@@ -17,6 +17,9 @@
       </sourceDesc>
     </fileDesc>
     <revisionDesc>
+      <change when="2024-10-29" who="#sbauman.emt">
+	Added <att>xml:lang</att> to every <gi>constraintSpec</gi>
+      </change>
       <change when="2023-08-06" who="#sbauman.emt">
         Add the <name>add_missing_scheme</name> and
         <name>replace_missing_scheme</name> tests for
@@ -82,7 +85,7 @@
           <moduleRef key="spoken"/>
           <moduleRef key="figures"/>
           <elementSpec ident="p" mode="change">
-            <constraintSpec mode="add" ident="c1" scheme="schematron">
+            <constraintSpec mode="add" ident="c1" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="p">
                   <sch:report test="tei:list"> 
@@ -91,11 +94,12 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec mode="add" ident="c2" scheme="schematron">
+            <constraintSpec mode="add" ident="c2" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="tei:p|tei:q">
                   <sch:report test="contains(@rend,' ')"> 
-                multi-valued rend is not supported </sch:report>
+                    multi-valued rend is not supported
+		  </sch:report>
                 </sch:rule>
               </constraint>
             </constraintSpec>
@@ -169,7 +173,7 @@
             </attList>
           </elementSpec>
           <elementSpec ident="div" mode="change">
-            <constraintSpec mode="add" ident="canondiv" scheme="schematron">
+            <constraintSpec mode="add" ident="canondiv" scheme="schematron" xml:lang="en">
               <constraint>
                 <sch:rule context="div">
                   <sch:report test="@type eq 'canon'  and  parent::tei:div/@type eq 'canon'">
@@ -456,21 +460,21 @@
             <content>
               <rng:ref name="macro.phraseSeq"/>
             </content>
-            <constraintSpec ident="add_missing_scheme">
+            <constraintSpec ident="add_missing_scheme" xml:lang="en">
               <desc>This <gi>constraintSpec</gi> is invalid because it is
               missing <att>scheme</att> in <val>add</val> mode.</desc>
               <constraint>
                 <sch:report test="false()">This rule never fires.</sch:report>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="replace_missing_scheme" mode="replace">
+            <constraintSpec ident="replace_missing_scheme" mode="replace" xml:lang="en">
               <desc>This <gi>constraintSpec</gi> is invalid because it is
               missing <att>scheme</att> in <val>replace</val> mode.</desc>
               <constraint>
                 <sch:report test="false()">This rule never fires.</sch:report>
               </constraint>
             </constraintSpec>
-            <constraintSpec ident="test_contextless_report" scheme="schematron">
+            <constraintSpec ident="test_contextless_report" scheme="schematron" xml:lang="en">
               <desc>This <gi>constraintSpec</gi> is invalid because it
               has an <gi>sch:report</gi> that does not have a context
               (i.e., does not have a <tag>sch:rule
@@ -488,7 +492,7 @@
                 *   content-language = whether ../* are Schematron 1.x ("schematron") or ISO Schematron elements
                 *   expected-result = OK, deprecated, or error
             -->
-            <constraintSpec scheme="schematron" ident="schematron_isoschematron_OK">
+            <constraintSpec scheme="schematron" ident="schematron_isoschematron_OK" xml:lang="en">
               <!-- This should *not* raise an error, as ISO Schematron
                    is allowed inside constraintSpec/schematron -->
               <constraint>
@@ -497,7 +501,7 @@
                 </sch:rule>
               </constraint>
             </constraintSpec>
-            <constraintSpec scheme="isoschematron" ident="isoschematron_isoschematron_error">
+            <constraintSpec scheme="isoschematron" ident="isoschematron_isoschematron_error" xml:lang="en">
               <!-- This should raise an error now, as "isoschematron"
                    is no longer allowed. -->
               <constraint>
@@ -509,7 +513,7 @@
           </elementSpec>
 
           <elementSpec ident="relation" mode="change">
-            <constraintSpec ident="activepassive" mode="delete" scheme="schematron"/>
+            <constraintSpec ident="activepassive" mode="delete" scheme="schematron" xml:lang="en"/>
           </elementSpec>
 
           <elementSpec ident="abbr" mode="change">

--- a/P5/Test/expected-results/detest_odd_schematron.log
+++ b/P5/Test/expected-results/detest_odd_schematron.log
@@ -3,7 +3,7 @@ Buildfile: /TEI/P5/Test/antruntest.xml
 validateodd:
      [echo] Validate detest.odd as ODD ...
      [echo]  ... against RelaxNG (../p5odds.rng) with jing ...
-     [echo]  ... against Schematron (../p5odds.message.isosch.xsl) with Saaxon via trax
+     [echo]  ... against Schematron (../p5odds.message.isosch.xsl) with Saxon via trax
      [xslt] Processing /TEI/P5/Test/detest.odd to /dev/null
      [xslt] Loading stylesheet /TEI/P5/p5odds.message.isosch.xsl
      [xslt]  Error: both the versionDate and xml:lang attributes on "remarks" are required when it is a child of "elementSpec". (@xml:lang and @versionDate)
@@ -21,8 +21,10 @@ validateodd:
      [xslt] Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
      [xslt] Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
      [xslt] The use of an &lt;sch:assert&gt; or &lt;sch:report&gt; that does not have a context (i.e., does not have an ancestor &lt;sch:rule&gt; with a @context attribute) in an ISO Schematron constraint specification is deprecated, and will become invalid after 2025-03-15. (( $assertsHaveContext, $reportsHaveContext ) = false() / warning)
-     [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified. (@scheme)
-     [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is "replace". (@scheme)
+     [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified (here on "add_missing_scheme") (@scheme)
+     [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is "replace" (here on "replace_missing_scheme") (@scheme)
+     [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified (here on "add_missing_scheme") (@scheme)
+     [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is "replace" (here on "replace_missing_scheme") (@scheme)
      [xslt] Since the @default-is-in-list-req attribute is required, it will always be specified. Thus the default value (of "ONE") will never be used. Either change the definition of the attribute so it is not required ("rec" or "opt"), or remove the defaultVal element. (tei:defaultVal)
      [xslt] Since the @default-NOT-in-list-req attribute is required, it will always be specified. Thus the default value (of "ONE") will never be used. Either change the definition of the attribute so it is not required ("rec" or "opt"), or remove the defaultVal element. (tei:defaultVal)
      [xslt] In the elementSpec defining blort2 the default value of the @default-NOT-in-list-opt attribute is not among the closed list of possible values (string(tei:defaultVal) = tei:valList/tei:valItem/@ident)

--- a/P5/Test/testjustfs.odd
+++ b/P5/Test/testjustfs.odd
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TEI xml:lang="en"  xmlns="http://www.tei-c.org/ns/1.0"
- xmlns:rng="http://relaxng.org/ns/structure/1.0" n="testjustfs">
-   <teiHeader>
-      <fileDesc>
-         <titleStmt>
-            <title>TEI with Just Feature Structures</title>
-            <author>Sebastian Rahtz</author>
-         </titleStmt>
-         <publicationStmt>
-	   <p> </p>
-	 </publicationStmt>
-         <sourceDesc>
-            <p>authored from scratch</p>
-         </sourceDesc>
-      </fileDesc>
-   </teiHeader>
-<text>
-<body>
-    <schemaSpec ident="testjustfs" start="fs">
-      <moduleRef key="tei"/>
-      <moduleRef key="iso-fs"/>
-      <elementSpec ident="fs" mode="change">
-	<constraintSpec ident="c1" scheme="schematron">
-	  <constraint>
-	    <ns xmlns="http://purl.oclc.org/dsdl/schematron" prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
-	  </constraint>
-	</constraintSpec>
-	<constraintSpec ident="c2" scheme="schematron">
-	  <constraint>
-	    <ns xmlns="http://purl.oclc.org/dsdl/schematron" prefix="rng" uri="http://relaxng.org/ns/structure/1.0"/>
-	  </constraint>
-	</constraintSpec>
-      </elementSpec>
-    </schemaSpec>
-</body>
-</text>
+     xmlns:rng="http://relaxng.org/ns/structure/1.0" n="testjustfs">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>TEI with Just Feature Structures</title>
+        <author>Sebastian Rahtz</author>
+      </titleStmt>
+      <publicationStmt>
+        <p> </p>
+      </publicationStmt>
+      <sourceDesc>
+        <p>authored from scratch</p>
+      </sourceDesc>
+    </fileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <schemaSpec ident="testjustfs" start="fs">
+        <moduleRef key="tei"/>
+        <moduleRef key="iso-fs"/>
+        <elementSpec ident="fs" mode="change">
+          <constraintSpec ident="c1" scheme="schematron" xml:lang="zxx">
+            <constraint>
+              <ns xmlns="http://purl.oclc.org/dsdl/schematron" prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
+            </constraint>
+          </constraintSpec>
+          <constraintSpec ident="c2" scheme="schematron" xml:lang="zxx">
+            <constraint>
+              <ns xmlns="http://purl.oclc.org/dsdl/schematron" prefix="rng" uri="http://relaxng.org/ns/structure/1.0"/>
+            </constraint>
+          </constraintSpec>
+        </elementSpec>
+      </schemaSpec>
+    </body>
+  </text>
 </TEI>
 
 

--- a/P5/Utilities/TEI-to-tei_customization.xslt
+++ b/P5/Utilities/TEI-to-tei_customization.xslt
@@ -436,7 +436,7 @@
   <!-- others -->
   <!-- ****** -->
   <xsl:template name="element-is-in-module">
-    <constraintSpec scheme="schematron" ident="element-is-in-module">
+    <constraintSpec scheme="schematron" ident="element-is-in-module" xml:lang="en">
       <constraint>
         <xsl:for-each select="//moduleSpec/@ident">
           <xsl:variable name="this" select="."/>
@@ -723,7 +723,7 @@
               <xsl:comment> allow tables, figures, and formulæ </xsl:comment>
               <moduleRef key="figures" except="notatedMusic"/>
               
-              <constraintSpec scheme="schematron" ident="mode-child-sanity">
+              <constraintSpec scheme="schematron" ident="mode-child-sanity" xml:lang="en">
                 <constraint>
                   <sch:rule context="*[ @mode eq 'delete' ]">
                     <sch:report test="child::*">The specification element ＜<sch:name/>＞ has both a
@@ -759,7 +759,7 @@
                     </alternate>
                   </sequence>
                 </content>
-                <constraintSpec scheme="schematron" ident="required-modules">
+                <constraintSpec scheme="schematron" ident="required-modules" xml:lang="en">
                   <gloss>required modules</gloss>
                   <constraint>
                     <sch:rule context="tei:schemaSpec">
@@ -783,7 +783,7 @@
                     </sch:rule>
                   </constraint>
                 </constraintSpec>
-                <constraintSpec scheme="schematron" ident="no-outside-specs">
+                <constraintSpec scheme="schematron" ident="no-outside-specs" xml:lang="en">
                   <desc>A <tag>*Spec</tag> element should either be within <gi>schemaSpec</gi>,
                     or be in a <gi>specGrp</gi> referred to by a <gi>specGrpRef</gi> wihin
                     <gi>schemaSpec</gi>.</desc>
@@ -800,7 +800,7 @@
                     </sch:rule>
                   </constraint>
                 </constraintSpec>
-                <constraintSpec scheme="schematron" ident="only-one-schemaSpec">
+                <constraintSpec scheme="schematron" ident="only-one-schemaSpec" xml:lang="en">
                   <desc>TEI permits <gi>schemaSpec</gi> as a
                   repeatable child of a variety of elements (including
                   <gi>front</gi>, <gi>body</gi>, <gi>back</gi>,
@@ -861,7 +861,7 @@
               </elementSpec>
 
               <elementSpec module="tagdocs" ident="moduleRef" mode="change">
-                <constraintSpec scheme="schematron" ident="if-url-then-prefix">
+                <constraintSpec scheme="schematron" ident="if-url-then-prefix" xml:lang="en">
                   <desc>This is not strictly necessary. The TEI patterns have a default prefix (the
                     value of <att>ident</att> of <gi>schemaSpec</gi>), so if only one external
                     module is imported, it does not need a prefix — there will not be any collisions
@@ -876,7 +876,7 @@
                     </sch:rule>
                   </constraint>
                 </constraintSpec>
-                <constraintSpec scheme="schematron" ident="no-duplicate-modules">
+                <constraintSpec scheme="schematron" ident="no-duplicate-modules" xml:lang="en">
                   <constraint>
                     <sch:rule context="tei:moduleRef[ @key ]">
                       <sch:let name="mykey" value="@key"/>
@@ -886,7 +886,7 @@
                     </sch:rule>
                   </constraint>
                 </constraintSpec>
-                <constraintSpec scheme="schematron" ident="need-required">
+                <constraintSpec scheme="schematron" ident="need-required" xml:lang="en">
                   <constraint>
                     <sch:rule context="tei:moduleRef[ @except ]">
                       <sch:let name="exceptions" value="tokenize( @except, '\s+' )"/>
@@ -915,7 +915,7 @@
                     </sch:rule>
                   </constraint>
                 </constraintSpec>
-                    <constraintSpec scheme="schematron" ident="include-required">
+                    <constraintSpec scheme="schematron" ident="include-required" xml:lang="en">
                       <constraint>
                         <sch:rule context="tei:moduleRef[ @key eq 'textstructure' and @include ]">
                           <sch:let name="inclusions" value="tokenize( @include, '\s+' )"/>
@@ -1215,7 +1215,7 @@
                     <elementRef key="listRef"        minOccurs="0" maxOccurs="unbounded"/>
                   </sequence>
                 </content>
-                <constraintSpec scheme="schematron" ident="module-except-when-add">
+                <constraintSpec scheme="schematron" ident="module-except-when-add" xml:lang="en">
                   <constraint>
                     <sch:rule context="tei:elementSpec">
                       <sch:assert test="@mode">
@@ -1227,7 +1227,7 @@
                     </sch:rule>
                   </constraint>
                 </constraintSpec>
-                <constraintSpec scheme="schematron" ident="only-1-per">
+                <constraintSpec scheme="schematron" ident="only-1-per" xml:lang="en">
                   <constraint>
                     <sch:rule context="tei:elementSpec">
                       <sch:report test="//tei:elementSpec[ @ident eq current()/@ident  and  not( . is current() ) ]"
@@ -1235,7 +1235,7 @@
                     </sch:rule>
                   </constraint>
                 </constraintSpec>
-                <constraintSpec scheme="schematron" ident="dont-delete-required">
+                <constraintSpec scheme="schematron" ident="dont-delete-required" xml:lang="en">
                   <constraint>
                     <sch:rule context="tei:elementSpec">
                       <sch:report test="@mode='delete' and @ident='TEI'">Removing ＜TEI＞ from your
@@ -1256,21 +1256,21 @@
 		    </sch:rule>
                   </constraint>
                 </constraintSpec>
-                <constraintSpec scheme="schematron" ident="content_when_adding">
+                <constraintSpec scheme="schematron" ident="content_when_adding" xml:lang="en">
                   <constraint>
                     <sch:rule context="tei:elementSpec[ @mode = ('add','replace') ]">
                       <sch:assert test="tei:content">When adding a new element (whether replacing an old one or not), a content model must be specified; but this ＜elementSpec＞ does not have a ＜content＞ child.</sch:assert>
                     </sch:rule>
                   </constraint>
                 </constraintSpec>
-                <constraintSpec scheme="schematron" ident="empty_when_deleting">
+                <constraintSpec scheme="schematron" ident="empty_when_deleting" xml:lang="en">
                   <constraint>
                     <sch:rule context="tei:elementSpec[ @mode eq 'delete']">
                       <sch:report test="*">When used to delete an element from your schema, the ＜elementSpec＞ should be empty</sch:report>
                     </sch:rule>
                   </constraint>
                 </constraintSpec>
-                <constraintSpec scheme="schematron" ident="add_implies_ns">
+                <constraintSpec scheme="schematron" ident="add_implies_ns" xml:lang="en">
                   <constraint>
                     <sch:rule context="tei:elementSpec[ @mode eq 'add'  or  not( @mode ) ]">
                       <sch:assert test="ancestor-or-self::*/@ns">When used to add an element, ＜elementSpec＞ (or its ancestor ＜schemaSpec＞) should have an @ns attribute.</sch:assert>
@@ -1530,7 +1530,7 @@
               <classSpec ident="att.global" module="tei" mode="change" type="atts">
                 <attList>
                   <attDef ident="xml:id" mode="change" ns="http://www.w3.org/XML/1998/namespace">
-                    <constraintSpec scheme="schematron" ident="unique_xmlIDs">
+                    <constraintSpec scheme="schematron" ident="unique_xmlIDs" xml:lang="en">
                       <constraint>
 			<sch:rule context="@xml:id">
                           <sch:let name="myID" value="normalize-space(.)"/>
@@ -1550,7 +1550,7 @@
               <classSpec ident="att.global.rendition" module="tei" mode="delete" type="atts"/>
               <classSpec ident="att.global.responsibility" module="tei" mode="delete" type="atts"/>
 
-              <constraintSpec scheme="schematron" ident="tei-source">
+              <constraintSpec scheme="schematron" ident="tei-source" xml:lang="en">
                 <desc>Constrains the <att>source</att> attribute of
                 various tagset documentation elements to those values
                 recommended by TEI</desc>

--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -44,6 +44,12 @@
         <moduleRef url="Exemplars/mathml2-main.rng"/>
         <moduleRef url="Exemplars/relaxng.rng"/>
 
+	<elementSpec module="tagdocs" ident="constraintSpec" mode="change">
+	  <attList>
+	    <attDef mode="change" ident="xml:lang" usage="req"/>
+	  </attList>
+	</elementSpec>
+	
         <constraintSpec scheme="schematron" ident="when_glosses_English_required">
           <desc>Per <ref
           target="https://github.com/TEIC/TEI/issues/2037">ticket


### PR DESCRIPTION
Added `@xml:lang="en"` to the 88 `<constraintSpec>`s that did not already have `@xml:lang`. (It turns out there were three that already had it, all of which are in "fr".)