### PR TITLE
use `<constraintDecl>` in Guidelines and tei_customization, and add CMC to French Guidelines

### DIFF
--- a/P5/Source/Specs/TEI.xml
+++ b/P5/Source/Specs/TEI.xml
@@ -42,24 +42,6 @@
       </alternate>
     </sequence>
   </content>
-  <constraintSpec ident="c1" scheme="schematron" xml:lang="en">
-    <constraint>
-      <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
-      <sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
-    </constraint>
-  </constraintSpec>
-  <constraintSpec ident="c2" scheme="schematron" xml:lang="en">
-    <constraint>
-      <sch:ns prefix="rng" uri="http://relaxng.org/ns/structure/1.0"/>
-      <sch:ns prefix="rna" uri="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-    </constraint>
-  </constraintSpec>
-  <constraintSpec ident="c3" scheme="schematron" xml:lang="en">
-    <constraint>
-      <sch:ns prefix="sch" uri="http://purl.oclc.org/dsdl/schematron"/>
-      <sch:ns prefix="sch1x" uri="http://www.ascc.net/xml/schematron"/>
-    </constraint>
-  </constraintSpec>
   <attList>
     <attDef ident="version" usage="opt">
       <desc versionDate="2018-01-24" xml:lang="en">specifies the version number of the TEI Guidelines against

--- a/P5/Source/guidelines-en.xml
+++ b/P5/Source/guidelines-en.xml
@@ -7,8 +7,9 @@ $Date$
 $Id$
 -->
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
-     xmlns:rng="http://relaxng.org/ns/structure/1.0" version="5.0"
-     rend="book" xml:lang="en">
+     xmlns:rng="http://relaxng.org/ns/structure/1.0"
+     xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+     version="5.0" rend="book" xml:lang="en">
   <teiHeader>
     <fileDesc>
       <titleStmt>
@@ -68,6 +69,16 @@ $Id$
       </publicationStmt>
       <sourceDesc><p>A long history from P2 onwards. See further <ptr target="#PREFS"/></p></sourceDesc>
     </fileDesc>
+    <encodingDesc>
+      <constraintDecl scheme="schematron" xml:lang="en">
+        <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
+        <sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+        <sch:ns prefix="rng" uri="http://relaxng.org/ns/structure/1.0"/>
+        <sch:ns prefix="rna" uri="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        <sch:ns prefix="sch" uri="http://purl.oclc.org/dsdl/schematron"/>
+        <sch:ns prefix="sch1x" uri="http://www.ascc.net/xml/schematron"/>
+      </constraintDecl>
+    </encodingDesc>
     <revisionDesc>
       <change>
         <date>$Date$.</date>

--- a/P5/Source/guidelines-fr.xml
+++ b/P5/Source/guidelines-fr.xml
@@ -7,8 +7,9 @@ $Date$
 $Id$
 -->
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
-     xmlns:rng="http://relaxng.org/ns/structure/1.0" version="5.0"
-     rend="book" xml:lang="en">
+     xmlns:rng="http://relaxng.org/ns/structure/1.0"
+     xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+     version="5.0" rend="book" xml:lang="en">
   <teiHeader>
     <fileDesc>
       <titleStmt>
@@ -68,6 +69,16 @@ $Id$
       </publicationStmt>
       <sourceDesc><p>A long history from P2 onwards. See further <ptr target="#PREFS"/></p></sourceDesc>
     </fileDesc>
+    <encodingDesc>
+      <constraintDecl scheme="schematron" xml:lang="fr">
+        <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
+        <sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+        <sch:ns prefix="rng" uri="http://relaxng.org/ns/structure/1.0"/>
+        <sch:ns prefix="rna" uri="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        <sch:ns prefix="sch" uri="http://purl.oclc.org/dsdl/schematron"/>
+        <sch:ns prefix="sch1x" uri="http://www.ascc.net/xml/schematron"/>
+      </constraintDecl>
+    </encodingDesc>
     <revisionDesc>
       <change>
         <date>$Date$.</date>
@@ -113,6 +124,7 @@ $Id$
       <include xmlns="http://www.w3.org/2001/XInclude" href="Guidelines/en/VE-Verse.xml"/>
       <include xmlns="http://www.w3.org/2001/XInclude" href="Guidelines/en/DR-PerformanceTexts.xml"/>
       <include xmlns="http://www.w3.org/2001/XInclude" href="Guidelines/en/TS-TranscriptionsofSpeech.xml"/>
+      <include xmlns="http://www.w3.org/2001/XInclude" href="Guidelines/en/CMC-ComputerMediatedCommunication.xml"/>
       <include xmlns="http://www.w3.org/2001/XInclude" href="Guidelines/en/DI-PrintDictionaries.xml"/>
       <include xmlns="http://www.w3.org/2001/XInclude" href="Guidelines/en/MS-ManuscriptDescription.xml"/>
       <include xmlns="http://www.w3.org/2001/XInclude" href="Guidelines/en/PH-PrimarySources.xml"/>

--- a/P5/Utilities/TEI-to-tei_customization.xslt
+++ b/P5/Utilities/TEI-to-tei_customization.xslt
@@ -744,6 +744,10 @@
               <moduleRef key="namesdates" include="persName placeName orgName"/>
               <xsl:comment> allow tables, figures, and formulæ </xsl:comment>
               <moduleRef key="figures" except="notatedMusic"/>
+
+              <constraintDecl scheme="schematron" queryBinding="xslt2">
+                <sch:ns prefix="teix" uri="http://www.tei-c.org/ns/Examples"/>
+              </constraintDecl>
               
               <constraintSpec scheme="schematron" ident="mode-child-sanity" xml:lang="en">
                 <constraint>


### PR DESCRIPTION
Three changes:
 * Use `<constraintDecl>` for Schematron namespace declarations in tei_customization
 * Use `<constraintDecl>` (instead of hack `<constraintSpecs>`) in the _Guidelines_ (both en & fr)
 * Added CMC to fr _Guidelines_ (kinda embarrassing that it wasn’t there!)
 
 **WARNING:**
 This PR will **not** work against the released or current dev Stylesheets, but rather against the sydb_fix_constraintDecl_oversight_01 branch of the Stylesheets; and thus it should **not** be merged until (TEIC/Stylesheets#727) is merged!