### PR TITLE
use Pure ODD for content model elements

### DIFF
--- a/P5/Source/Specs/alternate.xml
+++ b/P5/Source/Specs/alternate.xml
@@ -12,12 +12,18 @@
   <content>
     <alternate minOccurs="1" maxOccurs="1">
       <sequence minOccurs="1" maxOccurs="1">
-        <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
-        <elementRef key="valList" minOccurs="0" maxOccurs="1"/>
+        <classRef key="model.contentPart" minOccurs="1" maxOccurs="1"/>
+	<alternate minOccurs="1" maxOccurs="1">
+	  <sequence minOccurs="1" maxOccurs="1">
+            <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>	  
+	    <elementRef key="valList" minOccurs="0" maxOccurs="1"/>
+	  </sequence>
+	  <elementRef key="valList" minOccurs="1" maxOccurs="1"/>
+	</alternate>
       </sequence>
       <sequence minOccurs="1" maxOccurs="1">
-        <elementRef key="valList" minOccurs="1" maxOccurs="1"/>
-        <classRef key="model.contentPart" minOccurs="0" maxOccurs="unbounded"/>
+	<elementRef key="valList" minOccurs="1" maxOccurs="1"/>
+        <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
       </sequence>
     </alternate>
   </content>

--- a/P5/Source/Specs/alternate.xml
+++ b/P5/Source/Specs/alternate.xml
@@ -10,18 +10,17 @@
     <memberOf key="model.contentPart"/>
   </classes>
   <content>
-    <alternate minOccurs="1" maxOccurs="unbounded">
-      <elementRef key="valList"/>
-      <classRef key="model.contentPart"/>
+    <alternate minOccurs="1" maxOccurs="1">
+      <sequence minOccurs="1" maxOccurs="1">
+        <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
+        <elementRef key="valList" minOccurs="0" maxOccurs="1"/>
+      </sequence>
+      <sequence minOccurs="1" maxOccurs="1">
+        <elementRef key="valList" minOccurs="1" maxOccurs="1"/>
+        <classRef key="model.contentPart" minOccurs="0" maxOccurs="unbounded"/>
+      </sequence>
     </alternate>
   </content>
-  <constraintSpec ident="alternatechilden" scheme="schematron" xml:lang="en">
-    <constraint>
-      <sch:rule context="tei:alternate">
-        <sch:assert test="count(*) gt 1">The alternate element must have at least two child elements</sch:assert>
-      </sch:rule>
-    </constraint>
-  </constraintSpec>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-alternate-egXML-eg" xml:lang="en" source="#UND"><content>
       <alternate>

--- a/P5/Source/Specs/alternate.xml
+++ b/P5/Source/Specs/alternate.xml
@@ -10,20 +10,70 @@
     <memberOf key="model.contentPart"/>
   </classes>
   <content>
+    <!--
+        What we would like to have is
+          <interleave>
+            <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
+            <alternate>
+              <classRef key="model.contentPart" minOccurs="1" maxOccurs="1"/>
+              <elementRef key="valList" minOccurs="0" maxOccurs="1">
+            </alternate>
+          </interleave>
+        OR, equivalently,
+          ( model.contentPart+ & ( model.contentPart | valList? ) )
+        but
+        a) that is not valid in RELAX NG, anyway (because
+           model.contentPart is a member of an interleave
+           more than once); and
+        b) even if it were it probably could not be converted to DTD (or to XSD?)
+           due to ambiguity.   
+
+        So the following mildly complex content model does the same
+        thing without use of <interleave> and in an unambiguous way.
+        (Thus it can be converted to a valid DTD.)
+        Here is a briefly annotated version of the ODD content model
+        that follows, expressed using the RELAX NG compact syntax
+        instead:
+        (
+          ( valList, model.contentPart+ )        # starts with <valList>
+          |                                      # (and is followed by %contentPart;s)
+          (                                      # OR
+            model.contentPart,                   # starts with %contentPart;
+            (                                    #   which is followed by
+              valList                            #     <valList>
+              |                                  #     or
+              ( model.contentPart+, valList? )   #     more %contentPart;s and maybe a <valList>
+            )
+          )
+        )
+    -->
     <alternate minOccurs="1" maxOccurs="1">
