### PR TITLE
Implement @hcayless solution #1 for issue @2246 — do not test `@spanTo` across files

### DIFF
--- a/P5/Source/Specs/att.spanning.xml
+++ b/P5/Source/Specs/att.spanning.xml
@@ -5,7 +5,7 @@
   <desc versionDate="2006-01-05" xml:lang="en">provides attributes for elements which delimit a span of text by pointing mechanisms rather than by enclosing it.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">포함보다는 포인터 메카니즘을 통하여 구분된 텍스트 구간을 나타내는 요소의 속성을 제공한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">提供元素的屬性，這些元素使用參照機制來限定某一文字段，而非包含此文字段。</desc>
-  <desc versionDate="2008-04-05" xml:lang="ja">テキスト幅の範囲を内容としてではなく参照機能を使って示す要素に付与さ れる属性を示す。</desc>
+  <desc versionDate="2008-04-05" xml:lang="ja">テキスト幅の範囲を内容としてではなく参照機能を使って示す要素に付与される属性を示す。</desc>
   <desc versionDate="2007-06-12" xml:lang="fr">fournit des attributs pour les éléments qui délimitent un passage de texte par des mécanismes de pointage plutôt qu'en entourant le passage.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">proporciona atributos para elementos que delimitan un fragmento de texto utilizando los señalizadores en lugar de cerrando el texto.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">assegna degli attributi agli elementi che delimitano una porzione di testo utilizzando dei puntatori invece di racchiudere il testo stesso</desc>

--- a/P5/Source/Specs/att.spanning.xml
+++ b/P5/Source/Specs/att.spanning.xml
@@ -5,15 +5,13 @@
   <desc versionDate="2006-01-05" xml:lang="en">provides attributes for elements which delimit a span of text by pointing mechanisms rather than by enclosing it.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">포함보다는 포인터 메카니즘을 통하여 구분된 텍스트 구간을 나타내는 요소의 속성을 제공한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">提供元素的屬性，這些元素使用參照機制來限定某一文字段，而非包含此文字段。</desc>
-  <desc versionDate="2008-04-05" xml:lang="ja">テキスト幅の範囲を内容としてではなく参照機能を使って示す要素に付与さ
-  れる属性を示す。</desc>
+  <desc versionDate="2008-04-05" xml:lang="ja">テキスト幅の範囲を内容としてではなく参照機能を使って示す要素に付与さ れる属性を示す。</desc>
   <desc versionDate="2007-06-12" xml:lang="fr">fournit des attributs pour les éléments qui délimitent un passage de texte par des mécanismes de pointage plutôt qu'en entourant le passage.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">proporciona atributos para elementos que delimitan un fragmento de texto utilizando los señalizadores en lugar de cerrando el texto.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">assegna degli attributi agli elementi che delimitano una porzione di testo utilizzando dei puntatori invece di racchiudere il testo stesso</desc>
   <attList>
     <attDef ident="spanTo" usage="opt">
-      <desc versionDate="2005-10-10" xml:lang="en">indicates the end of a span initiated by the element
-        bearing this attribute.</desc>
+      <desc versionDate="2005-10-10" xml:lang="en">indicates the end of a span initiated by the element bearing this attribute.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">이 속성을 포함하는 요소에 의해 시작된 구간의 끝을 나타낸다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">指出文字段的結尾，該文字段以帶有此屬性的元素開頭。</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">当該要素が示す範囲の終点を示す。</desc>
@@ -22,12 +20,11 @@
       <desc versionDate="2007-01-21" xml:lang="it">indica la fine della porzione di testo che ha inizio con l'elemento a cui è assegnato l'attributo</desc>
       <datatype><dataRef key="teidata.pointer"/></datatype>
       <constraintSpec ident="spanTo-points-to-following" scheme="schematron" xml:lang="en">
