### PR TITLE
add the missing entities for angle brackets

### DIFF
--- a/P5/Source/Specs/constraintSpec.xml
+++ b/P5/Source/Specs/constraintSpec.xml
@@ -109,7 +109,7 @@
       <constraintSpec scheme="schematron" ident="usage_based_on_mode" xml:lang="en">
         <constraint>
           <sch:rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]">
-            <sch:assert test="@scheme">The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is <sch:value-of select="if (@mode) then concat('&quot;',@mode,'&quot;') else 'not specified'"/> (here on "<sch:value-of select="@ident"/>")</sch:assert>
+            <sch:assert test="@scheme">The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is <sch:value-of select="if (@mode) then concat('&quot;',@mode,'&quot;') else 'not specified'"/> (here on "&lt;sch:value-of select="@ident"/&gt;")</sch:assert>
           </sch:rule>
         </constraint>
       </constraintSpec>


### PR DESCRIPTION
This one is very loosely connected to #2623 in that I just continue a very shallow inspection of that commit. 
This seems to be a case where the regex did not catch the brackets to be converted to entities (or I miss something important, and hence the request for @sydb to inspect the PR)