### PR TITLE
Removing conflicting sup css rules in teic.css and guidelines.css

### DIFF
--- a/P5/guidelines.css
+++ b/P5/guidelines.css
@@ -630,6 +630,10 @@ div.note ul {
 }
 span.noteLabel {
 }
+a.notelink {
+    text-decoration: none;
+}
+
 /* images */
 div.figure {
     text-align: left;
@@ -812,10 +816,7 @@ span.icon {
     font-weight: bold;
     font-size: large;
 }
-sup {
-    vertical-align: top;
-    font-size: 70%;
-}
+
 /* paragraphs */
 p, div.p {
     margin-top: 0.3em;


### PR DESCRIPTION
Also adds a rule for a.notelink.

This addresses the Stylesheets issue 718: https://github.com/TEIC/Stylesheets/issues/718 

I copy from there:

There seem to be conflicted rules for sup.

In guidelines.css :

```
sup {
    vertical-align: top;
    font-size: 70%;
}
```

In teic.css :

```
sub,
sup {
  position: relative;
  font-size: 0.75em;
  line-height: 0;
  vertical-align: baseline;
}

sup {
  top: -0.5em;
}
```

Both are applied to the guidelines html version, as guidelines.css imports teic.css .

The version in teic.css is newer, made by @hcayless 3 months ago. The version in guidelines.css is older, 17 years ago by Sebastian Rahtz

If we remove the instructions in guidelines.css the links are at the correct height.

There remains the issue of the underlined, but that should be done directly for the class notelink

