### PR TITLE
added att.placement to att.transcriptional, modified specs for #2542, #2551, #2528, #2572

### DIFF
--- a/P5/Exemplars/tei_tite.odd
+++ b/P5/Exemplars/tei_tite.odd
@@ -1045,8 +1045,8 @@ some say, "No."
       <equiv filter="tite-acdc.xsl" mimeType="text/xsl" name="b"/>
       <desc  xml:lang="en" versionDate="2014-01-12">(bold) for capturing typographical feature: bold glyphs.</desc>
       <classes>
-       <memberOf key="model.hiLike"/>
        <memberOf key="att.global"/>
+       <memberOf key="model.hiLike"/>
       </classes>
       <content>
        <macroRef key="macro.paraContent"/>
@@ -1056,8 +1056,8 @@ some say, "No."
       <equiv filter="tite-acdc.xsl" mimeType="text/xsl" name="i"/>
       <desc  xml:lang="en" versionDate="2014-01-12">(italics) for capturing typographical feature: italicized glyphs.</desc>
       <classes>
-       <memberOf key="model.hiLike"/>
        <memberOf key="att.global"/>
+       <memberOf key="model.hiLike"/>
       </classes>
       <content>
        <macroRef key="macro.paraContent"/>
@@ -1067,8 +1067,8 @@ some say, "No."
       <equiv filter="tite-acdc.xsl" mimeType="text/xsl" name="ul"/>
       <desc  xml:lang="en" versionDate="2014-01-12">(underline) for capturing typographical feature: underlined glyphs.</desc>
       <classes>
-       <memberOf key="model.hiLike"/>
        <memberOf key="att.global"/>
+       <memberOf key="model.hiLike"/>
       </classes>
       <content>
        <macroRef key="macro.paraContent"/>
@@ -1078,8 +1078,8 @@ some say, "No."
       <equiv filter="tite-acdc.xsl" mimeType="text/xsl" name="sub"/>
       <desc  xml:lang="en" versionDate="2014-01-12">(subscript) for capturing typographical feature: subscript glyphs.</desc>
       <classes>
-       <memberOf key="model.hiLike"/>
        <memberOf key="att.global"/>
+       <memberOf key="model.hiLike"/>
       </classes>
       <content>
        <macroRef key="macro.paraContent"/>
@@ -1089,8 +1089,8 @@ some say, "No."
       <equiv filter="tite-acdc.xsl" mimeType="text/xsl" name="sup"/>
       <desc  xml:lang="en" versionDate="2014-01-12">(superscript) for capturing typographical feature: superscript glyphs.</desc>
       <classes>
-       <memberOf key="model.hiLike"/>
        <memberOf key="att.global"/>
+       <memberOf key="model.hiLike"/>
       </classes>
       <content>
        <macroRef key="macro.paraContent"/>
@@ -1100,8 +1100,8 @@ some say, "No."
       <equiv filter="tite-acdc.xsl" mimeType="text/xsl" name="smcap"/>
       <desc  xml:lang="en" versionDate="2014-01-12">(smallcaps) for capturing typographical feature: glyphs in small capitals.</desc>
       <classes>
-       <memberOf key="model.hiLike"/>
        <memberOf key="att.global"/>
+       <memberOf key="model.hiLike"/>
       </classes>
       <content>
        <macroRef key="macro.paraContent"/>
@@ -1114,8 +1114,8 @@ some say, "No."
       <desc  xml:lang="en" versionDate="2014-12-11">with the <att>cols</att> attribute is used to mark
        where a document changes columnar layout.</desc>
       <classes>
-       <memberOf key="model.milestoneLike"/>
        <memberOf key="att.global"/>
+       <memberOf key="model.milestoneLike"/>
       </classes>
       <content>
 	<empty/>
@@ -1145,9 +1145,9 @@ some say, "No."
         <att>rend</att> attribute and leave the element empy; if the ornament can be represented
        with characters, include these in the element.</desc>
       <classes>