-        <desc versionDate="2018-07-06" xml:lang="en">The @spanTo attribute must point to an element following the
-        current element</desc>
+        <desc versionDate="2025-01-19" xml:lang="en">The @spanTo attribute must point to an element following the current element; however, this can only be tested if both this element and the one pointed to are in the same document.</desc>
         <constraint>
-          <sch:rule context="tei:*[@spanTo]">
-            <sch:assert test="id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)]">
-The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow the current element <sch:name/>
+          <sch:rule context="tei:*[ starts-with( @spanTo, '#') ]">
+            <sch:assert test="id( substring( @spanTo, 2 ) ) >> .">
+	      The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow the current <sch:name/> element 
             </sch:assert>
           </sch:rule>
         </constraint>
@@ -36,15 +33,15 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
   </attList>
   <remarks versionDate="2012-10-29" xml:lang="en">
     <p>The span is defined as running in document order from the start
-    of the content of the pointing element  to the end of the
+    of the content of the pointing element to the end of the
     content of the element pointed to by the <att>spanTo</att> attribute (if
     any). If no value is supplied for the attribute, the assumption is that the span is
     coextensive with the pointing element. If no content is present,
     the assumption is that the starting point of the span is
-    immediately following the element itself. </p>
+    immediately following the element itself.</p>
   </remarks>
   <remarks versionDate="2007-06-12" xml:lang="fr">
-    <p> Le passage est défini comme courant depuis le début du contenu de l'élément pointeur (s'il y en a un) jusqu'à la fin du contenu de l'élément
+    <p>Le passage est défini comme courant depuis le début du contenu de l'élément pointeur (s'il y en a un) jusqu'à la fin du contenu de l'élément
       pointé par l'attribut <att>spanTo</att> (s'il y en a un), dans l'ordre du document. Si aucune valeur n'est fournie pour l'attribut, il est entendu
       que le passage est de même étendue que l'élément pointeur.</p>
   </remarks>

--- a/P5/Test/detest.xml
+++ b/P5/Test/detest.xml
@@ -135,7 +135,7 @@
           <delSpan spanTo="#ds1"/>This one doesn't<anchor xml:id="ds1"/> but that's also OK.
           <delSpan/> That one (just to my left) is illegal
           <delSpan spanTo="#ds2"/> as is that one
-          <delSpan spanTo="notMeaningful"/> and that one</p>
+          <delSpan spanTo="notMeaningful"/> but that one will not be reported either way</p>
 	</div>
 	
 	<div type="canon">

--- a/P5/Test/expected-results/detest_xml_schematron.log
+++ b/P5/Test/expected-results/detest_xml_schematron.log
@@ -1,9 +1,6 @@
 The @generatedBy attribute is for use within a &lt;post&gt; element. (ancestor-or-self::tei:post)
 The @generatedBy attribute is for use within a &lt;post&gt; element. (ancestor-or-self::tei:post)
- The element indicated by @spanTo (#ds2) must follow the current element delSpan
-          (id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)])
- The element indicated by @spanTo (notMeaningful) must follow the current element delSpan
-          (id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)])
+ The element indicated by @spanTo (#ds2) must follow the current delSpan element (id( substring( @spanTo, 2 ) ) &gt;&gt; .)
  @schemeVersion can only be used if @scheme is specified. (@scheme and not(@scheme = 'free'))
 The abbr element should not be categorized in detail with @subtype unless also categorized in general with @type (@type)
 The div element should not be categorized in detail with @subtype unless also categorized in general with @type (@type)


### PR DESCRIPTION
Since no one has discussed this further in over 2 years, I just went ahead and changed the Schematron (as proposed on the issue) to only test that the target element follows the current element iff the `@spanTo` starts with ‘#’. I used (what I think) is an easier-to-understand XPath, though.

This is not an ideal solution, of course, because (IMHO) we should allow a user to put whitespace in the attr value and still get the test (i.e., we should use normalize-space() in the code). Also, doesn’t `.#duck` also point to the element with ID "duck"? For that matter, doesn’t `../me.xml#duck` point to it if the current file happens to be called me.xml? 