### PR TITLE
Update to content model of 'ography'-elements

### DIFF
--- a/P5/Source/Specs/event.xml
+++ b/P5/Source/Specs/event.xml
@@ -35,10 +35,10 @@
       <alternate minOccurs="0" maxOccurs="unbounded">
         <classRef key="model.noteLike"/>
         <classRef key="model.biblLike"/>
+        <classRef key="model.ptrLike"/>
         <elementRef key="linkGrp"/>
         <elementRef key="link"/>
         <elementRef key="idno"/>
-        <elementRef key="ptr"/>
       </alternate>
       <classRef key="model.eventLike" minOccurs="0" maxOccurs="unbounded"/>
       <alternate minOccurs="0" maxOccurs="unbounded">

--- a/P5/Source/Specs/org.xml
+++ b/P5/Source/Specs/org.xml
@@ -44,9 +44,9 @@
       <alternate minOccurs="0" maxOccurs="unbounded">
         <classRef key="model.noteLike"/>
         <classRef key="model.biblLike"/>
+        <classRef key="model.ptrLike"/>
         <elementRef key="linkGrp"/>
         <elementRef key="link"/>
-        <elementRef key="ptr"/>
       </alternate>
       <classRef key="model.personLike" minOccurs="0" maxOccurs="unbounded"/>
     </sequence>

--- a/P5/Source/Specs/person.xml
+++ b/P5/Source/Specs/person.xml
@@ -164,6 +164,32 @@
       </person>
     </egXML>
   </exemplum>
+  <exemplum xml:lang="en">
+    <p>This example demonstrates the use of a <gi>ref</gi> element to provide more information about a person.</p>
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-person-egxml-ebb">
+      <person xml:id="Kelly_FH" sex="F">
+        <persName>Miss Kelly</persName>
+        <persName>
+          <surname>Kelly</surname>
+          <forename>Frances</forename>
+          <forename>Harriet</forename>
+        </persName>
+        <birth when="1805-06-30">
+          <placeName>Chelsea, Middlesex, England</placeName>
+        </birth>
+        <death when="1887-03-19">
+          <placeName>Middlesex, England</placeName>
+        </death>
+        <occupation type="theater" subtype="actor"/>
+        <note>
+          <persName ref="#MRM">Mitford</persName> mentions traveling to London to see Miss Kelly perform in her Journal on <date when="1820-06-29">June 29, 1820</date>.
+          It seems possible Mitford might have been going to see her perform in the comic opera, <title level="m">The Promissory Note</title>, 
+          which opened in the <placeName ref="#Opera_House">Theatre Royal</placeName> on June 29 and continued into July 1820.                
+        </note>
+        <ref target="https://d1m87s0l7jnwya.cloudfront.net/melodrama/lyceum_1820-07-10_britishlibrary_lsidyv4332b851_1809-1821_lyceum_english_opera_0434/"><title level="m">Romantic Melodrama</title>’s record of Miss Kelly’s performance in <title level="m">The Promissory Note</title>.</ref>
+      </person>
+    </egXML>
+  </exemplum>
   <remarks versionDate="2005-12-14" xml:lang="en">
     <p rend="dataDesc">May contain either a prose description organized as paragraphs, or a sequence of more specific demographic elements drawn
             from the <ident type="class">model.personPart</ident> class.</p>

--- a/P5/Source/Specs/person.xml
+++ b/P5/Source/Specs/person.xml
@@ -166,27 +166,24 @@
   </exemplum>
   <exemplum xml:lang="en">
     <p>This example demonstrates the use of a <gi>ref</gi> element to provide more information about a person.</p>
-    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-person-egxml-ebb">
-      <person xml:id="Kelly_FH" sex="F">
-        <persName>Miss Kelly</persName>
-        <persName>
-          <surname>Kelly</surname>
-          <forename>Frances</forename>
-          <forename>Harriet</forename>
-        </persName>
-        <birth when="1805-06-30">
-          <placeName>Chelsea, Middlesex, England</placeName>
-        </birth>
-        <death when="1887-03-19">
-          <placeName>Middlesex, England</placeName>
-        </death>
-        <occupation type="theater" subtype="actor"/>
-        <note>
-          <persName ref="#MRM">Mitford</persName> mentions traveling to London to see Miss Kelly perform in her Journal on <date when="1820-06-29">June 29, 1820</date>.
-          It seems possible Mitford might have been going to see her perform in the comic opera, <title level="m">The Promissory Note</title>, 
-          which opened in the <placeName ref="#Opera_House">Theatre Royal</placeName> on June 29 and continued into July 1820.                
-        </note>
-        <ref target="https://d1m87s0l7jnwya.cloudfront.net/melodrama/lyceum_1820-07-10_britishlibrary_lsidyv4332b851_1809-1821_lyceum_english_opera_0434/"><title level="m">Romantic Melodrama</title>’s record of Miss Kelly’s performance in <title level="m">The Promissory Note</title>.</ref>
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-person-egxml-dram">
+      <person age="G2" role="author" xml:id="W0212" sex="F">
+        <birth when="1787"/>
+        <death when="1855"/>
+        <persName type="main">Mitford, Mary Russell (1787–1855)</persName>
+        <persName resp="Nicoll">MITFORD, MARY RUSSELL</persName>
+        <listBibl type="lacyTitles">
+          <desc>Lacy's Acting Editions</desc>
+          <bibl><ref target="lacy:L1280">Foscari</ref></bibl>
+          <bibl><ref target="lacy:L1337">Rienzi</ref></bibl>
+        </listBibl>
+        <listRef type="seeAlso">
+          <ref target="https://www.victorianresearch.org/atcl/show_author.php?aid=1386">ATCL</ref>
+          <ref target="https://doi.org/10.1093/ref:odnb/18859">ODNB</ref>
+          <ref target="https://en.wikipedia.org/wiki/Mary_Russell_Mitford">Wikipedia</ref>
+          <ref>Curran (contribs:23)</ref>
+          <ref target="https://digitalmitford.org">Digital Mitford</ref>
+        </listRef>
       </person>
     </egXML>
   </exemplum>

