### PR TITLE
Making bibl, and others, member of att.canonical.

### DIFF
--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -4208,7 +4208,7 @@ below.  </p>
   </egXML>
   The <att>key</att> attribute, on the other hand, links a bibliographical reference to an externally- or project-defined identifier as demonstrated here:
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibkey" source="#NONE">
-    <bibl key="Homer Iliad 16">Book 16 of <author>Homer</author>'s <title>Iliad</title>.</bibl>
+    <bibl key="Homer_Iliad.16">Book 16 of <author>Homer</author>'s <title>Iliad</title>.</bibl>
   </egXML>
   These attributes should not be used for encoding bibliographic pointers (short-form citations); for that purpose, see section <ptr target="#COBIXR"/> below.
 </p>

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -4202,7 +4202,7 @@ encoding of short-form references such as <mentioned>Baxter,
 cross-references to such elements; see section <ptr target="#COBIXR"/>
 below.  </p> 
 <p>
-  Bibliographic references encoded with <gi>bibl</gi>, <gi>biblFull</gi>, or <gi>biblStruct</gi> may link to a likely more detailed bibliographic reference to the same resource using either the attribute <att>ref</att> or <att>key</att> defined in <ident type="class">att.canonical</ident>. The <att>ref</att> may be used to point to a definition either within or outside the TEI document, as shown in the following example:
+  Bibliographic references encoded with <gi>bibl</gi>, <gi>biblFull</gi>, or <gi>biblStruct</gi> may link to a another, likely more detailed, bibliographic reference to the same resource using either the attribute <att>ref</att> or <att>key</att> defined in <ident type="class">att.canonical</ident>. The <att>ref</att> attribute performs this linking function using a URI that may point either within or outside the TEI document, as shown in the following example:
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibref" source="#NONE">
     <bibl ref="https://search.worldcat.org/title/song-of-achilles/oclc/911117343"><title>The song of Achilles</title> by <author>Madeline Miller</author>.</bibl>
   </egXML>

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -4206,7 +4206,7 @@ below.  </p>
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibref" source="#NONE">
     <bibl ref="https://search.worldcat.org/title/song-of-achilles/oclc/911117343"><title>The song of Achilles</title> by <author>Madeline Miller</author>.</bibl>
   </egXML>
-  The <att>key</att> attribute, on the other hand, links a bibliographical reference to an externally- or project-defined identifier as demonstrated here:
+  The <att>key</att> attribute, on the other hand, associates a bibliographical reference to an external or project-defined identifier as demonstrated here:
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibkey" source="#NONE">
     <bibl key="Homer_Iliad.16">Book 16 of <author>Homer</author>'s <title>Iliad</title>.</bibl>
   </egXML>

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -4202,7 +4202,7 @@ encoding of short-form references such as <mentioned>Baxter,
 cross-references to such elements; see section <ptr target="#COBIXR"/>
 below.  </p> 
 <p>
-  Bibliographic references encoded with <gi>bibl</gi>, <gi>biblFull</gi>, and <gi>biblStruct</gi> may link to a likely more detailed bibliographic reference to the same resource using either the attribute <att>ref</att> or <att>key</att> defined in <ident type="class">att.canonical</ident>. The <att>ref</att> may be used to point to a definition either within or outside the TEI document, as shown in the following example:
+  Bibliographic references encoded with <gi>bibl</gi>, <gi>biblFull</gi>, or <gi>biblStruct</gi> may link to a likely more detailed bibliographic reference to the same resource using either the attribute <att>ref</att> or <att>key</att> defined in <ident type="class">att.canonical</ident>. The <att>ref</att> may be used to point to a definition either within or outside the TEI document, as shown in the following example:
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibref" source="#NONE">
     <bibl ref="https://search.worldcat.org/title/song-of-achilles/oclc/911117343"><title>The song of Achilles</title> by <author>Madeline Miller</author>.</bibl>
   </egXML>

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -4202,7 +4202,7 @@ encoding of short-form references such as <mentioned>Baxter,
 cross-references to such elements; see section <ptr target="#COBIXR"/>
 below.  </p> 
 <p>
