### PR TITLE
Addresses #2653

### DIFF
--- a/P5/Source/Specs/att.canonical.xml
+++ b/P5/Source/Specs/att.canonical.xml
@@ -108,7 +108,7 @@
     precedence when both <att>key</att> and <att>ref</att> are
     provided. For this reason simultaneous use of both is not
     recommended unless documentation explaining the use is provided,
-    probably in an ODD customizaiton, for interchange.</p>
+    probably in an ODD customization, for interchange.</p>
   </remarks>
   <listRef>
     <ptr target="#NDATTSnr"/>

--- a/P5/Source/Specs/att.edition.xml
+++ b/P5/Source/Specs/att.edition.xml
@@ -50,8 +50,9 @@
 	  still living their personal lives in zest and endless
 	  novelty of action, … I saw myself still
 	  preserving, though with increasing difficulty, my lucid
-	  con<pc force="inter">-</pc><pb n="291" break="no" edRef="#stapledon1937"/>sciousness;</p>
+	  con<pb n="291" break="no" edRef="#stapledon1937"/>sciousness;</p>
     </egXML>
+    <p>In the above example, the soft hyphen in Stapledon 1937 is omitted. Such decisions may be documented in the edition's declaration of editorial principles, e.g. with the <gi>hyphenation</gi> element in the <gi>teiHeader</gi>.</p>
   </exemplum>
   <remarks versionDate="2025-07-08" xml:lang="en">
     <p>These guidelines provide no semantic basis or suggested

--- a/P5/Source/Specs/att.edition.xml
+++ b/P5/Source/Specs/att.edition.xml
@@ -2,8 +2,7 @@
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tei" type="atts" xml:id="class-attr-edition" ident="att.edition">
-  <desc versionDate="2013-01-11" xml:lang="en">provides attributes identifying the source edition from which
-  some encoded feature derives.</desc>
+  <desc versionDate="2013-01-11" xml:lang="en">provides attributes identifying the source edition from which some encoded feature derives.</desc>
   <desc versionDate="2009-05-28" xml:lang="fr">fournit des attributs identifiant l'édition source dont provient une quelconque caractéristique encodée.</desc>
   <desc versionDate="2019-05-20" xml:lang="ja">符号化された属性が派生する元のソースのエディションを特定する属性を提供する。</desc>
   <attList>
@@ -51,7 +50,14 @@
 	  still living their personal lives in zest and endless
 	  novelty of action, … I saw myself still
 	  preserving, though with increasing difficulty, my lucid
-	  con-<pb n="291" edRef="#stapledon1937"/>sciousness;</p>
+	  con<pc force="inter">-</pc><pb n="291" break="no" edRef="#stapledon1937"/>sciousness;</p>
     </egXML>
   </exemplum>
+  <remarks versionDate="2025-07-08" xml:lang="en">
+    <p>These guidelines provide no semantic basis or suggested
+      precedence when both <att>ed</att> and <att>edRef</att> are
+      provided. For this reason simultaneous use of both is not
+      recommended unless documentation explaining the use is provided,
+      probably in an ODD customization, for interchange.</p>
+  </remarks>
 </classSpec>


### PR DESCRIPTION
This PR proposes a bit of a middle of the ground approach to resolving ambiguity between `@ed` and `@edRef` (as discussed in #2653) by simply copying the discussion of the similar case of `@key` and `@ref` in `att.canonical`. 

I also tried to update the example based on @sydb's suggestion, but would be glad for any other suggestions.  