### PR TITLE
add missing periods in the AI chapter (18.4.2)

### DIFF
--- a/P5/Source/Guidelines/en/AI-AnalyticMechanisms.xml
+++ b/P5/Source/Guidelines/en/AI-AnalyticMechanisms.xml
@@ -1147,7 +1147,7 @@ have <att>join</att> with the value <val>right</val> on the tokens
 on a single direction of adjacency is enough. Strategies vary, and it is important to
 document them in the TEI header.</p>
 <p>The following example shows a German sentence <mentioned>Wir fahren in den
-Urlaub</mentioned> (<q>We're going on vacation</q>) annotated with all the attributes discussed
+Urlaub.</mentioned> (<q>We're going on vacation.</q>) annotated with all the attributes discussed
 above.<note place="bottom">The annotation values have been adapted from the <ref target="https://weblicht.sfs.uni-tuebingen.de/weblicht/">CLARIN Weblicht service</ref>,
 where e.g. the full morphosyntactic description of the first item reads: <code><![CDATA[[cat pronoun,
 personal true, substituting true, person 1, case nominative, number plural]]]></code>, and has been


### PR DESCRIPTION
The prose quotes/mentions two sentences (source and translation) without periods, but it's the entire (source) sentence that gets annotated in the immediately following example, _together with the period_. 

It looked as if the visual editor were going to allow me to push directly to the dev branch, and I panicked a bit and created the PR manually. I hope that's OK. 