### PR TITLE
Reverted em-dashes to double hyphens

### DIFF
--- a/P5/Source/Guidelines/en/HD-Header.xml
+++ b/P5/Source/Guidelines/en/HD-Header.xml
@@ -2136,10 +2136,10 @@ the following examples:
       </keywords>
     </egXML>
 <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="HD43-egXML-oh"><keywords scheme="http://id.loc.gov/authorities/about.html#lcsh">
-  <term>English literature — History and criticism — Data processing.</term>
-  <term>English literature — History and criticism — Theory, etc.</term>
-  <term>English language — Style — Data processing.</term>
-  <term>Style, Literary — Data processing.</term>
+  <term>English literature -- History and criticism -- Data processing.</term>
+  <term>English literature -- History and criticism -- Theory, etc.</term>
+  <term>English language -- Style -- Data processing.</term>
+  <term>Style, Literary -- Data processing.</term>
 </keywords></egXML>
 </p>
 <p>If the authority file is not available online, but is generally

--- a/P5/Source/Guidelines/fr/HD-Header.xml
+++ b/P5/Source/Guidelines/fr/HD-Header.xml
@@ -2083,10 +2083,10 @@ l’en-tête TEI, et est décrit dans la section 5.3.6 Déclaration de classific
 </keywords></egXML>
 <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="HD43-egXML-ep"><keywords scheme="#lcsh">
   <list>
-    <item>Littérature anglaise — Histoire et critique — Traitement des données.</item>
-    <item>Littérature anglaise — Histoire et critique — Théorie, etc.</item>
-    <item>Langue anglaise — Style — Traitement des données.</item>
-    <item>Style, Littérature — Traitement des données.</item>
+    <item>Littérature anglaise -- Histoire et critique -- Traitement des données.</item>
+    <item>Littérature anglaise -- Histoire et critique -- Théorie, etc.</item>
+    <item>Langue anglaise -- Style -- Traitement des données.</item>
+    <item>Style, Littérature -- Traitement des données.</item>
   </list>
 </keywords></egXML>
 <!-- LC subject tracings on R Potter, ed., Literary           -->

--- a/P5/Source/Specs/att.cmc.xml
+++ b/P5/Source/Specs/att.cmc.xml
@@ -92,7 +92,7 @@
         <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="class-attr-cmc-egXML-mz">
           <post type="standard" generatedBy="human" indentLevel="2" synch="#t00394407" who="#WU00005582">
             <p> Kurze Nachfrage: Die Hieros für den Goldnamen stammen
-              auch von Beckerath gem. Literatur ? Grüße —</p><signed generatedBy="template" rend="inline"><gap reason="signatureContent"/><time generatedBy="template">18:50, 22. Okt. 2008 (CEST)</time></signed>
+              auch von Beckerath gem. Literatur ? Grüße --</p><signed generatedBy="template" rend="inline"><gap reason="signatureContent"/><time generatedBy="template">18:50, 22. Okt. 2008 (CEST)</time></signed>
           </post>
         </egXML>
       </exemplum>   

--- a/P5/Source/Specs/att.indentation.xml
+++ b/P5/Source/Specs/att.indentation.xml
@@ -14,7 +14,7 @@
       <exemplum xml:lang="de">
         <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="class-attr-indentation-egXML-gi">
           <post type="standard" generatedBy="human" indentLevel="3" synch="#t02622878" who="#WU00018921">
-            <p> Wie du siehst hab ich die Lemma geändert, danke für den Hinweis, ich war nämlich selbst auch etwas unsicher bei der ganzen Sache und bin jetzt damit auch viel glücklicher!—</p>
+            <p> Wie du siehst hab ich die Lemma geändert, danke für den Hinweis, ich war nämlich selbst auch etwas unsicher bei der ganzen Sache und bin jetzt damit auch viel glücklicher!--</p>
             <signed rend="inline" generatedBy="template"><gap reason="signatureContent"/>
             <time generatedBy="template">12:01, 12. Jun. 2009 (CEST)</time>
             </signed>

--- a/P5/Source/Specs/classDecl.xml
+++ b/P5/Source/Specs/classDecl.xml
@@ -40,7 +40,7 @@ codes used elsewhere in the text.</desc>
       <textClass>
         <keywords scheme="#LCSH">
           <term>Political science</term>
-          <term>United States — Politics and government —
+          <term>United States -- Politics and government --
                       Revolution, 1775-1783</term>
         </keywords>
       </textClass>
@@ -58,7 +58,7 @@ codes used elsewhere in the text.</desc>
       <!-- ... -->
       <textClass>
         <keywords scheme="#RAMEAU">
-          <term>Bien et mal — Enseignement coranique</term>
+          <term>Bien et mal -- Enseignement coranique</term>
         </keywords>
       </textClass>
     </egXML>

--- a/P5/Source/Specs/hi.xml
+++ b/P5/Source/Specs/hi.xml
@@ -39,7 +39,7 @@
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-hi-egXML-ec" source="#fr-ex-Bataille_Arbre">
       <p>Au fronton, on lit cette inscription : <hi rend="uppercase">attends. Tu verras.</hi> Le
           notaire encore prétend qu' elle ne saurait être antérieure au XVIII siècle, car, sinon, l'
-          on eût écrit —<q>tu voiras</q>—. </p>
+          on eût écrit --<q>tu voiras</q>--. </p>
     </egXML>
   </exemplum>
   <exemplum xml:lang="zh-TW">