--- a/P5/Source/Specs/person.xml
+++ b/P5/Source/Specs/person.xml
@@ -166,12 +166,12 @@
   </exemplum>
   <exemplum xml:lang="en">
     <p>This example demonstrates the use of a <gi>ref</gi> element to provide more information about a person.</p>
-    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-person-egxml-dram">
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-person-egxml-dr">
       <person age="G2" role="author" xml:id="W0212" sex="F">
         <birth when="1787"/>
         <death when="1855"/>
         <persName type="main">Mitford, Mary Russell (1787–1855)</persName>
-        <persName resp="Nicoll">MITFORD, MARY RUSSELL</persName>
+        <persName resp="#Nicoll">MITFORD, MARY RUSSELL</persName>
         <listBibl type="lacyTitles">
           <desc>Lacy's Acting Editions</desc>
           <bibl><ref target="lacy:L1280">Foscari</ref></bibl>
@@ -181,7 +181,6 @@
           <ref target="https://www.victorianresearch.org/atcl/show_author.php?aid=1386">ATCL</ref>
           <ref target="https://doi.org/10.1093/ref:odnb/18859">ODNB</ref>
           <ref target="https://en.wikipedia.org/wiki/Mary_Russell_Mitford">Wikipedia</ref>
-          <ref>Curran (contribs:23)</ref>
           <ref target="https://digitalmitford.org">Digital Mitford</ref>
         </listRef>
       </person>

--- a/P5/Source/Specs/person.xml
+++ b/P5/Source/Specs/person.xml
@@ -23,16 +23,12 @@
   </classes>
   <content>
     <alternate>
-      
         <classRef key="model.pLike" minOccurs="1" maxOccurs="unbounded"/>
-      
-      
         <alternate minOccurs="0" maxOccurs="unbounded">
           <classRef key="model.personPart"/>
           <classRef key="model.global"/>
-          <elementRef key="ptr"/>
+          <classRef key="model.ptrLike"/>
         </alternate>
-      
     </alternate>
   </content>
   <attList>
@@ -45,14 +41,13 @@
       <desc versionDate="2007-05-04" xml:lang="es">establece el rol o la clasificación primaria de una persona.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">stabilisce il ruolo o la classificazione primaria di una persona</desc>
       <datatype maxOccurs="unbounded"><dataRef key="teidata.enumerated"/></datatype>
-<remarks versionDate="2013-12-21" xml:lang="en">
+      <remarks versionDate="2013-12-21" xml:lang="en">
         <p>Values for this attribute may be locally defined by a
 	project, using arbitrary keywords such as <val>artist</val>,
 	<val>employer</val>, <val>author</val>, <val>relative</val>, or
 	<val>servant</val>, each of which should be associated with a
 	definition. Such local definitions will typically be provided by a
-	<gi>valList</gi> element in the project schema
-specification.</p></remarks>
+	<gi>valList</gi> element in the project schema specification.</p></remarks>
     </attDef>
     <attDef ident="sex" usage="opt">
       <desc versionDate="2005-12-14" xml:lang="en">specifies the sex of the person.</desc>
@@ -83,14 +78,13 @@ specification.</p></remarks>
       <desc versionDate="2007-05-04" xml:lang="es">especifica un intervalo de edad para una persona.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">indica la fascia di età di una persona</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
-<remarks versionDate="2013-12-21" xml:lang="en">
+      <remarks versionDate="2013-12-21" xml:lang="en">
         <p>Values for this attribute may be locally defined by a
 	project, using arbitrary keywords such as <val>infant</val>,
 	<val>child</val>, <val>teen</val>, <val>adult</val>, or
 	<val>senior</val>, each of which should be associated with a
 	definition. Such local definitions will typically be provided by a