+      <!--
+          Two possible sets of children: my content either starts with
+          <valList> or with a member of model.contentPart.
+      -->
       <sequence minOccurs="1" maxOccurs="1">
-        <classRef key="model.contentPart" minOccurs="1" maxOccurs="1"/>
-	<alternate minOccurs="1" maxOccurs="1">
-	  <sequence minOccurs="1" maxOccurs="1">
-            <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>	  
-	    <elementRef key="valList" minOccurs="0" maxOccurs="1"/>
-	  </sequence>
-	  <elementRef key="valList" minOccurs="1" maxOccurs="1"/>
-	</alternate>
+        <!-- Content starts with <valList> is simple: a single
+             <valList> followed by one or more members of
+             model.contentPart: -->
+        <elementRef key="valList" minOccurs="1" maxOccurs="1"/>
+        <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
       </sequence>
       <sequence minOccurs="1" maxOccurs="1">
-	<elementRef key="valList" minOccurs="1" maxOccurs="1"/>
-        <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- Content starts with a member of model.contentPart is not
+             as simple: after the single initial member of
+             model.contentPart we could either have just a <valList>
+             (for a total of 2 children) or we could have an
+             additional one or more members of model.contentPart,
+             optionally followed by a <valList>. -->
+        <classRef key="model.contentPart" minOccurs="1" maxOccurs="1"/>
+        <alternate minOccurs="1" maxOccurs="1">
+          <elementRef key="valList" minOccurs="1" maxOccurs="1"/>
+          <sequence minOccurs="1" maxOccurs="1">
+            <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>       
+            <elementRef key="valList" minOccurs="0" maxOccurs="1"/>
+          </sequence>
+        </alternate>
       </sequence>
     </alternate>
   </content>

--- a/P5/Source/Specs/closer.xml
+++ b/P5/Source/Specs/closer.xml
@@ -5,7 +5,7 @@
   <gloss versionDate="2007-06-12" xml:lang="en">closer</gloss>
   <gloss versionDate="2022-06-16" xml:lang="es">cierre</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">formule finale</gloss>
-  <desc versionDate="2007-04-06" xml:lang="en">groups together salutations, datelines, and similar phrases appearing as a final group at
+  <desc versionDate="2007-04-06" xml:lang="en">groups together salutations, datelines, bylines, and similar phrases appearing as a final group at
     the end of a division, especially of a letter.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">구역의 마지막, 특히 편지의 종료부에 발문으로 나타나는 인사말, 날짜 표시란, 그리고 유사 구를 합하여
     모아 놓는다.</desc>
@@ -31,6 +31,7 @@ aparecen en la última sección al final de una división, especialmente en una 
       <alternate minOccurs="0" maxOccurs="unbounded">
         <textNode/>
         <classRef key="model.gLike"/>
+        <elementRef key="byline"/>
         <elementRef key="signed"/>
         <elementRef key="dateline"/>
         <elementRef key="salute"/>

--- a/P5/Source/Specs/interleave.xml
+++ b/P5/Source/Specs/interleave.xml
@@ -9,15 +9,8 @@
     <memberOf key="model.contentPart"/>
   </classes>
   <content>
-    <classRef key="model.contentPart" maxOccurs="unbounded"/>
+    <classRef key="model.contentPart" minOccurs="2" maxOccurs="unbounded"/>
   </content>
-  <constraintSpec ident="interleavechilden" scheme="schematron" xml:lang="en">
-    <constraint>
-      <sch:rule context="tei:interleave">
-        <sch:assert test="count(*) gt 1">The interleave element must have at least two child elements</sch:assert>
-      </sch:rule>
-    </constraint>
-  </constraintSpec>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="en" source="#UND">
       <content>

--- a/P5/Source/Specs/sequence.xml
+++ b/P5/Source/Specs/sequence.xml
@@ -9,20 +9,12 @@
     <memberOf key="model.contentPart"/>
   </classes>
   <content>
-    <classRef key="model.contentPart" maxOccurs="unbounded"/>
+    <classRef key="model.contentPart" minOccurs="2" maxOccurs="unbounded"/>
   </content>
