### PR TITLE
Removed enumerated values in the attribute descriptions 

### DIFF
--- a/P5/Source/Specs/att.citing.xml
+++ b/P5/Source/Specs/att.citing.xml
@@ -7,9 +7,8 @@
   <classes/>
   <attList>
     <attDef ident="unit" usage="opt">
-      <desc versionDate="2012-12-17" xml:lang="en">identifies the unit of information conveyed by the element, e.g. <val>columns</val>, <val>pages</val>, <val>volume</val>, <val>entry</val>.</desc>
-      <desc versionDate="2017-06-24" xml:lang="fr">identifie le type d'information
-      que transmet l'élément, par exemple <val>colonnes</val>, <val>pages</val>, <val>volume</val>, <val>inscription</val>, etc.</desc>
+      <desc versionDate="2025-03-31" xml:lang="en">identifies the unit of information conveyed by the element.</desc>
+      <desc versionDate="2025-03-31" xml:lang="fr">identifie le type d'information que transmet l'élément.</desc>
       <desc versionDate="2019-01-04" xml:lang="ja">当該要素が伝える情報の単位を特定する。たとえば、カラム (<val>columns</val>)、頁 (<val>pages</val>)、巻 (<val>volume</val>)、エントリ (<val>entry</val>) 等。</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <valList type="semi">
@@ -32,8 +31,7 @@
 	  <desc versionDate="2007-05-02" xml:lang="zh-TW">該元素標記的內容為一期刊號或冊號與期刊號。</desc>
 	  <desc versionDate="2008-04-06" xml:lang="es">el elemento contiene el número de la edición, o los números del volumen y de la edición.</desc>
 	  <desc versionDate="2019-01-04" xml:lang="ja">号番号かまたは巻と号の番号を含む。</desc>
-	  <desc versionDate="2008-03-30" xml:lang="fr">l'élément contient un numéro de
-	  livraison ou bien un numéro de volume et de livraison.</desc>
+	  <desc versionDate="2008-03-30" xml:lang="fr">l'élément contient un numéro de livraison ou bien un numéro de volume et de livraison.</desc>
 	  <desc versionDate="2007-01-21" xml:lang="it">l'elemento contiene l'indicazione del numero della pubblicazione</desc>
 	</valItem>
 	<valItem ident="page">
@@ -46,8 +44,7 @@
 	  <desc versionDate="2007-05-02" xml:lang="zh-TW">該元素標記的內容為一頁數或頁數範圍。</desc>
 	  <desc versionDate="2021-01-18" xml:lang="es">el elemento contiene un número de página o un intervalo de páginas.</desc>
 	  <desc versionDate="2019-01-04" xml:lang="ja">ページ番号またはページ範囲を含む。</desc>
-	  <desc versionDate="2008-03-30" xml:lang="fr">l'élément contient un nombre de pages
-	  ou l'étendue de sélection des pages.</desc>
+	  <desc versionDate="2008-03-30" xml:lang="fr">l'élément contient un nombre de pages ou l'étendue de sélection des pages.</desc>
 	  <desc versionDate="2007-01-21" xml:lang="it">l'elemento contiene l'indicazione di pagina o pagine</desc>
 	</valItem>
 	<valItem ident="line">
@@ -60,13 +57,11 @@
 	  <gloss versionDate="2008-04-06" xml:lang="es">capítulo</gloss>
 	  <gloss versionDate="2009-01-06" xml:lang="fr">chapitre</gloss>
 	  <gloss versionDate="2007-11-06" xml:lang="it">capitolo</gloss>
-	  <desc versionDate="2013-06-17" xml:lang="en">the element contains a chapter indication (number
-	  and/or title)</desc>
+	  <desc versionDate="2013-06-17" xml:lang="en">the element contains a chapter indication (number and/or title)</desc>
 	  <desc versionDate="2007-12-20" xml:lang="ko">장 표시(숫자와/또는 제목)를 포함한다.</desc>
 	  <desc versionDate="2008-04-06" xml:lang="es">el elemento contiene la indicación del capítulo (número y/o el título)</desc>
 	  <desc versionDate="2019-01-04" xml:lang="ja">章の識別子(番号やタイトル)を含む。</desc>
