### PR TITLE
p5odds: Allow "URN" as value of `@type` of `<idno>`

### DIFF
--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -44,12 +44,12 @@
         <moduleRef url="Exemplars/mathml2-main.rng"/>
         <moduleRef url="Exemplars/relaxng.rng"/>
 
-	<elementSpec module="tagdocs" ident="constraintSpec" mode="change">
-	  <attList>
-	    <attDef mode="change" ident="xml:lang" usage="req"/>
-	  </attList>
-	</elementSpec>
-	
+        <elementSpec module="tagdocs" ident="constraintSpec" mode="change">
+          <attList>
+            <attDef mode="change" ident="xml:lang" usage="req"/>
+          </attList>
+        </elementSpec>
+        
         <constraintSpec scheme="schematron" ident="when_glosses_English_required">
           <desc>Per <ref
           target="https://github.com/TEIC/TEI/issues/2037">ticket
@@ -676,8 +676,14 @@
                 <valItem ident="ISBN">
                   <gloss versionDate="2013-10-30" xml:lang="en">International Standard Book Number</gloss>
                 </valItem>
-                <valItem ident="url">
-                  <gloss versionDate="2013-10-30" xml:lang="en">any form of web address</gloss>
+                <valItem ident="URI">
+                  <gloss versionDate="2013-10-30" xml:lang="en">any form of web address (a URL or a URN)</gloss>
+                </valItem>
+                <valItem ident="URL">
+                  <gloss versionDate="2024-12-04" xml:lang="en">Uniform Resource Locator</gloss>
+                </valItem>
+                <valItem ident="URN">
+                  <gloss versionDate="2024-12-04" xml:lang="en">Uniform Resource Name</gloss>
                 </valItem>
               </valList>
             </attDef>

--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -677,7 +677,8 @@
                   <gloss versionDate="2013-10-30" xml:lang="en">International Standard Book Number</gloss>
                 </valItem>
                 <valItem ident="URI">
-                  <gloss versionDate="2013-10-30" xml:lang="en">any form of web address (a URL or a URN)</gloss>
+                  <gloss versionDate="2024-12-04" xml:lang="en">Uniform Resource Identifier</gloss>
+		  <desc versionDate="2013-10-30" xml:lang="en">any form of web address (that is, a URL or a URN)</desc>
                 </valItem>
                 <valItem ident="URL">
                   <gloss versionDate="2024-12-04" xml:lang="en">Uniform Resource Locator</gloss>


### PR DESCRIPTION
Per Slack conversation with @raffazizzi , add "URN" as possible value to `@type` of `<idno>` in p5odds. While I was there I also:

- Changed "url" to "URL"
- Added "URI"
- Updated glosses & descriptions a bit

I have checked. Use of `<idno type="URN">` results in output that is not really pretty in the HTML _Guidelines_ (specifically, in the Bibliography), but not particularly ugly, either, and does not falsely imply that your web browser will open a URN. (Which use of `<ptr target="urn:duck:billed:platypus"/>` would.)

I have also checked, and there were no occurrences of `<idno type="url">` in P5, so changing this to "URL" should not cause problems.