### PR TITLE
remove contextless schematron deprecation

### DIFF
--- a/P5/Source/Specs/constraintDecl.xml
+++ b/P5/Source/Specs/constraintDecl.xml
@@ -18,6 +18,8 @@
       <anyElement minOccurs="0" maxOccurs="unbounded"/>             <!-- typically <sch:ns> elements -->
     </sequence>
   </content>
+  <!-- NOTE: Also see constraint "context-required" in file constraintSpec.xml,
+       which may be fired on a <constraintDecl> as well. -->
   <constraintSpec scheme="schematron" ident="one-constraintDecl-per-scheme" xml:lang="en">
     <!-- Note: the “not a descendant of <egXML>” predicate on the
          XPath defining $schemes is required for the P5 build process,

--- a/P5/Source/Specs/constraintSpec.xml
+++ b/P5/Source/Specs/constraintSpec.xml
@@ -63,13 +63,8 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
-  <constraintSpec ident="context-required" scheme="schematron" type="deprecationWarning" validUntil="2025-04-15" xml:lang="en">
-    <desc type="deprecationInfo" versionDate="2024-03-15" xml:lang="en">
-      The use of ISO Schematron <gi>sch:assert</gi> and
-      <gi>sch:report</gi> elements without a parent <gi>sch:rule</gi>
-      with a <att>context</att> attribute is deprecated — it will be
-      an error after 2025-03-15.</desc>
-    <!-- It is somewhat easier and clearer to use
+  <constraintSpec ident="context-required" scheme="schematron" xml:lang="en">
+    <!-- It would be somewhat easier and clearer to use
          "tei:constraintSpec[ @scheme eq 'schematron']//( sch:assert | sch:report )"
          as the context and then test for "ancestor::sch:rule/@context".
          But if we did that, then a user who had multiple
@@ -80,7 +75,8 @@
       <sch:rule context="tei:constraintSpec[ @scheme eq 'schematron']/tei:constraint[ .//sch:assert | .//sch:report ]">
         <sch:let name="assertsHaveContext" value="for $a in .//sch:assert return exists( $a/ancestor::sch:rule/@context )"/>
         <sch:let name="reportsHaveContext" value="for $r in .//sch:report return exists( $r/ancestor::sch:rule/@context )"/>
-        <sch:report test="( $assertsHaveContext, $reportsHaveContext ) = false()" role="warning">The use of an &lt;sch:assert&gt; or &lt;sch:report&gt; that does not have a context (i.e., does not have an ancestor &lt;sch:rule&gt; with a @context attribute) in an ISO Schematron constraint specification is deprecated, and will become invalid after 2025-03-15.</sch:report>
+        <sch:report test="( $assertsHaveContext, $reportsHaveContext )
+			  = false()" role="warning">An &lt;sch:assert&gt; or &lt;sch:report&gt; element must be a descendant of an &lt;sch:rule&gt; that has a @context.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/constraintSpec.xml
+++ b/P5/Source/Specs/constraintSpec.xml
@@ -62,23 +62,21 @@
     </constraint>
   </constraintSpec>
   <constraintSpec ident="context-required" scheme="schematron" xml:lang="en">
-    <!-- Note: This constraint fires on some cases of
-         <constraintDecl>, as well. -->
+    <!-- Note: This constraint also fires on some cases of <constraintDecl>. -->
     <!-- It would be somewhat easier and clearer to use
          "tei:constraintSpec[ @scheme eq 'schematron']//( sch:assert | sch:report )"
-         as the context and then test for "ancestor::sch:rule/@context".
+         as the context, and then test for "ancestor::sch:rule/@context".
          But if we did that, then a user who had multiple
          <sch:assert>s and <sch:report>s in a single contextless
          constraint would get multiple messages. This way she only
          gets one message. -->
     <constraint>