+       <memberOf key="att.global"/>
        <memberOf key="model.inter"/>
        <memberOf key="model.titlepagePart"/>
-       <memberOf key="att.global"/>
       </classes>
       <content>
        <textNode/>

--- a/P5/Source/Specs/add.xml
+++ b/P5/Source/Specs/add.xml
@@ -32,7 +32,6 @@
     <memberOf key="att.global"/>
     <memberOf key="att.cmc"/>
     <memberOf key="att.dimensions"/>
-    <memberOf key="att.placement"/>
     <memberOf key="att.transcriptional"/>
     <memberOf key="att.typed"/>
     <memberOf key="model.linePart"/>

--- a/P5/Source/Specs/addSpan.xml
+++ b/P5/Source/Specs/addSpan.xml
@@ -20,7 +20,6 @@
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.dimensions"/>
-    <memberOf key="att.placement"/>
     <memberOf key="att.spanning"/>
     <memberOf key="att.transcriptional"/>
     <memberOf key="att.typed"/>

--- a/P5/Source/Specs/att.transcriptional.xml
+++ b/P5/Source/Specs/att.transcriptional.xml
@@ -14,8 +14,8 @@ relatifs à l'intervention de l'auteur ou du copiste dans un texte lors de la
 transcription de sources manuscrites ou assimilées.</desc>
   <desc versionDate="2007-11-06" xml:lang="it">assegna degli attributi propri degli elementi che descrivono il carattere di un intervento dell'autore o del trascrittore di un testo nella redazione di un manoscritto o di altra fonte simile</desc>
   <classes>
-    
     <memberOf key="att.editLike"/>
+    <memberOf key="att.placement"/>
     <memberOf key="att.written"/>
   </classes>
   <attList>

--- a/P5/Source/Specs/div.xml
+++ b/P5/Source/Specs/div.xml
@@ -21,7 +21,8 @@
     <memberOf key="att.global"/>
     <memberOf key="att.declaring"/>
     <memberOf key="att.divLike"/>
-    <memberOf key="att.transcriptional"/>
+    <memberOf key="att.written"/>
+    <memberOf key="att.placement"/>
     <memberOf key="att.typed"/>
     <memberOf key="model.divLike"/>
   </classes>

--- a/P5/Source/Specs/div.xml
+++ b/P5/Source/Specs/div.xml
@@ -21,8 +21,8 @@
     <memberOf key="att.global"/>
     <memberOf key="att.declaring"/>
     <memberOf key="att.divLike"/>
+    <memberOf key="att.transcriptional"/>
     <memberOf key="att.typed"/>
-    <memberOf key="att.written"/>
     <memberOf key="model.divLike"/>
   </classes>
   <content>

--- a/P5/Source/Specs/div.xml
+++ b/P5/Source/Specs/div.xml
@@ -21,9 +21,9 @@
     <memberOf key="att.global"/>
     <memberOf key="att.declaring"/>
     <memberOf key="att.divLike"/>
-    <memberOf key="att.written"/>
     <memberOf key="att.placement"/>
     <memberOf key="att.typed"/>
+    <memberOf key="att.written"/>
     <memberOf key="model.divLike"/>
   </classes>
   <content>

--- a/P5/Source/Specs/postscript.xml
+++ b/P5/Source/Specs/postscript.xml
@@ -13,7 +13,7 @@ lettre.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.cmc"/>
-    <memberOf key="att.written"/>
+    <memberOf key="att.transcriptional"/>
     <memberOf key="model.divBottomPart"/>
   </classes>
   <content>

--- a/P5/Source/Specs/postscript.xml
+++ b/P5/Source/Specs/postscript.xml
@@ -13,8 +13,8 @@ lettre.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.cmc"/>
-    <memberOf key="att.written"/>
     <memberOf key="att.placement"/>