--- a/P5/Source/Specs/keywords.xml
+++ b/P5/Source/Specs/keywords.xml
@@ -68,9 +68,9 @@
   <exemplum versionDate="2008-04-06" xml:lang="fr">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-keywords-egXML-dn">
       <keywords scheme="#fr_RAMEAU">
-        <term>Littérature française — 20ème siècle — Histoire et critique</term>
-        <term>Littérature française — Histoire et critique — Théorie, etc.</term>
-        <term>Français (langue) — Style — Bases de données.</term>
+        <term>Littérature française -- 20ème siècle -- Histoire et critique</term>
+        <term>Littérature française -- Histoire et critique -- Théorie, etc.</term>
+        <term>Français (langue) -- Style -- Bases de données.</term>
       </keywords>
     </egXML>
   </exemplum>

--- a/P5/Source/Specs/locusGrp.xml
+++ b/P5/Source/Specs/locusGrp.xml
@@ -29,9 +29,9 @@
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-locusGrp-egXML-gd" xml:lang="de">
       <msItem>
         <locusGrp>
-          <locus from="13" to="26">Bl. 13–26</locus>
-          <locus from="37" to="58">37–58</locus>
-          <locus from="82" to="96">82–96</locus>
+          <locus from="13" to="26">Bl. 13--26</locus>
+          <locus from="37" to="58">37--58</locus>
+          <locus from="82" to="96">82--96</locus>
         </locusGrp>
         <note>Stücke von Daniel Ecklin’s Reise ins h. Land</note>
       </msItem>

--- a/P5/Source/Specs/post.xml
+++ b/P5/Source/Specs/post.xml
@@ -164,7 +164,7 @@ See the file COPYING.txt for details.
       <post type="standard" generatedBy="human" indentLevel="3" synch="#t02622878" who="#WU00018921">
         <p> Wie du siehst hab ich die Lemma geändert, danke für den Hinweis, ich war nämlich
         selbst auch etwas unsicher bei der ganzen Sache und bin jetzt damit auch viel
-        glücklicher!—</p><signed rend="inline" generatedBy="template"><gap reason="signatureContent"/>
+        glücklicher!--</p><signed rend="inline" generatedBy="template"><gap reason="signatureContent"/>
         <time generatedBy="template">12:01, 12. Jun. 2009 (CEST)</time>
       </signed>
       </post>

--- a/P5/Source/Specs/taxonomy.xml
+++ b/P5/Source/Specs/taxonomy.xml
@@ -116,7 +116,7 @@
           <catDesc>Dernières lettres</catDesc>
         </category>
         <category xml:id="fr_tax.a.c.">
-          <catDesc>Littérature européenne — 16e siècle</catDesc>
+          <catDesc>Littérature européenne -- 16e siècle</catDesc>
         </category>
         <category xml:id="fr_tax.a.c.1">
           <catDesc>Satire de la Renaissance </catDesc>

--- a/P5/Source/Specs/textClass.xml
+++ b/P5/Source/Specs/textClass.xml
@@ -64,9 +64,9 @@
       <textClass>
         <keywords scheme="#fr_RAMEAU">
           <list>
-            <item>Littérature française — 20ème siècle — Histoire et critique</item>
-            <item>Littérature française — Histoire et critique — Théorie, etc.</item>
-            <item>Français (langue) — Style — Bases de données.</item>
+            <item>Littérature française -- 20ème siècle -- Histoire et critique</item>
+            <item>Littérature française -- Histoire et critique -- Théorie, etc.</item>
+            <item>Français (langue) -- Style -- Bases de données.</item>
           </list>
         </keywords>
       </textClass>

--- a/P5/Source/Specs/view.xml
+++ b/P5/Source/Specs/view.xml
@@ -26,11 +26,11 @@ dialogue.</desc>
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-view-egXML-fc">
       <view><name>Max</name> joins his daughter
 at the window. <hi>Rain</hi> sprays his
-        face— </view>
+        face-- </view>
       <view><camera>Max's POV</camera> He sees occasional
 windows open, and just across from his apartment
 house, a <hi>man</hi> opens the front door of
-        a brownstone—</view>
+        a brownstone--</view>
     </egXML>
   </exemplum>
   <exemplum versionDate="2008-04-06" xml:lang="fr">
@@ -63,8 +63,8 @@ house, a <hi>man</hi> opens the front door of
   </exemplum>
   <exemplum xml:lang="zh-TW">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-view-egXML-xu">
-      <view><name>馬克思</name>隨他女兒到窗邊。<hi>雨水</hi> 打在他臉上— </view>
-      <view><camera>馬克思的視點</camera> 他看見一些打開的窗戶，而就在他公寓對面，有一個<hi>男子</hi> 正打開富麗堂皇的大門。—</view>
+      <view><name>馬克思</name>隨他女兒到窗邊。<hi>雨水</hi> 打在他臉上-- </view>
+      <view><camera>馬克思的視點</camera> 他看見一些打開的窗戶，而就在他公寓對面，有一個<hi>男子</hi> 正打開富麗堂皇的大門。--</view>
     </egXML>
   </exemplum>
   <exemplum xml:lang="zh-TW">


### PR DESCRIPTION
Following up on #2155 to revert a number of em-dashes back to double hyphens, especially in cases where the double hyphens are part of original text in `<egXML>`. Note that this PR does not cover *all* cases marked in #2155; we are still awaiting some responses.