-	<gi>valList</gi> element in the project schema
-specification.</p></remarks>
+	<gi>valList</gi> element in the project schema specification.</p></remarks>
     </attDef>
   </attList>
   <exemplum xml:lang="en">

--- a/P5/Source/Specs/place.xml
+++ b/P5/Source/Specs/place.xml
@@ -6,13 +6,10 @@
   <gloss versionDate="2008-12-09" xml:lang="fr">lieu</gloss>
   <desc versionDate="2007-06-14" xml:lang="en">contains data about a geographic location.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">지리적 위치에 관한 데이터를 포함한다.</desc>
-  <desc versionDate="2008-04-06" xml:lang="es">contiene los datos sobre una localización
-    geográfica</desc>
+  <desc versionDate="2008-04-06" xml:lang="es">contiene los datos sobre una localización geográfica</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">地理上の場所のデータを示す。</desc>
-  <desc versionDate="2008-12-09" xml:lang="fr">contient des informations sur un lieu
-    géographique.</desc>
-  <desc versionDate="2007-11-06" xml:lang="it">contiene informazioni relative a un luogo
-    geografico</desc>
+  <desc versionDate="2008-12-09" xml:lang="fr">contient des informations sur un lieu géographique.</desc>
+  <desc versionDate="2007-11-06" xml:lang="it">contiene informazioni relative a un luogo geografico</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.editLike"/>

--- a/P5/Source/Specs/place.xml
+++ b/P5/Source/Specs/place.xml
@@ -6,10 +6,13 @@
   <gloss versionDate="2008-12-09" xml:lang="fr">lieu</gloss>
   <desc versionDate="2007-06-14" xml:lang="en">contains data about a geographic location.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">지리적 위치에 관한 데이터를 포함한다.</desc>
-  <desc versionDate="2008-04-06" xml:lang="es">contiene los datos sobre una localización geográfica</desc>
+  <desc versionDate="2008-04-06" xml:lang="es">contiene los datos sobre una localización
+    geográfica</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">地理上の場所のデータを示す。</desc>
-  <desc versionDate="2008-12-09" xml:lang="fr">contient des informations sur un lieu géographique.</desc>
-  <desc versionDate="2007-11-06" xml:lang="it">contiene informazioni relative a un luogo geografico</desc>
+  <desc versionDate="2008-12-09" xml:lang="fr">contient des informations sur un lieu
+    géographique.</desc>
+  <desc versionDate="2007-11-06" xml:lang="it">contiene informazioni relative a un luogo
+    geografico</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.editLike"/>
@@ -19,40 +22,28 @@
   </classes>
   <content>
     <sequence>
-      
-        <classRef key="model.headLike" minOccurs="0" maxOccurs="unbounded"/>
-      
+      <classRef key="model.headLike" minOccurs="0" maxOccurs="unbounded"/>
       <alternate>
-        
-          
-            <classRef key="model.pLike" minOccurs="0" maxOccurs="unbounded"/>
-          
-        
-        
-          <alternate minOccurs="0" maxOccurs="unbounded">
-            <classRef key="model.labelLike"/>
-            <classRef key="model.placeStateLike"/>
-            <classRef key="model.eventLike"/>
-            <elementRef key="name"/>
-          </alternate>
-        
+        <classRef key="model.pLike" minOccurs="0" maxOccurs="unbounded"/>
+        <alternate minOccurs="0" maxOccurs="unbounded">
+          <classRef key="model.labelLike"/>
+          <classRef key="model.placeStateLike"/>
+          <classRef key="model.eventLike"/>
+          <elementRef key="name"/>
+        </alternate>
       </alternate>
-      
-        <alternate minOccurs="0" maxOccurs="unbounded">
-          <classRef key="model.noteLike"/>
-          <classRef key="model.biblLike"/>
-          <elementRef key="idno"/>
-          <elementRef key="ptr"/>
-          <elementRef key="linkGrp"/>
-          <elementRef key="link"/>
-        </alternate>
-      
-      
-        <alternate minOccurs="0" maxOccurs="unbounded">
-          <classRef key="model.placeLike"/>
-          <elementRef key="listPlace"/>
-        </alternate>
-      
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.noteLike"/>
+        <classRef key="model.biblLike"/>
+        <classRef key="model.ptrLike"/>
+        <elementRef key="idno"/>
+        <elementRef key="linkGrp"/>
+        <elementRef key="link"/>
+      </alternate>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.placeLike"/>
+        <elementRef key="listPlace"/>
+      </alternate>
     </sequence>
   </content>
   <exemplum xml:lang="en">


### PR DESCRIPTION
Updated the content model of `place.xml`, `event.xml`, `person.xml` and `org.xml` replacing the `<elementRef>` for `ptr` with the `<classRef>` for `model.ptrLike`, following #2651. 