-  <constraintSpec ident="sequencechilden" scheme="schematron" xml:lang="en">
-    <constraint>
-      <sch:rule context="tei:sequence">
-        <sch:assert test="count(*) gt 1">The sequence element must have at least two child elements</sch:assert>
-      </sch:rule>
-    </constraint>
-  </constraintSpec>
   <attList>
     <attDef ident="preserveOrder" validUntil="2026-06-15">
       <desc type="deprecationInfo" versionDate="2024-03-15" xml:lang="en">The <att>preserveOrder</att> on <gi>sequence</gi> has been deprecated. The <gi>interleave</gi> element should be used to denote unordered constructs.</desc>
-      <desc xml:lang="en" versionDate="2023-03-21">if false, indicates that
-      component elements of a sequence may occur in any order.</desc>
+      <desc xml:lang="en" versionDate="2023-03-21">if false, indicates that component elements of a sequence may occur in any order.</desc>
       <datatype><dataRef key="teidata.truthValue"/></datatype>
     </attDef>
   </attList>


### PR DESCRIPTION
~NOTE — this PR is to merge changes into the `iss2154_interleave` branch, not `dev`. Therefore it would beehoove us to merge it **before** we merge `iss2154_interleave`.~
_____
The primary idea behind this PR is to use Pure ODD, rather than Schematron, to require that each of the content model wrapper elements (`<alternate>`, `<interleave>`, and `<sequence>`) has two or more children.

HOWEVER, as I went about doing so I realized that the existing content model for `<alternate>` had a bug. It was
~~~
 ( valList | model.contentPart )*
~~~
That allows for two or more `<valList>` children. I am not 100% sure what having an `<alternate>` with 3 `<valList>`s would _mean_.¹ But in any case, if there is more than one `<valList>`, the Stylesheets simply ignore the whole `<alternate>` (and, in my test, the `<elementRef>` I had before it, but not the `<elementRef>` I had after it — weird).

So I replaced this content model (and the Schematron that went with it to ensure 2+ children) with:
~~~
(
  ( model.contentPart, ( ( model.contentPart+, valList?) | valList) )
  |
  ( valList, model.contentPart+)
)
~~~
That is reasonably complicated, partially because it is a mildly complex set of restrictions, and partially because we cannot use an ambigous model (because DTDs and XSDs choke on them). But I have provided an English description below. In any case, the really astute reader may notice that this new content model prohibits two sequences of elements that were allowed under the old one:

1. Any sequence that has more than one `<valList>`. Since these don’t work, anyway, this is a good thing. (And one of the desired effects.)
2. One or more `model.contentPart` followed by a `<valList>` followed by one or more `model.contentPart`. It is at least very difficult, if not impossible, to allow this sequence and remain unambiguous. But I really cannot see any user complaining that she has to put the `<valList>` either first or last. (Heck, I find it hard to imagine any user ever making use of an `<alternate>` that includes a `<valList>` child and has more than 2 children. There are no such cases in P5.)

In any case, I have built P5 and the exemplars and run the tests in the Docker (this branch against the `dev` branch of the Stylesheets), and they all worked.

### below
It is a bit easier to say this in English if the content model were written in a different order:
~~~
(
  ( valList, model.contentPart+)
  |
  ( model.contentPart, ( valList | ( model.contentPart+, valList?)  )
)
~~~
That declares exactly the same content, and if I had thought ahead to the problem of explaining it in English, I might have done it that way. Given this re-ordered model, the following is a possibly helpful description of it:

> The content either starts with vL or with m.cP.
> If it starts with vL, then that single vL must be followed by one or more m.cP.
> If it starts with m.cP, it is actually starting with either a single m.cP, in which case that single m.cP must be followed by a vL; or it is starting with a sequence of two or more m.cPs, in which case said sequence _may_ be followed by a single vL (or not).

### notes
¹ My guess is that it would mean “any one value from any of these value lists”. And one could imagine a situation where it would be useful to get the lists into the `<alternate>` via XInclude, and thus allowing more than 1 would be necessary. But I daresay no one has ever even seen that done before, let alone done it, because our Stylesheets couldn’t process it!