-  Bibliographic references encoded with <gi>bibl</gi>, <gi>biblFull</gi>, or <gi>biblStruct</gi> may link to a another, possibly more detailed, bibliographic reference to the same resource using either the attribute <att>ref</att> or <att>key</att> defined in <ident type="class">att.canonical</ident>. The <att>ref</att> attribute performs this linking function using a URI that may point either within or outside the TEI document, as shown in the following example:
+  Bibliographic references encoded with <gi>bibl</gi>, <gi>biblFull</gi>, or <gi>biblStruct</gi> may link to another, possibly more detailed, bibliographic reference to the same resource using either the attribute <att>ref</att> or <att>key</att> defined in <ident type="class">att.canonical</ident>. The <att>ref</att> attribute performs this linking function using a URI that may point either within or outside the TEI document, as shown in the following example:
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibref" source="#NONE">
     <bibl ref="https://search.worldcat.org/title/song-of-achilles/oclc/911117343"><title>The song of Achilles</title> by <author>Madeline Miller</author>.</bibl>
   </egXML>

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -4202,7 +4202,7 @@ encoding of short-form references such as <mentioned>Baxter,
 cross-references to such elements; see section <ptr target="#COBIXR"/>
 below.  </p> 
 <p>
-  Bibliographic references encoded with <gi>bibl</gi>, <gi>biblFull</gi>, and <gi>biblStruct</gi> may use the attributes defined in <ident type="class">att.canonical</ident>: <att>ref</att> and <att>key</att>. The <att>ref</att> may be used to point to a more detailed definition, either within or outside the TEI document, as shown in the following example:
+  Bibliographic references encoded with <gi>bibl</gi>, <gi>biblFull</gi>, and <gi>biblStruct</gi> may link to a likely more detailed bibliographic reference to the same resource using either the attribute <att>ref</att> or <att>key</att> defined in <ident type="class">att.canonical</ident>. The <att>ref</att> may be used to point to a definition either within or outside the TEI document, as shown in the following example:
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibref" source="#NONE">
     <bibl ref="https://search.worldcat.org/title/song-of-achilles/oclc/911117343"><title>The song of Achilles</title> by <author>Madeline Miller</author>.</bibl>
   </egXML>

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -4201,6 +4201,17 @@ encoding of short-form references such as <mentioned>Baxter,
 1983</mentioned> is not as <gi>bibl</gi> elements but as
 cross-references to such elements; see section <ptr target="#COBIXR"/>
 below.  </p> 
+<p>
+  Bibliographic references encoded with <gi>bibl</gi>, <gi>biblFull</gi>, and <gi>biblStruct</gi> may use the attributes defined in <ident type="class">att.canonical</ident>: <att>ref</att> and <att>key</att>. The <att>ref</att> may be used to point to a more detailed definition, either within or outside the TEI document, as shown in the following example:
+  <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibref" source="#NONE">
+    <bibl ref="https://search.worldcat.org/title/song-of-achilles/oclc/911117343"><title>The song of Achilles</title> by <author>Madeline Miller</author>.</bibl>
+  </egXML>
+  The <att>key</att> attribute, on the other hand, links a bibliographical reference to an externally- or project-defined identifier as demonstrated here:
+  <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibkey" source="#NONE">
+    <bibl key="Homer Iliad 16">Book 16 of <author>Homer</author>'s <title>Iliad</title>.</bibl>
+  </egXML>
+  These attributes should not be used for encoding bibliographic pointers (short-form citations); for that purpose, see section <ptr target="#COBIXR"/> below.
+</p>
 <p>In cases where the encoder wishes to impose more structure on the
 bibliographic information, for example to make sure it conforms to a
 particular stylesheet or retrieval processor, the <gi>biblStruct</gi>
@@ -5476,8 +5487,8 @@ following example:
   normalize bibliographic references: <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBIXR-egXML-cc" source="#NONE">Nelson claims (<ref target="#NEL80">Nelson [1980]</ref> pages 13–37)
     ...</egXML> 
   If it is desired to capture additional information like this in a short-form