-      <sch:rule context="tei:constraintSpec[ @scheme eq 'schematron']/tei:constraint[ .//sch:assert | .//sch:report ]
-                         |
-                         tei:constraintDecl[ @scheme eq 'schematron'][ .//sch:assert | .//sch:report ]">
+      <sch:rule context="(tei:constraintSpec|tei:constraintDecl)[ @scheme eq 'schematron'][ .//sch:assert | .//sch:report ]">
         <sch:let name="assertsHaveContext" value="for $a in .//sch:assert return exists( $a/ancestor::sch:rule/@context )"/>
         <sch:let name="reportsHaveContext" value="for $r in .//sch:report return exists( $r/ancestor::sch:rule/@context )"/>
-        <sch:report test="( $assertsHaveContext, $reportsHaveContext )
-                          = false()" role="warning">An &lt;sch:assert&gt; or &lt;sch:report&gt; element must be a descendant of an &lt;sch:rule&gt; that has a @context.</sch:report>
+        <sch:report test="( $assertsHaveContext, $reportsHaveContext ) = false()">An &lt;sch:assert&gt; or &lt;sch:report&gt;
+          element must be a descendant of an &lt;sch:rule&gt; that has a @context; one or more inside this
+          <sch:value-of select="local-name(.)"/> are not.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/constraintSpec.xml
+++ b/P5/Source/Specs/constraintSpec.xml
@@ -3,11 +3,9 @@
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" xml:id="gi-constraintSpec" ident="constraintSpec">
   <gloss versionDate="2009-06-10" xml:lang="en">constraint on schema</gloss>
-
   <gloss versionDate="2024-02-28" xml:lang="ja">スキーマの制約</gloss>
   <desc versionDate="2017-06-24" xml:lang="en">contains a formal constraint, typically expressed in a rule-based schema language, to which a construct must conform in order to be considered valid</desc>
-  <desc versionDate="2024-02-28" xml:lang="ja">〔データの〕構造が妥当であるために満たしていなければならない形式的な制約。
-    通常は規則ベースのスキーマ言語で表現される。</desc>
+  <desc versionDate="2024-02-28" xml:lang="ja">〔データの〕構造が妥当であるために満たしていなければならない形式的な制約。 通常は規則ベースのスキーマ言語で表現される。</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.identified"/>
@@ -64,6 +62,8 @@
     </constraint>
   </constraintSpec>
   <constraintSpec ident="context-required" scheme="schematron" xml:lang="en">
+    <!-- Note: This constraint fires on some cases of
+         <constraintDecl>, as well. -->
     <!-- It would be somewhat easier and clearer to use
          "tei:constraintSpec[ @scheme eq 'schematron']//( sch:assert | sch:report )"
          as the context and then test for "ancestor::sch:rule/@context".
@@ -72,11 +72,13 @@
          constraint would get multiple messages. This way she only
          gets one message. -->
     <constraint>
-      <sch:rule context="tei:constraintSpec[ @scheme eq 'schematron']/tei:constraint[ .//sch:assert | .//sch:report ]">
+      <sch:rule context="tei:constraintSpec[ @scheme eq 'schematron']/tei:constraint[ .//sch:assert | .//sch:report ]
+                         |
+                         tei:constraintDecl[ @scheme eq 'schematron'][ .//sch:assert | .//sch:report ]">
         <sch:let name="assertsHaveContext" value="for $a in .//sch:assert return exists( $a/ancestor::sch:rule/@context )"/>
         <sch:let name="reportsHaveContext" value="for $r in .//sch:report return exists( $r/ancestor::sch:rule/@context )"/>
         <sch:report test="( $assertsHaveContext, $reportsHaveContext )
-			  = false()" role="warning">An &lt;sch:assert&gt; or &lt;sch:report&gt; element must be a descendant of an &lt;sch:rule&gt; that has a @context.</sch:report>
+                          = false()" role="warning">An &lt;sch:assert&gt; or &lt;sch:report&gt; element must be a descendant of an &lt;sch:rule&gt; that has a @context.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Test/expected-results/detest_odd_schematron.log
+++ b/P5/Test/expected-results/detest_odd_schematron.log
@@ -20,7 +20,7 @@ validateodd:
      [xslt] Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
      [xslt] Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
      [xslt] Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
-     [xslt] The use of an &lt;sch:assert&gt; or &lt;sch:report&gt; that does not have a context (i.e., does not have an ancestor &lt;sch:rule&gt; with a @context attribute) in an ISO Schematron constraint specification is deprecated, and will become invalid after 2025-03-15. (( $assertsHaveContext, $reportsHaveContext ) = false() / warning)
+     [xslt] An &lt;sch:assert&gt; or &lt;sch:report&gt; element must be a descendant of an &lt;sch:rule&gt; that has a @context. (( $assertsHaveContext, $reportsHaveContext ) = false() / warning)
      [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified (here on "add_missing_scheme") (@scheme)
      [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is "replace" (here on "replace_missing_scheme") (@scheme)
      [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified (here on "add_missing_scheme") (@scheme)

--- a/P5/Test/expected-results/detest_odd_schematron.log
+++ b/P5/Test/expected-results/detest_odd_schematron.log
@@ -20,7 +20,7 @@ validateodd:
      [xslt] Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
      [xslt] Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
      [xslt] Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute (tei:constraint/sch:* and not( @scheme eq 'schematron'))
-     [xslt] An &lt;sch:assert&gt; or &lt;sch:report&gt; element must be a descendant of an &lt;sch:rule&gt; that has a @context. (( $assertsHaveContext, $reportsHaveContext ) = false() / warning)
+     [xslt] An &lt;sch:assert&gt; or &lt;sch:report&gt; element must be a descendant of an &lt;sch:rule&gt; that has a @context; one or more inside this constraintSpec are not. (( $assertsHaveContext, $reportsHaveContext ) = false())
      [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified (here on "add_missing_scheme") (@scheme)
      [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is "replace" (here on "replace_missing_scheme") (@scheme)
      [xslt] The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified (here on "add_missing_scheme") (@scheme)


### PR DESCRIPTION
Change deprecation warning for contextless `<sch:assert>` or `<sch:report>` to an actual error.  

Note that this is HIGH priority as our “complain about deprecations 60 days before they expire” rule means the _Guidelines_ build is broken.

(Note — I have just realized that a contextless `<sch:assert>` or `<sch:report>` could sneak in via `<constraintDecl>`. But that is a problem for a different ticket.)