### PR TITLE
heed `@role` of `<sch:assert>` and `<sch:report>`

### DIFF
--- a/P5/Utilities/validator.xsl
+++ b/P5/Utilities/validator.xsl
@@ -46,7 +46,13 @@
   <xsl:template match="svrl:failed-assert|svrl:successful-report">
     <xsl:variable name="outGI">
       <xsl:choose>
-        <xsl:when test="@role='nonfatal'">WARNING</xsl:when>
+	<!-- We explicitly test for the 6 values oXygen provides in its
+	     “sample values include” list, plus the 1 other value that
+	     actually occurs in P5. -->
+	<xsl:when test="@role = ('info','information')">INFORMATION</xsl:when>
+	<xsl:when test="@role = ('warn','warning')"    >WARNING</xsl:when>
+	<xsl:when test="@role eq 'nonfatal'"           >WARNING</xsl:when>
+	<xsl:when test="@role = ('error','fatal')"     >ERROR</xsl:when>
         <xsl:otherwise>ERROR</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>


### PR DESCRIPTION
Turns out we were only testing for "nonfatal" vs everything else. However (since oXygen gives user the choice of "info", "information", "warn", "warning", "error", or "fatal") we have several cases of other values. Changed code to check for any of the union of the values we actually have and the values oXygen has in its “sample values include” list.

I did not set a milestone for this because it is _not_ for the 4.9.0 or some future release, it is for tomorrow’s 4.8.1 release.

