### PR TITLE
fix `@ident` of `<remarks>`, at least partially

### DIFF
--- a/P5/Source/Specs/remarks.xml
+++ b/P5/Source/Specs/remarks.xml
@@ -4,33 +4,25 @@
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="tagdocs" xml:id="gi-remarks" ident="remarks">
   <gloss versionDate="2007-06-12" xml:lang="en">remarks</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">remarques</gloss>
-  <desc versionDate="2005-01-14" xml:lang="en">contains any commentary or discussion about the usage of an element, attribute, class, or
-    entity not otherwise documented within the containing element.</desc>
-  <desc versionDate="2007-12-20" xml:lang="ko">포함 요소 내에서 다르게 기록된 것이 없다면 요소, 속성, 부류 또는 개체의 사용 예에 관한 논평 또는
-    토론을 포함한다.</desc>
+  <desc versionDate="2005-01-14" xml:lang="en">contains any commentary or discussion about the usage of an element, attribute, class, or entity not otherwise documented within the containing element.</desc>
+  <desc versionDate="2007-12-20" xml:lang="ko">포함 요소 내에서 다르게 기록된 것이 없다면 요소, 속성, 부류 또는 개체의 사용 예에 관한 논평 또는 토론을 포함한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含任何關於元素、屬性、元素集，或實體的使用資訊之評論或討論，該元素、屬性、元素集或實體未以其他方式紀錄在所包含的元素中。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">要素、属性、クラス、エンティティに関する、まだ文書化されていない解説 や論議を示す。</desc>
-  <desc versionDate="2007-06-12" xml:lang="fr">contient tout commentaire sur l'utilisation d'un élément,
-    d'un attribut, d'une classe ou d'une entité qui n'est pas documentée ailleurs à l'intérieur de
-    l'élément conteneur.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene cualquier comentario o explicación relativa al
-    uso de elementos, atributos, clases o entitades no documentados de otra manera en el elemento
-    que los contiene.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene un qualsiasi commento o discussione relativi
-    all'utilizzo di elementi, attributi, classi o entità non altrimenti documentati nell'elemento
-    che li contiene</desc>
+  <desc versionDate="2007-06-12" xml:lang="fr">contient tout commentaire sur l'utilisation d'un élément, d'un attribut, d'une classe ou d'une entité qui n'est pas documentée ailleurs à l'intérieur de l'élément conteneur.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene cualquier comentario o explicación relativa al uso de elementos, atributos, clases o entitades no documentados de otra manera en el elemento que los contiene.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene un qualsiasi commento o discussione relativi all'utilizzo di elementi, attributi, classi o entità non altrimenti documentati nell'elemento che li contiene</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.combinable"/>
     <memberOf key="att.translatable"/>
   </classes>
-  <content>    
-      <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>    
+  <content>
+    <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>
   </content>
   <attList>
     <attDef ident="ident" usage="opt">
-      <desc versionDate="2020-01-30" xml:lang="en">specifies the remark concerned.</desc>
-      <datatype><dataRef key="teidata.text"/></datatype>
+      <desc versionDate="2020-01-30" xml:lang="en">supplies the identifier by which the remarks may be referenced.</desc>
+      <datatype><dataRef key="teidata.name"/></datatype>
     </attDef>
   </attList>
   <exemplum xml:lang="en">
@@ -54,18 +46,6 @@
       </remarks>
     </egXML>
   </exemplum>
-  <remarks versionDate="2005-01-14" xml:lang="en">
-    <p rend="dataDesc">Contains at least one paragraph, unless it is empty.</p>
-    <p>As defined in ODD, must contain paragraphs; should be special.para</p>
-  </remarks>
-  <remarks versionDate="2007-06-12" xml:lang="fr">
-    <p rend="dataDesc"> Contient au moins un paragraphe, sauf s'il est vide.</p>
-    <p>Comme c'est défini en ODD, doit contenir des paragraphes ; devrait être special.para</p>
-  </remarks>
-  <remarks versionDate="2008-04-05" xml:lang="ja">
-    <p rend="dataDesc"> 空要素でなければ、少なくとも段落をひとつ含む。 </p>
-    <p> ODDにあるよう、段落を含む必要がある。 </p>
-  </remarks>
   <listRef>
     <ptr target="#TDTAG"/>
     <ptr target="#TDATT"/>

--- a/P5/Source/Specs/remarks.xml
+++ b/P5/Source/Specs/remarks.xml
@@ -21,7 +21,7 @@
   </content>
   <attList>
     <attDef ident="ident" usage="opt">
-      <desc versionDate="2020-01-30" xml:lang="en">supplies the identifier by which the remarks may be referenced.</desc>
+      <desc versionDate="2025-02-11" xml:lang="en">supplies the identifier by which the remarks may be referenced.</desc>
       <datatype><dataRef key="teidata.name"/></datatype>
     </attDef>
   </attList>


### PR DESCRIPTION
Changed the definition of `@ident` of `<remarks>` (from teidata.text to teidata.name); and changed its description (from “specifies the remark concerned.” to “supplies the identifier by which the remarks may be referenced.”).  