### PR TITLE
p5odds.odd bug fix

### DIFF
--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -184,8 +184,8 @@
             </desc>
             <constraint>
               <sch:rule context="tei:eg">
-                <sch:report test="matches( .//text()[last()], '&#x0A;\s*$')">trailing newline not allowed</sch:report>
-                <sch:report test="matches( .//text()[1],      '^\s*&#x0A;')">leading newline not allowed</sch:report>
+                <sch:report test="matches( ./text()[last()], '&#x0A;\s*$')">trailing newline not allowed</sch:report>
+                <sch:report test="matches( ./text()[1],      '^\s*&#x0A;')">leading newline not allowed</sch:report>
               </sch:rule>
             </constraint>
           </constraintSpec>

--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -184,8 +184,8 @@
             </desc>
             <constraint>
               <sch:rule context="tei:eg">
-                <sch:report test="matches( ./text()[last()], '&#x0A;\s*$')">trailing newline not allowed</sch:report>
-                <sch:report test="matches( ./text()[1],      '^\s*&#x0A;')">leading newline not allowed</sch:report>
+                <sch:report test="matches( string(.), '&#x0A;\s*$')">trailing newline not allowed</sch:report>
+                <sch:report test="matches( string(.), '^\s*&#x0A;')">leading newline not allowed</sch:report>
               </sch:rule>
             </constraint>
           </constraintSpec>


### PR DESCRIPTION
The constraint on `<eg>` was looking for _all_ descendant text nodes, not just child text nodes. That means that if there is any phrase-level encoding in an `<eg>`  then there is more than one text node that has (for example) `position()=last()`, and the XPath fails because only one item is allowed as the first argument to `matches()`.

Fix seems trivial: search only for child text nodes, not descendant text nodes.

Note: I am not sure the “TEI: ODD” label is correctly — it might be for the TEI language defined _by_ the Guidelines, not the TEI language defined _for_ the Guidelines. Sigh. Anyway, this is **high** priority because it is holding up work on #2516.