-  reference, then <gi>bibl</gi> may be used with the <att>corresp</att> attribute pointing to
-  the full bibliographic reference: <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBIXR-egXML-hi" source="#NONE">Nelson claims (<bibl corresp="#NEL80">Nelson [1980] pages <biblScope unit="page" from="13" to="37">13–37</biblScope></bibl>) ...</egXML>
+  reference, then <gi>bibl</gi> may be used with the <att>ref</att> attribute pointing to
+  the full bibliographic reference: <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBIXR-egXML-hi" source="#NONE">Nelson claims (<bibl ref="#NEL80">Nelson [1980] pages <biblScope unit="page" from="13" to="37">13–37</biblScope></bibl>) ...</egXML>
 </p>
 <p>The <gi>ref</gi> element may also be used to provide a reference to a copy of the bibliographic item itself, particularly if this is available online, as in the following example: 
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBIXR-egXML-ad" source="#NONE">

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -4206,7 +4206,7 @@ below.  </p>
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibref" source="#NONE">
     <bibl ref="https://search.worldcat.org/title/song-of-achilles/oclc/911117343"><title>The song of Achilles</title> by <author>Madeline Miller</author>.</bibl>
   </egXML>
-  The <att>key</att> attribute, on the other hand, associates a bibliographical reference to an external or project-defined identifier as demonstrated here:
+  The <att>key</att> attribute, on the other hand, associates a bibliographical reference with an external or project-defined identifier as demonstrated here:
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibkey" source="#NONE">
     <bibl key="Homer_Iliad.16">Book 16 of <author>Homer</author>'s <title>Iliad</title>.</bibl>
   </egXML>

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -4202,7 +4202,7 @@ encoding of short-form references such as <mentioned>Baxter,
 cross-references to such elements; see section <ptr target="#COBIXR"/>
 below.  </p> 
 <p>
-  Bibliographic references encoded with <gi>bibl</gi>, <gi>biblFull</gi>, or <gi>biblStruct</gi> may link to a another, likely more detailed, bibliographic reference to the same resource using either the attribute <att>ref</att> or <att>key</att> defined in <ident type="class">att.canonical</ident>. The <att>ref</att> attribute performs this linking function using a URI that may point either within or outside the TEI document, as shown in the following example:
+  Bibliographic references encoded with <gi>bibl</gi>, <gi>biblFull</gi>, or <gi>biblStruct</gi> may link to a another, possibly more detailed, bibliographic reference to the same resource using either the attribute <att>ref</att> or <att>key</att> defined in <ident type="class">att.canonical</ident>. The <att>ref</att> attribute performs this linking function using a URI that may point either within or outside the TEI document, as shown in the following example:
   <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="COBITY-egXML-bibref" source="#NONE">
     <bibl ref="https://search.worldcat.org/title/song-of-achilles/oclc/911117343"><title>The song of Achilles</title> by <author>Madeline Miller</author>.</bibl>
   </egXML>

--- a/P5/Source/Specs/bibl.xml
+++ b/P5/Source/Specs/bibl.xml
@@ -25,6 +25,7 @@
     ausgezeichnet sein können.</desc>
   <classes>
     <memberOf key="att.global"/>
+    <memberOf key="att.canonical"/>
     <memberOf key="att.cmc"/>
     <memberOf key="att.declarable"/>
     <memberOf key="att.docStatus"/>

--- a/P5/Source/Specs/biblFull.xml
+++ b/P5/Source/Specs/biblFull.xml
@@ -23,6 +23,7 @@
     strutturata nella quale sono presenti tutti i componenti di descrizione di un file TEI.</desc>
   <classes>
     <memberOf key="att.global"/>
+    <memberOf key="att.canonical"/>
     <memberOf key="att.cmc"/>
     <memberOf key="att.declarable"/>
     <memberOf key="att.docStatus"/>

--- a/P5/Source/Specs/biblStruct.xml
+++ b/P5/Source/Specs/biblStruct.xml
@@ -22,6 +22,7 @@
     contenere solo altri elemento nell'ordine specificato.</desc>
   <classes>
     <memberOf key="att.global"/>
+    <memberOf key="att.canonical"/>
     <memberOf key="att.cmc"/>
     <memberOf key="att.declarable"/>
     <memberOf key="att.docStatus"/>


### PR DESCRIPTION
First pass at addressing #2392: Made bibl, biblFull, and biblStruct members of att.canonical. Ajusted the guidelines to reflect this addition and clarified uses of bibl vs ref.