### PR TITLE
Allow hand in dateline

### DIFF
--- a/P5/Source/Specs/dateline.xml
+++ b/P5/Source/Specs/dateline.xml
@@ -25,6 +25,7 @@
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.cmc"/>
+    <memberOf key="att.written"/>
     <memberOf key="model.divWrapper"/>
     <memberOf key="model.pLike.front"/>
   </classes>


### PR DESCRIPTION
This PR makes `dateline` member of `att.written` so that `hand` is available.

addresses #2550