+    <memberOf key="att.written"/>
     <memberOf key="model.divBottomPart"/>
   </classes>
   <content>

--- a/P5/Source/Specs/postscript.xml
+++ b/P5/Source/Specs/postscript.xml
@@ -13,7 +13,8 @@ lettre.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.cmc"/>
-    <memberOf key="att.transcriptional"/>
+    <memberOf key="att.written"/>
+    <memberOf key="att.placement"/>
     <memberOf key="model.divBottomPart"/>
   </classes>
   <content>

--- a/P5/Source/Specs/rt.xml
+++ b/P5/Source/Specs/rt.xml
@@ -10,7 +10,6 @@
   <desc versionDate="2021-01-31" xml:lang="ja">本文の一部と密接な関連を持つ注釈（主に読み方）としてのルビテキストを含む。</desc>
   <classes>
     <memberOf key="att.global"/>
-    <memberOf key="att.placement"/>
     <memberOf key="att.transcriptional"/>
     <memberOf key="att.typed"/>
   </classes>

--- a/P5/Source/Specs/sp.xml
+++ b/P5/Source/Specs/sp.xml
@@ -26,7 +26,8 @@
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.ascribed.directed"/>
-    <memberOf key="att.transcriptional"/>
+    <memberOf key="att.written"/>
+    <memberOf key="att.placement"/>
     <memberOf key="model.divPart"/>
   </classes>
   <content>

--- a/P5/Source/Specs/sp.xml
+++ b/P5/Source/Specs/sp.xml
@@ -26,8 +26,8 @@
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.ascribed.directed"/>
-    <memberOf key="att.written"/>
     <memberOf key="att.placement"/>
+    <memberOf key="att.written"/>
     <memberOf key="model.divPart"/>
   </classes>
   <content>

--- a/P5/Source/Specs/sp.xml
+++ b/P5/Source/Specs/sp.xml
@@ -26,6 +26,7 @@
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.ascribed.directed"/>
+    <memberOf key="att.transcriptional"/>
     <memberOf key="model.divPart"/>
   </classes>
   <content>

--- a/P5/Source/Specs/speaker.xml
+++ b/P5/Source/Specs/speaker.xml
@@ -21,8 +21,8 @@
     Figuren in einem Dramentext oder -fragment.</desc>
   <classes>
     <memberOf key="att.global"/>
-    <memberOf key="att.written"/>
     <memberOf key="att.placement"/>
+    <memberOf key="att.written"/>
     </classes>
   <content>
     <macroRef key="macro.phraseSeq"/>

--- a/P5/Source/Specs/speaker.xml
+++ b/P5/Source/Specs/speaker.xml
@@ -21,7 +21,8 @@
     Figuren in einem Dramentext oder -fragment.</desc>
   <classes>
     <memberOf key="att.global"/>
-    <memberOf key="att.transcriptional"/>
+    <memberOf key="att.written"/>
+    <memberOf key="att.placement"/>
     </classes>
   <content>
     <macroRef key="macro.phraseSeq"/>

--- a/P5/Source/Specs/speaker.xml
+++ b/P5/Source/Specs/speaker.xml
@@ -21,6 +21,7 @@
     Figuren in einem Dramentext oder -fragment.</desc>
   <classes>
     <memberOf key="att.global"/>
+    <memberOf key="att.transcriptional"/>
     </classes>
   <content>
     <macroRef key="macro.phraseSeq"/>


### PR DESCRIPTION
This PR may resolve 4 tickets calling for expanded use of `@place` on various elements. It currently addresses 2 tickets: #2542 and #2551. If this works, I'm also going to see if we can apply it to resolve #2572 and #2528. If everything all checks out, this may supersede these PRs:
* PR #2643 
* PR #2664

The method for applying att.placement involves adding it to att.transcriptional, which also allows these elements access to related attributes designed for related purposes: These attributes are all "specific to elements encoding authorial or scribal intervention in a text when transcribing manuscript or similar sources."