### PR TITLE
Fix gloss

### DIFF
--- a/P5/Source/Specs/attDef.xml
+++ b/P5/Source/Specs/attDef.xml
@@ -123,7 +123,7 @@
           <gloss xml:lang="zh-TW" versionDate="2007-05-02">必備的</gloss>
         </valItem>
         <valItem ident="rec">
-          <gloss versionDate="2005-01-14" xml:lang="en">recommended </gloss>
+          <gloss versionDate="2005-01-14" xml:lang="en">recommended</gloss>
           <gloss xml:lang="zh-TW" versionDate="2007-05-02">推薦的</gloss>
           <gloss versionDate="2008-04-05" xml:lang="ja">推奨。</gloss>
           <gloss versionDate="2007-06-12" xml:lang="fr">recommandé</gloss>
@@ -131,7 +131,7 @@
           <gloss versionDate="2007-05-04" xml:lang="es">recomendado</gloss>
         </valItem>
         <valItem ident="opt">
-          <gloss versionDate="2005-01-14" xml:lang="en">optional </gloss>
+          <gloss versionDate="2005-01-14" xml:lang="en">optional</gloss>
           <gloss versionDate="2008-04-05" xml:lang="ja">選択的。</gloss>
           <gloss versionDate="2007-06-12" xml:lang="fr">facultatif</gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">facoltativo</gloss>

--- a/P5/Source/Specs/castGroup.xml
+++ b/P5/Source/Specs/castGroup.xml
@@ -6,7 +6,7 @@
   <gloss versionDate="2007-12-20" xml:lang="ko">배역 목록 모아 놓기</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">角色群組</gloss>
   <gloss versionDate="2008-04-06" xml:lang="es">grupo de reparto</gloss>
-  <gloss versionDate="2007-06-12" xml:lang="fr">liste de personnages </gloss>
+  <gloss versionDate="2007-06-12" xml:lang="fr">liste de personnages</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">raggruppamento della lista dei personaggi</gloss>
   <gloss versionDate="2023-10-02" xml:lang="ja">配役リスト内グループ</gloss>
   <desc versionDate="2017-02-07" xml:lang="en">groups one or more individual <gi>castItem</gi>

--- a/P5/Source/Specs/castList.xml
+++ b/P5/Source/Specs/castList.xml
@@ -6,7 +6,7 @@
   <gloss versionDate="2007-12-20" xml:lang="ko">배역 목록</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">角色清單</gloss>
   <gloss versionDate="2008-04-06" xml:lang="es">reparto</gloss>
-  <gloss versionDate="2007-06-12" xml:lang="fr">distribution </gloss>
+  <gloss versionDate="2007-06-12" xml:lang="fr">distribution</gloss>
   <gloss versionDate="2024-04-11" xml:lang="de">Besetzungsliste</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">elenco dei personaggi</gloss>
   <gloss versionDate="2023-10-02" xml:lang="ja">配役リスト</gloss>

--- a/P5/Source/Specs/div1.xml
+++ b/P5/Source/Specs/div1.xml
@@ -6,7 +6,7 @@
   <gloss versionDate="2007-12-20" xml:lang="ko">1 층위 텍스트 구역</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">區段層次一</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">division du texte de niveau 1</gloss>
-  <gloss versionDate="2006-10-18" xml:lang="de"> Textgliederungsebene -1 </gloss>
+  <gloss versionDate="2006-10-18" xml:lang="de"> Textgliederungsebene -1</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">división textual de primer nivel</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">partizione testuale di livello 1</gloss>
   <desc versionDate="2007-02-11" xml:lang="en">contains a first-level subdivision of the front, body, or back of a text.</desc>

--- a/P5/Source/Specs/div2.xml
+++ b/P5/Source/Specs/div2.xml
@@ -6,7 +6,7 @@
   <gloss versionDate="2007-12-20" xml:lang="ko">2 층위 텍스트 구역</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">區段層次二</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">division du texte de niveau 2</gloss>
-  <gloss versionDate="2006-10-18" xml:lang="de"> Textgliederungsebene -2 </gloss>
+  <gloss versionDate="2006-10-18" xml:lang="de"> Textgliederungsebene -2</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">división textual de segundo nivel</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">partizione testuale di livello 2</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">contains a second-level subdivision of the front, body, or back of a

--- a/P5/Source/Specs/div3.xml
+++ b/P5/Source/Specs/div3.xml
@@ -6,7 +6,7 @@
   <gloss versionDate="2007-12-20" xml:lang="ko">3 층위 텍스트 구역</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">區段層次三</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">division du texte de niveau 3</gloss>
