### PR TITLE
Adding missing `<listRef>`s for #2652

### DIFF
--- a/P5/Source/Specs/listRef.xml
+++ b/P5/Source/Specs/listRef.xml
@@ -69,5 +69,6 @@
   </remarks>
   <listRef>
     <ptr target="#TDcrystalsCEdc"/>
+    <ptr target="#IM-unified">
   </listRef>
 </elementSpec>

--- a/P5/Source/Specs/listRef.xml
+++ b/P5/Source/Specs/listRef.xml
@@ -69,6 +69,6 @@
   </remarks>
   <listRef>
     <ptr target="#TDcrystalsCEdc"/>
-    <ptr target="#IM-unified">
+    <ptr target="#IM-unified"/>
   </listRef>
 </elementSpec>

--- a/P5/Source/Specs/listRef.xml
+++ b/P5/Source/Specs/listRef.xml
@@ -67,4 +67,7 @@
     </list>
     </p>
   </remarks>
+  <listRef>
+    <ptr target="#TDcrystalsCEdc"/>
+  </listRef>
 </elementSpec>

--- a/P5/Source/Specs/outputRendition.xml
+++ b/P5/Source/Specs/outputRendition.xml
@@ -66,7 +66,6 @@
   </remarks>
    
   <listRef>
-    <ptr target="#TDPMPM"/>
     <ptr target="#TDPMOR"/>
   </listRef>
   

--- a/P5/Source/Specs/outputRendition.xml
+++ b/P5/Source/Specs/outputRendition.xml
@@ -68,7 +68,6 @@
   <listRef>
     <ptr target="#TDPMPM"/>
     <ptr target="#TDPMOR"/>
-    <ptr target="#TDPMMC"/>
   </listRef>
   
 </elementSpec>

--- a/P5/Source/Specs/outputRendition.xml
+++ b/P5/Source/Specs/outputRendition.xml
@@ -64,10 +64,11 @@
       (CSS2 or later) be used to express the required formatting information.</p>
    
   </remarks>
-  <!-- 
+   
   <listRef>
-    <ptr target="#WhereWeDiscussIt" type="div2"/>
-    <ptr target="#WhereWeDiscussIt" type="div2"/>
+    <ptr target="#TDPMPM"/>
+    <ptr target="#TDPMOR"/>
+    <ptr target="#TDPMMC"/>
   </listRef>
-  -->
+  
 </elementSpec>

--- a/P5/Source/Specs/paramList.xml
+++ b/P5/Source/Specs/paramList.xml
@@ -29,10 +29,8 @@
   <remarks versionDate="2015-08-21" xml:lang="en">
     <p>The <gi>paramList</gi> element provides a a mechanism to document parameter specifications using child <gi>paramSpec</gi> elements.</p>
   </remarks>
-<!--
   <listRef>
-      <ptr target="#WhereWeDiscussIt" type="div2"/>
-    <ptr target="#WhereWeDiscussIt" type="div2"/>
+      <ptr target="#TDPMMB"/>
+      <ptr target="#TDPMDEF"/>
   </listRef>
- --> 
 </elementSpec>


### PR DESCRIPTION
This PR addresses the missing `<listRef>`s highlighted in #2652. I have started work on this issue and added `<listRef>`s to the Spec pages of the following individual elements: `<listRef>`, `<paramList>`, and `<outputRendition>`. These were the most straightforward instances which clearly required a `<listRef>` and where there was a specific section in the Guidelines to which we could point.

I have not yet started to address the remaining specifications which also do not have a `<listRef>` (see [table](https://github.com/TEIC/TEI/issues/2652#issue-2782672438)) as these other instances require further discussion at Council, but I hope that this PR could serve to store these future updates as well.

