### PR TITLE
Added `byline` to `closer` content model

### DIFF
--- a/P5/Source/Specs/byline.xml
+++ b/P5/Source/Specs/byline.xml
@@ -17,6 +17,7 @@ on its title page or at the head or end of the work.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.cmc"/>
+    <memberOf key="model.divBottomPart"/>
     <memberOf key="model.divWrapper"/>
     <memberOf key="model.pLike.front"/>
     <memberOf key="model.titlepagePart"/>

--- a/P5/Source/Specs/byline.xml
+++ b/P5/Source/Specs/byline.xml
@@ -17,7 +17,6 @@ on its title page or at the head or end of the work.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.cmc"/>
-    <memberOf key="model.divBottomPart"/>
     <memberOf key="model.divWrapper"/>
     <memberOf key="model.pLike.front"/>
     <memberOf key="model.titlepagePart"/>

--- a/P5/Source/Specs/closer.xml
+++ b/P5/Source/Specs/closer.xml
@@ -5,7 +5,7 @@
   <gloss versionDate="2007-06-12" xml:lang="en">closer</gloss>
   <gloss versionDate="2022-06-16" xml:lang="es">cierre</gloss>
   <gloss versionDate="2007-06-12" xml:lang="fr">formule finale</gloss>
-  <desc versionDate="2007-04-06" xml:lang="en">groups together salutations, datelines, and similar phrases appearing as a final group at
+  <desc versionDate="2007-04-06" xml:lang="en">groups together salutations, datelines, bylines, and similar phrases appearing as a final group at
     the end of a division, especially of a letter.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">구역의 마지막, 특히 편지의 종료부에 발문으로 나타나는 인사말, 날짜 표시란, 그리고 유사 구를 합하여
     모아 놓는다.</desc>
@@ -31,6 +31,7 @@ aparecen en la última sección al final de una división, especialmente en una 
       <alternate minOccurs="0" maxOccurs="unbounded">
         <textNode/>
         <classRef key="model.gLike"/>
+        <elementRef key="byline"/>
         <elementRef key="signed"/>
         <elementRef key="dateline"/>
         <elementRef key="salute"/>


### PR DESCRIPTION
This PR addresses issue #2658 to allow `byline` in `closer`. Tested locally via Docker but it doesn't seem to pass tests on GitHub.