-  <gloss versionDate="2006-10-18" xml:lang="de"> Textgliederungsebene -3 </gloss>
+  <gloss versionDate="2006-10-18" xml:lang="de"> Textgliederungsebene -3</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">división textual de tercer nivel</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">partizione testuale di livello 3</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">contains a third-level subdivision of the front, body, or back of a text.</desc>

--- a/P5/Source/Specs/div4.xml
+++ b/P5/Source/Specs/div4.xml
@@ -6,7 +6,7 @@
   <gloss versionDate="2007-12-20" xml:lang="ko">4 층위 텍스트 구역</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">區段層次四</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">division du texte de niveau 4</gloss>
-  <gloss versionDate="2006-10-18" xml:lang="de">Textgliederungsebene -4 </gloss>
+  <gloss versionDate="2006-10-18" xml:lang="de">Textgliederungsebene -4</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">división textual de cuarto nivel</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">partizione testuale di livello 4</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">contains a fourth-level subdivision of the front, body, or back of a text.</desc>

--- a/P5/Source/Specs/div6.xml
+++ b/P5/Source/Specs/div6.xml
@@ -6,7 +6,7 @@
   <gloss versionDate="2007-12-20" xml:lang="ko">6 층위 텍스트 구역</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">區段層次六</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">division du texte de niveau 6</gloss>
-  <gloss versionDate="2006-10-18" xml:lang="de">Textgliederungsebene -6 </gloss>
+  <gloss versionDate="2006-10-18" xml:lang="de">Textgliederungsebene -6</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">división textual de sexto nivel</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">partizione testuale di livello 6</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">contains a sixth-level subdivision of the front, body, or back of a text.</desc>

--- a/P5/Source/Specs/div7.xml
+++ b/P5/Source/Specs/div7.xml
@@ -6,7 +6,7 @@
   <gloss versionDate="2007-12-20" xml:lang="ko">7 층위 텍스트 구역</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">區段層次七</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr"> division du texte de niveau 7</gloss>
-  <gloss versionDate="2006-10-18" xml:lang="de"> Textgliederungsebene -7 </gloss>
+  <gloss versionDate="2006-10-18" xml:lang="de"> Textgliederungsebene -7</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">división textual de nivel séptimo</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">partizione testuale di livello 7</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">contains the smallest possible subdivision of the front, body or back of a text, larger than

--- a/P5/Source/Specs/fDescr.xml
+++ b/P5/Source/Specs/fDescr.xml
@@ -4,7 +4,7 @@
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="iso-fs" xml:id="gi-fDescr" ident="fDescr">
   <gloss versionDate="2005-01-14" xml:lang="en">feature description (in FSD)</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">자질 기술(FSD에서)</gloss>
-  <gloss versionDate="2007-05-02" xml:lang="zh-TW">功能描述 (在功能結構宣告中) </gloss>
+  <gloss versionDate="2007-05-02" xml:lang="zh-TW">功能描述 (在功能結構宣告中)</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">description de trait (dans FSD)</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">descripción de rasgo (en FSD)</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">descrifine di tratto (in FSD)</gloss>

--- a/P5/Source/Specs/fsdDecl.xml
+++ b/P5/Source/Specs/fsdDecl.xml
@@ -6,7 +6,7 @@
   <gloss versionDate="2009-04-16" xml:lang="fr">Déclaration de système de traits (FSD)</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">자질 체계 선언</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">功能系統宣告</gloss>
-  <gloss versionDate="2018-07-18" xml:lang="de">Deklaration des Merkmalsystems </gloss>
+  <gloss versionDate="2018-07-18" xml:lang="de">Deklaration des Merkmalsystems</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">declaración FSD (Declaración del Sistema de Rasgos)</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">dichiarazione su FSD (dichiarazione del sistema di tratti)</gloss>
   <desc versionDate="2007-09-26" xml:lang="en">provides a feature system declaration comprising one or more

--- a/P5/Source/Specs/geoDecl.xml
+++ b/P5/Source/Specs/geoDecl.xml
@@ -79,7 +79,7 @@
         <valItem ident="OSGB36">
           <gloss versionDate="2007-07-04" xml:lang="en">ordnance survey great britain</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">영국 육지 측량부</gloss>
-          <gloss versionDate="2008-03-30" xml:lang="fr">Système de coordonnées de Grande-Bretagne (OSGB) </gloss>
+          <gloss versionDate="2008-03-30" xml:lang="fr">Système de coordonnées de Grande-Bretagne (OSGB)</gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">sistema di riferimento a reticolato OSGB36</gloss>
           <desc versionDate="2007-06-25" xml:lang="en">the value supplied is to be interpreted as a British National Grid Reference.</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">제시된 값은 영국 측량 참조로 해석된다.</desc>

