### PR TITLE
remove bold emphasis

### DIFF
--- a/P5/Source/Guidelines/en/CH-LanguagesCharacterSets.xml
+++ b/P5/Source/Guidelines/en/CH-LanguagesCharacterSets.xml
@@ -649,12 +649,12 @@ dates, and predefined value lists.</note></p></div>
     encodings, and the way characters which under ISO-8859-n use
     all eight bits are encoded in UTF-8 is significantly different,
     giving rise to puzzling errors. Abstract characters that have a
-    <emph rend="italic">single</emph> byte code point where the
+    <emph>single</emph> byte code point where the
     highest bit is set (that is, they have a decimal numeric
     representation between 129 and 255) are encoded in ISO-8859-n
-    as a <emph rend="italic">single</emph> byte with the same value
+    as a <emph>single</emph> byte with the same value
     as the code point. But in UTF-8 code-point values inside that
-    range are expressed as a <emph rend="italic">two</emph> byte
+    range are expressed as a <emph>two</emph> byte
     sequence. That is to say, the abstract character in question is
     no longer represented in the file or in memory by the same number
     as its code-point value: it is <hi>transformed</hi> (hence the T in

--- a/P5/Source/Guidelines/en/CH-LanguagesCharacterSets.xml
+++ b/P5/Source/Guidelines/en/CH-LanguagesCharacterSets.xml
@@ -227,9 +227,9 @@ dates, and predefined value lists.</note></p></div>
     storey</soCalled> version (as in <ref target="#fig1">figure
     1</ref> in the examples from Umpush, or URW Bookman L Demi Bold).
     We say that the single and double-storey symbols both represent
-    one and the same the same <emph>abstract
-    character</emph> <mentioned>a</mentioned> using two different
-    <emph>glyphs</emph>. Similarly, an uppercase
+    one and the same the same <term>abstract
+    character</term> <mentioned>a</mentioned> using two different
+    <term>glyphs</term>. Similarly, an uppercase
     <mentioned>A</mentioned> in a serif typeface has additional
     strokes that are absent from the same letter when printed using a
     sans-serif typeface, so that once again we have differing glyphs

--- a/P5/Source/Guidelines/en/CH-LanguagesCharacterSets.xml
+++ b/P5/Source/Guidelines/en/CH-LanguagesCharacterSets.xml
@@ -77,7 +77,7 @@ processes, the identifier for the language must be constructed as in
 BCP 47 comprises two Internet Engineering Task Force documents,
 referred to separately as RFC 5646 and RFC 4647; over time, other IETF
 documents may succeed these as the best current practice.</note>. This
-<emph rend="bold">same</emph> identifier has to be used to identify
+<emph>same</emph> identifier has to be used to identify
 the corresponding <gi>language</gi> element in the TEI header, if one
 is present.</p>
 <p>The first part of BCP 47 is called <ref target="#CH-BIBL-4"><title>Tags for Identifying
@@ -227,9 +227,9 @@ dates, and predefined value lists.</note></p></div>
     storey</soCalled> version (as in <ref target="#fig1">figure
     1</ref> in the examples from Umpush, or URW Bookman L Demi Bold).
     We say that the single and double-storey symbols both represent
-    one and the same the same <emph rend="bold">abstract
+    one and the same the same <emph>abstract
     character</emph> <mentioned>a</mentioned> using two different
-    <emph rend="bold">glyphs</emph>. Similarly, an uppercase
+    <emph>glyphs</emph>. Similarly, an uppercase
     <mentioned>A</mentioned> in a serif typeface has additional
     strokes that are absent from the same letter when printed using a
     sans-serif typeface, so that once again we have differing glyphs


### PR DESCRIPTION
This removes the `rend="bold"` from emphases in "Languages and Character Sets" of the Guidelines. In general it is considered bad practice to have single bold words in running text, also the double-emphasis (bold + italic) looks weird.

There are a few more cases in "Computer-mediated Communication", but used in list items.