### PR TITLE
Fix for issue #2642.

### DIFF
--- a/P5/Source/Specs/sp.xml
+++ b/P5/Source/Specs/sp.xml
@@ -32,11 +32,12 @@
   </classes>
   <content>
     <sequence>
-      <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-      <sequence minOccurs="0">
-        <elementRef key="speaker"/>
+      <alternate minOccurs="0" maxOccurs="unbounded">
         <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-      </sequence>
+        <classRef key="model.stageLike" minOccurs="0" maxOccurs="unbounded"/>
+      </alternate>
+      <elementRef key="speaker"/>
+      <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
       <sequence minOccurs="1" maxOccurs="unbounded">
         <alternate>
           <elementRef key="lg"/>

--- a/P5/Source/Specs/sp.xml
+++ b/P5/Source/Specs/sp.xml
@@ -32,10 +32,10 @@
   </classes>
   <content>
     <sequence>
-      <sequence minOccurs="0" maxOccurs="unbounded">
-        <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-        <classRef key="model.stageLike" minOccurs="0" maxOccurs="unbounded"/>
-      </sequence>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.global" minOccurs="1" maxOccurs="1"/>
+        <classRef key="model.stageLike" minOccurs="1" maxOccurs="1"/>
+      </alternate>
       <sequence>
         <elementRef key="speaker"/>
         <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>

--- a/P5/Source/Specs/sp.xml
+++ b/P5/Source/Specs/sp.xml
@@ -32,12 +32,14 @@
   </classes>
   <content>
     <sequence>
-      <alternate minOccurs="0" maxOccurs="unbounded">
+      <sequence minOccurs="0" maxOccurs="unbounded">
         <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
         <classRef key="model.stageLike" minOccurs="0" maxOccurs="unbounded"/>
-      </alternate>
-      <elementRef key="speaker"/>
-      <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
+      </sequence>
+      <sequence>
+        <elementRef key="speaker"/>
+        <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
+      </sequence>
       <sequence minOccurs="1" maxOccurs="unbounded">
         <alternate>
           <elementRef key="lg"/>

--- a/P5/Test/testall.xml
+++ b/P5/Test/testall.xml
@@ -1441,6 +1441,8 @@ What do you heere? Shal we giue ore and drowne, haue you a
       <p>Worke you then.</p>
     </sp>
     <sp>
+      <!-- Test for allowing stage before speaker. -->
+      <stage>Manet.</stage>
       <speaker rend="it">Anth.</speaker>
       <p>Hang cur, hang, you whoreson insolent Noyse-maker, we are lesse afraid
         to be drownde, then thou art.</p>


### PR DESCRIPTION
I believe this addresses the issue, allowing members of `model.stageLike` in alternation with the existing `model.global` before the optional `<speaker>` element. I've also added an instance into one of the test files.