### PR TITLE
Replace `<p>` with `<ab>` in Core Tags for Drama example

### DIFF
--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -5914,24 +5914,26 @@ are prose or verse:
         noise of Thunder and Lightning heard: Enter
         a Ship-master, and a Boteswaine.</stage>
       <sp>
-         <speaker>Master.</speaker> <p>Bote-swaine.</p>
+         <speaker>Master.</speaker> 
+        <ab>Bote-swaine.</ab>
       </sp>
       <sp>
-         <speaker>Botes.</speaker> <p>Heere Master: What cheere?</p>
+         <speaker>Botes.</speaker> 
+        <ab>Heere Master: What cheere?</ab>
       </sp>
       <sp>
          <speaker>Mast.</speaker>
-         <p>Good: Speake to th' Mariners: fall
+         <ab>Good: Speake to th' Mariners: fall
            too't, yarely, or we run our selues a ground,
            bestirre, bestirre.  <stage type="move">Exit.</stage>
-         </p>
+         </ab>
       </sp>
       <stage type="move">Enter Mariners.</stage>
       <sp>
          <speaker>Botes.</speaker>
-         <p>Heigh my hearts, cheerely, cheerely my harts: yare,
+         <ab>Heigh my hearts, cheerely, cheerely my harts: yare,
            yare: Take in the toppe-sale: Tend to th' Masters whistle:
-           Blow till thou burst thy winde, if roome e-nough.</p>
+           Blow till thou burst thy winde, if roome e-nough.</ab>
       </sp>
    </div2>
 </div1></egXML>


### PR DESCRIPTION
This PR addresses point 2 of issue #2719 and replaces `<p>` with `<ab>` for the fourth example in the [Core Tags for Drama](https://tei-c.org/release/doc/tei-p5-doc/en/html/CO.html#CODR) section of the Guidelines. Council decided in the July 2025 call that this is a straightforward change and should be merged at your earliest convenience @hennyu and @bleekere. 