### PR TITLE
Make rotate attribute of type teidata.numeric

### DIFF
--- a/P5/Source/Specs/zone.xml
+++ b/P5/Source/Specs/zone.xml
@@ -41,7 +41,7 @@ element.</desc>
         Als Bezugspunkt gilt dabei die natürliche Ausrichtung des <gi>surface</gi>-Elternelements, die entweder
         im <gi>msDesc</gi>-Element beschrieben ist oder durch die Koordinaten des <gi>surface</gi>-Elements selbst.
         Die Drehung wird in Bogengrad angegeben.</desc>
-      <datatype minOccurs="1" maxOccurs="1"><dataRef key="teidata.count"/></datatype>
+      <datatype minOccurs="1" maxOccurs="1"><dataRef key="teidata.numeric"/></datatype>
       <defaultVal>0</defaultVal>
     </attDef>
   </attList>


### PR DESCRIPTION
This PR changes `zone@rotate` into `teidata.numeric` in order to allow negative and non-integer values.
Closes #2637