-	  <desc versionDate="2008-03-30" xml:lang="fr">l'élément contient une indication de
-	  chapitre (le numéro et/ou le titre)</desc>
+	  <desc versionDate="2008-03-30" xml:lang="fr">l'élément contient une indication de chapitre (le numéro et/ou le titre)</desc>
 	  <desc versionDate="2007-11-06" xml:lang="it">l'elemento contiene un'indicazione di capitolo (numero e/o titolo</desc>
 	</valItem>
 	<valItem ident="part">
@@ -75,8 +70,7 @@
 	  <desc versionDate="2007-05-02" xml:lang="zh-TW">該元素標明的內容為單書或集合作品的一部份。</desc>
 	  <desc versionDate="2008-04-06" xml:lang="es">el elemento identifica una parte de un libro o de una colección.</desc>
 	  <desc versionDate="2019-01-04" xml:lang="ja">書籍や叢書の部分を特定する。</desc>
-	  <desc versionDate="2008-03-30" xml:lang="fr">l'élément identifie une partie d'un
-	  livre ou une anthologie.</desc>
+	  <desc versionDate="2008-03-30" xml:lang="fr">l'élément identifie une partie d'un livre ou une anthologie.</desc>
 	  <desc versionDate="2007-01-21" xml:lang="it">l'elemento identifica una parte di un libro o di una raccolta</desc>
 	</valItem>
 	<valItem ident="column">

--- a/P5/Source/Specs/gap.xml
+++ b/P5/Source/Specs/gap.xml
@@ -49,8 +49,7 @@
       <desc versionDate="2007-12-20" xml:lang="ko">누락의 이유를 제시한다. 그 값의 예들은 다음과 같다: <val>sampling</val>,
           <val>illegible</val>, <val>inaudible</val>, <val>irrelevant</val>, <val>cancelled</val>,
           <val>cancelled and illegible</val></desc>
-      <desc versionDate="2007-05-02" xml:lang="zh-TW">說明省略的原因。屬性值的例子有<val>sampling</val>、<val>illegible</val>、<val>inaudible</val>、<val>irrelevant</val>、<val>cancelled</val>、<val>cancelled
-          and illegible</val>。</desc>
+      <desc versionDate="2025-03-31" xml:lang="zh-TW">說明省略的原因。</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">省略の理由を示す。例えば、 <val>見本</val>、<val>聞こえない</val>、
           <val>無関係</val>、<val>取り消し</val>、<val>取り消しがありかつ判読できない</val>、など。</desc>
       <desc versionDate="2017-02-06" xml:lang="fr">donne la raison de l'omission.</desc>
@@ -74,10 +73,8 @@
 	</valItem>
 	<valItem ident="editorial">
 	  <gloss versionDate="2021-02-01" xml:lang="en">editorial</gloss>
-	  <desc versionDate="2017-02-06" xml:lang="en">for features omitted from
-	  transcription due to editorial policy</desc>
-	  <desc versionDate="2017-02-07" xml:lang="de">für Bestandteile, 
-	  die aus editorischen Gründen nicht übertragen wurden</desc>
+	  <desc versionDate="2017-02-06" xml:lang="en">for features omitted from transcription due to editorial policy</desc>
+	  <desc versionDate="2017-02-07" xml:lang="de">für Bestandteile, die aus editorischen Gründen nicht übertragen wurden</desc>
 	</valItem>
 	<valItem ident="illegible">
 	  <gloss versionDate="2017-02-06" xml:lang="en">illegible</gloss>
@@ -112,19 +109,14 @@
     <attDef ident="agent" usage="opt">
       <gloss versionDate="2016-11-25" xml:lang="en">agent</gloss>
       <gloss versionDate="2016-11-25" xml:lang="de">Ursache</gloss>
-      <desc versionDate="2005-08-03" xml:lang="en">in the case of text omitted because of damage, categorizes the cause of the damage, if
-        it can be identified.</desc>
+      <desc versionDate="2005-08-03" xml:lang="en">in the case of text omitted because of damage, categorizes the cause of the damage, if it can be identified.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">훼손으로 인해 누락된 텍스트의 경우, 확인이 가능하다면 그 훼손 원인을 분류하여 기술한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">若省略是由於內容遭受損毀，且可識別損毀原因，則針對損毀原因加以分類。</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">損傷が原因のテキスト省略の場合、特定可能であれば当該損傷を分類する。</desc>
-      <desc versionDate="2007-06-12" xml:lang="fr">lorsque du texte est omis de la transcription en
-        raison d'un dommage, catégorise la cause du dommage, si celle-ci peut être identifiée.</desc>
-      <desc versionDate="2007-05-04" xml:lang="es">En el caso de texto omitido a causa de algún daño,
-        identifica (si es posible) la causa de tal daño.</desc>
-      <desc versionDate="2007-01-21" xml:lang="it">nel caso in cui il testo sia stato omesse a causa di
-        danneggiamento, indica la causa del danno qualora possa essere identificata.</desc>
-      <desc versionDate="2016-11-25" xml:lang="de">bestimmt im Falle von Text, der wegen Beschädigung weggelassen wird, 
-        die Ursache für den Schaden, sofern er ermittelt werden kann.</desc>
+      <desc versionDate="2007-06-12" xml:lang="fr">lorsque du texte est omis de la transcription en raison d'un dommage, catégorise la cause du dommage, si celle-ci peut être identifiée.</desc>
+      <desc versionDate="2007-05-04" xml:lang="es">En el caso de texto omitido a causa de algún daño, identifica (si es posible) la causa de tal daño.</desc>
+      <desc versionDate="2007-01-21" xml:lang="it">nel caso in cui il testo sia stato omesse a causa di danneggiamento, indica la causa del danno qualora possa essere identificata.</desc>
+      <desc versionDate="2016-11-25" xml:lang="de">bestimmt im Falle von Text, der wegen Beschädigung weggelassen wird, die Ursache für den Schaden, sofern er ermittelt werden kann.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
       <valList type="open">
         <valItem ident="rubbing">
@@ -133,13 +125,10 @@
           <desc versionDate="2007-06-27" xml:lang="en">damage results from rubbing of the leaf edges</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">책장 모서리 마모로 인한 훼손</desc>
           <desc versionDate="2007-05-02" xml:lang="zh-TW">損毀起因於書頁邊緣摩擦受損</desc>
-          <desc versionDate="2008-04-06" xml:lang="es">daños resultantes del frotamiento de los bordes
-            de la hoja</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">daños resultantes del frotamiento de los bordes de la hoja</desc>
           <desc versionDate="2008-04-05" xml:lang="ja">葉のこすれによる損傷。</desc>
-          <desc versionDate="2008-03-30" xml:lang="fr">dégâts provoqués par le frottement des bords de
-            la feuille.</desc>
-          <desc versionDate="2007-01-21" xml:lang="it">il danno è causato da segni di strofinamento sui
-            bordi del foglio</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">dégâts provoqués par le frottement des bords de la feuille.</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">il danno è causato da segni di strofinamento sui bordi del foglio</desc>
           <desc versionDate="2016-11-25" xml:lang="de">Schaden, verursacht durch Abrieb an den Blatträndern</desc>
         </valItem>
         <valItem ident="mildew">
@@ -148,13 +137,10 @@
           <desc versionDate="2007-06-27" xml:lang="en">damage results from mildew on the leaf surface</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">곰팡이로 인한 책장 표면의 훼손</desc>
           <desc versionDate="2007-05-02" xml:lang="zh-TW">損毀起因於書頁表面發霉</desc>
-          <desc versionDate="2008-04-06" xml:lang="es">daños resultantes de la acción del moho en la
-            superficie de la hoja</desc>
+          <desc versionDate="2008-04-06" xml:lang="es">daños resultantes de la acción del moho en la superficie de la hoja</desc>
           <desc versionDate="2008-04-05" xml:lang="ja">葉の表面に付いた白カビによる損傷。</desc>
-          <desc versionDate="2008-03-30" xml:lang="fr">dégâts provoqués par de la moisissure sur la
-            surface de feuille.</desc>
-          <desc versionDate="2007-01-21" xml:lang="it">il danno è causato da macchie di umido sulla
-            superficie del foglio</desc>
+          <desc versionDate="2008-03-30" xml:lang="fr">dégâts provoqués par de la moisissure sur la surface de feuille.</desc>
+          <desc versionDate="2007-01-21" xml:lang="it">il danno è causato da macchie di umido sulla superficie del foglio</desc>
           <desc versionDate="2016-11-25" xml:lang="de">Schaden, verursacht durch Schimmelbefall</desc>
         </valItem>
         <valItem ident="smoke">

--- a/P5/Source/Specs/metDecl.xml
+++ b/P5/Source/Specs/metDecl.xml
@@ -55,23 +55,15 @@
   </content>
   <attList>
     <attDef ident="type" usage="opt">
-      <desc versionDate="2005-01-14" xml:lang="en">indicates whether the notation conveys the abstract metrical form, its actual prosodic
-        realization, or the rhyme scheme, or some combination thereof.</desc>
-      <desc versionDate="2009-01-05" xml:lang="fr">indique si la notation traduit la forme métrique
-        abstraite, sa réalisation prosodique, le schéma des rimes, ou une combinaison de ces
-        différents éléments.</desc>
+      <desc versionDate="2005-01-14" xml:lang="en">indicates whether the notation conveys the abstract metrical form, its actual prosodic realization, or the rhyme scheme, or some combination thereof.</desc>
+      <desc versionDate="2009-01-05" xml:lang="fr">indique si la notation traduit la forme métrique abstraite, sa réalisation prosodique, le schéma des rimes, ou une combinaison de ces différents éléments.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">표기법이 추상적 운율 형식, 그 실제 운율적 실현, 또는 운 스키마, 아니면 그것에 관련한
         결합을 포함하는지를 표시한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">指出該標記所傳達的為抽象韻律形式、實際韻律實踐、或者押韻形式，或任幾項之結合。</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">当該表記法が抽象的韻律形式、実際の韻律形式、押韻スキーム、これら の組み合わせを表すかどうかを示す。</desc>
-      <desc versionDate="2006-10-18" xml:lang="de">zeigt an, ob die Notation die abstrakte metrische
-        Form, die tatsächliche prosodische Realisierung oder das Reimschema oder eine Kombination
-        dessen wiedergibt.</desc>
-      <desc versionDate="2007-05-04" xml:lang="es">indica si la notación indica la forma métrica
-        abstracta, su realización prosódica real, el esquema rítmico o alguna combinación de todo
-        ello.</desc>
-      <desc versionDate="2007-01-21" xml:lang="it">indica se l'annotazione fornisce la forma metrica
-        estratta, la sua realizzazione prosodica,lo schema delle rime o un loro combinazione</desc>
+      <desc versionDate="2006-10-18" xml:lang="de">zeigt an, ob die Notation die abstrakte metrische Form, die tatsächliche prosodische Realisierung oder das Reimschema oder eine Kombination dessen wiedergibt.</desc>
+      <desc versionDate="2007-05-04" xml:lang="es">indica si la notación indica la forma métrica abstracta, su realización prosódica real, el esquema rítmico o alguna combinación de todo ello.</desc>
+      <desc versionDate="2007-01-21" xml:lang="it">indica se l'annotazione fornisce la forma metrica estratta, la sua realizzazione prosodica,lo schema delle rime o un loro combinazione</desc>
       <datatype minOccurs="1" maxOccurs="3"><dataRef key="teidata.enumerated"/></datatype>
       <defaultVal>met real</defaultVal>
       <valList type="closed">


### PR DESCRIPTION
Following #2663 I removed the repetative enumerations in the English and French `<desc>` of `att.citing/@unit` and (with help from my Chinese colleague Jiaqi) the Chinese `<desc>` to `gap/@reason`. 