--- a/P5/Source/Specs/gram.xml
+++ b/P5/Source/Specs/gram.xml
@@ -5,7 +5,7 @@
   <gloss versionDate="2005-01-14" xml:lang="en">grammatical information</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">문법 정보</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">文法資訊</gloss>
-  <gloss versionDate="2007-06-12" xml:lang="fr">information grammaticale </gloss>
+  <gloss versionDate="2007-06-12" xml:lang="fr">information grammaticale</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">información gramatical</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">informazioni grammaticali</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">within an entry in a dictionary or a terminological data file, contains grammatical information relating to a term, word, or form.</desc>
@@ -58,7 +58,7 @@
           <gloss versionDate="2007-06-12" xml:lang="fr">partie du discours (chacune des classes de
             mot auxquelles un mot peut appartenir dans une langue donnée, en fonction de la forme,
             du sens ou d'une combinaison de caractéristiques, par exemple nom, verbe, adjectif,
-            etc.) </gloss>
+            etc.)</gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">parte del discorso</gloss>
           <gloss versionDate="2007-05-04" xml:lang="es">parte del discurso (cualquiera de las
             categorías de palabras que se puede encontrar en una lengua dada, basándose en la forma,

--- a/P5/Source/Specs/headItem.xml
+++ b/P5/Source/Specs/headItem.xml
@@ -5,7 +5,7 @@
   <gloss versionDate="2005-01-14" xml:lang="en">heading for list items</gloss>
   <gloss versionDate="2007-12-20" xml:lang="ko">목록의 항목에 대한 표제부</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">列表項目的標題</gloss>
-  <gloss versionDate="2009-01-06" xml:lang="fr">intitulé d'une liste d'items </gloss>
+  <gloss versionDate="2009-01-06" xml:lang="fr">intitulé d'une liste d'items</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">encabezamiento de los ítems de una lista.</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">titolo per le voci della lista</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">contains the heading for the item or gloss column in a glossary list or similar structured

--- a/P5/Source/Specs/metDecl.xml
+++ b/P5/Source/Specs/metDecl.xml
@@ -78,13 +78,10 @@
         <valItem ident="met">
           <gloss versionDate="2007-05-12" xml:lang="en"><att>met</att> attribute</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko"><att>met</att> 속성</gloss>
-          <gloss versionDate="2007-05-02" xml:lang="zh-TW">屬性<att>met</att>
-               </gloss>
-          <gloss versionDate="2007-06-12" xml:lang="fr">attribut <att>met</att>
-               </gloss>
+          <gloss versionDate="2007-05-02" xml:lang="zh-TW">屬性<att>met</att></gloss>
+          <gloss versionDate="2007-06-12" xml:lang="fr">attribut <att>met</att></gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">attributo met</gloss>
-          <gloss versionDate="2007-05-04" xml:lang="es">atributo <att>met</att>
-               </gloss>
+          <gloss versionDate="2007-05-04" xml:lang="es">atributo <att>met</att></gloss>
           <desc versionDate="2007-05-12" xml:lang="en">declaration applies to the abstract metrical form recorded on the <att>met</att>
             attribute</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">선언은 <att>met</att> 속성에 기록된 추상적 운율 형식에 적용한다.</desc>
@@ -100,13 +97,10 @@
         <valItem ident="real">
           <gloss versionDate="2007-05-12" xml:lang="en"><att>real</att> attribute</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko"><att>real</att> 속성</gloss>
-          <gloss versionDate="2007-05-02" xml:lang="zh-TW">屬性<att>real</att>
-               </gloss>
-          <gloss versionDate="2007-06-12" xml:lang="fr">attribut <att>real</att>
-               </gloss>
+          <gloss versionDate="2007-05-02" xml:lang="zh-TW">屬性<att>real</att></gloss>
+          <gloss versionDate="2007-06-12" xml:lang="fr">attribut <att>real</att></gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">attributo real</gloss>
-          <gloss versionDate="2007-05-04" xml:lang="es">atributo <att>real</att>
-               </gloss>
+          <gloss versionDate="2007-05-04" xml:lang="es">atributo <att>real</att></gloss>
           <desc versionDate="2007-05-12" xml:lang="en">declaration applies to the actual realization of the conventional metrical structure
             recorded on the <att>real</att> attribute</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">선언은 <att>real</att> 속성에 기록된 관례적 운율 구조의 실제 실현에

--- a/P5/Source/Specs/move.xml
+++ b/P5/Source/Specs/move.xml
@@ -81,7 +81,7 @@
           <gloss versionDate="2007-07-04" xml:lang="en">left</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">왼쪽</gloss>
           <gloss versionDate="2008-04-06" xml:lang="es">izquierdo</gloss>
-          <gloss versionDate="2007-06-12" xml:lang="fr">à gauche </gloss>
+          <gloss versionDate="2007-06-12" xml:lang="fr">à gauche</gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">sinistra</gloss>
           <desc versionDate="2007-06-27" xml:lang="en">stage left</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">무대 왼쪽</desc>
@@ -109,7 +109,7 @@
           <gloss versionDate="2007-07-04" xml:lang="en">center</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">중앙</gloss>
           <gloss versionDate="2008-04-06" xml:lang="es">centro</gloss>
-          <gloss versionDate="2007-06-12" xml:lang="fr">au centre </gloss>
+          <gloss versionDate="2007-06-12" xml:lang="fr">au centre</gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">centro</gloss>
           <desc versionDate="2007-06-27" xml:lang="en">centre stage</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">무대 중앙</desc>

--- a/P5/Source/Specs/roleDesc.xml
+++ b/P5/Source/Specs/roleDesc.xml
@@ -6,7 +6,7 @@
   <gloss versionDate="2007-12-20" xml:lang="ko">배역 기술</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">角色描述</gloss>
   <gloss versionDate="2008-04-06" xml:lang="es">descripción del rol</gloss>
-  <gloss versionDate="2007-06-12" xml:lang="fr">description du rôle </gloss>
+  <gloss versionDate="2007-06-12" xml:lang="fr">description du rôle</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">descrizione del ruolo</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">describes a character's role in a drama.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">드라마에서 등장인물의 배역을 기술한다.</desc>

--- a/P5/Source/Specs/tech.xml
+++ b/P5/Source/Specs/tech.xml
@@ -6,7 +6,7 @@
   <gloss versionDate="2007-12-20" xml:lang="ko">전문적 무대 지시</gloss>
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">技術性舞台指示</gloss>
   <gloss versionDate="2008-04-06" xml:lang="es">dirección técnica de escena</gloss>
-  <gloss versionDate="2007-06-12" xml:lang="fr">indication technique de mise en scène </gloss>
+  <gloss versionDate="2007-06-12" xml:lang="fr">indication technique de mise en scène</gloss>
   <gloss versionDate="2007-01-21" xml:lang="it">Indicazioni i scena tecniche</gloss>
   <desc versionDate="2005-01-14" xml:lang="en">describes a special-purpose stage direction that is not
 meant for the actors.</desc>

--- a/P5/Source/Specs/usg.xml
+++ b/P5/Source/Specs/usg.xml
@@ -133,7 +133,7 @@
         <valItem ident="gram">
           <gloss versionDate="2007-07-04" xml:lang="en">grammatical</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">문법적</gloss>
-          <gloss versionDate="2007-06-12" xml:lang="fr">emploi grammatical </gloss>
+          <gloss versionDate="2007-06-12" xml:lang="fr">emploi grammatical</gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">grammaticale</gloss>
           <gloss versionDate="2007-05-04" xml:lang="es">uso gramatical</gloss>
           <desc versionDate="2007-06-27" xml:lang="en">grammatical usage</desc>

--- a/P5/Source/Specs/vMerge.xml
+++ b/P5/Source/Specs/vMerge.xml
@@ -7,7 +7,7 @@
   <gloss versionDate="2007-05-02" xml:lang="zh-TW">合併的值集合</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">collection fusionnée de valeurs</gloss>
   <gloss versionDate="2007-05-04" xml:lang="es">conjunto fusionado de valores</gloss>
-  <gloss versionDate="2007-01-21" xml:lang="it">una raccolta unificata di valori </gloss>
+  <gloss versionDate="2007-01-21" xml:lang="it">una raccolta unificata di valori</gloss>
   <desc versionDate="2006-06-28" xml:lang="en">represents a feature value which is the result of merging
   together the feature values contained by its children, using the organization
   specified by the <att>org</att> attribute.</desc>

--- a/P5/Source/Specs/valList.xml
+++ b/P5/Source/Specs/valList.xml
@@ -56,7 +56,7 @@
         <valItem ident="semi">
           <gloss versionDate="2007-07-04" xml:lang="en">semi-open</gloss>
           <gloss versionDate="2007-12-20" xml:lang="ko">반개방</gloss>
-          <gloss versionDate="2007-06-12" xml:lang="fr">semi-ouvert </gloss>
+          <gloss versionDate="2007-06-12" xml:lang="fr">semi-ouvert</gloss>
           <gloss versionDate="2007-11-06" xml:lang="it">semiaperto</gloss>
           <gloss versionDate="2007-05-04" xml:lang="es">todos los valores indicados deben ser
           soportados pero son consentidos otros valores para los que son necesarios sistemas de


### PR DESCRIPTION
This is a minor clean-up PR removing white space before the closing tags of `gloss` entries.

<img width="141" alt="grafik" src="https://github.com/user-attachments/assets/2bdb5ab2-e341-478c-92ff-62196379f988">
