### PR TITLE
fix dictionary example per #2718

### DIFF
--- a/P5/Source/Guidelines/en/BIB-Bibliography.xml
+++ b/P5/Source/Guidelines/en/BIB-Bibliography.xml
@@ -1292,6 +1292,14 @@
       <bibl xml:id="biblzh-tw_n18" xml:lang="zh-TW">台灣區三碼與三加二碼郵遞區號</bibl>
       <bibl xml:id="biblzh-tw_n47" xml:lang="zh-TW">《台灣叢書》，伊能嘉矩著，藏於國立台灣大學圖書館。(http://catalog.ndap.org.tw/?URN=2155366 (Aug 2008)).</bibl>
       <bibl xml:id="biblzh-tw_n27" xml:lang="zh-TW">唐．白居易．琵琶行</bibl>
+      <bibl xml:id="DIBO-egXML-lex0">
+        <author>Tasovac, T.</author>, <author>Romary, L.</author>, <author>Banski, P.</author>, <author>Bowers, J.</author>, <author>de Does, J.</author>, 
+        <author>Depuydt, K.</author>, <author>Erjavec, T.</author>, <author>Geyken, A.</author>, <author>Herold, A.</author>, <author>Hildenbrandt, V.</author>, 
+        <author>Khemakhem, M.</author>, <author>Lehečka, B.</author>, <author>Petrović, S.</author>, <author>Salgado, A.</author> and <author>Witt, A. </author>
+        <title level="m" type="main">TEI Lex-0: A baseline encoding for lexicographic data.</title>. <title level="m" type="sub">Version 0.9.3</title>.
+        <publisher>DARIAH Working Group on Lexical Resources.</publisher>, <date>2018</date> 
+        <ptr target="https://dariah-eric.github.io/lexicalresources/pages/TEILex0/TEILex0.html"/>.
+      </bibl>
       <bibl xml:id="TAYLOR">
         <author>Taylor, John</author>
         <title>The Cold Tearme or, The Frozen age, Or, The Metamorphosis of the Riuer of

--- a/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
+++ b/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
@@ -208,11 +208,10 @@ grouping two homograph entries.
     </entry>
   </body>
 </egXML>
-The encoding of a traditional root-based dictionary
-which starts with the root as the main headword, followed by
-full-fledged lexicographic entries of derived headwords, might
-make use of an <gi>entry</gi> for the main headword grouping
-the entries for the derived headwords, as follows.
+The following example demonstrates a possible encoding of a
+traditional root-based dictionary, which starts with the root as the
+main headword followed by full-fledged lexicographic entries of
+derived headwords.
 <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="DIBO-egXML-fh" xml:lang="ar" source="#DIBO-egXML-lex0">
   <entry type="wordFamily" xml:lang="ar" xml:id="syj">
     <form type="root">
@@ -220,7 +219,7 @@ the entries for the derived headwords, as follows.
     </form>
     <pc>:</pc>
     <!-- To fence (verb) -->
-    <entry type="mainEntry" xml:lang="ar" xml:id="syj1">
+    <entry type="mainEntry" xml:id="syj1">
      <form type="lemma">
        <orth>سيّج</orth>
      </form>
@@ -234,7 +233,7 @@ the entries for the derived headwords, as follows.
      <pc>٠</pc>
     </entry>
     <!-- A fence (noun) -->
-    <entry type="mainEntry" xml:lang="ar" xml:id="syj2">
+    <entry type="mainEntry" xml:id="syj2">
       <form type="lemma">
         <orth>السياج</orth>
       </form>
@@ -269,7 +268,7 @@ the entries for the derived headwords, as follows.
     </entry>
     <pc>٠</pc>
     <!-- A kind of fish -->
-    <entry type="mainEntry" xml:lang="ar" xml:id="syj3">
+    <entry type="mainEntry" xml:id="syj3">
       <form type="lemma">
         <orth>السيْجان</orth>
       </form>

--- a/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
+++ b/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
@@ -180,30 +180,30 @@ place where <q>three-D</q> would appear). </p>
 
 <p>A dictionary with no internal divisions might thus have a structure
 like the following; an outer <gi>entry</gi> element with a
-<att>type</att> attribute value of <val>wordFamily</val> is shown
+<att>type</att> attribute value of <val>homograph</val> is shown
 grouping two homograph entries.
 <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="DIBO-egXML-fg" xml:lang="und">
   <body>
     <entry>
       <form>
-	<orth>manifestation</orth> <!-- demonstration -->
+        <orth>manifestation</orth> <!-- demonstration -->
       </form>
     </entry>
     <entry>
       <form>
-	<orth>émeute</orth> <!-- riot -->
+        <orth>émeute</orth> <!-- riot -->
       </form>
     </entry>
-    <entry type="wordFamily">
-      <entry type="hom" n="1">
-	<form>
-	  <orth>grève</orth> <!-- strike -->
-	</form>
+    <entry type="homograph">
+      <entry n="1">
+        <form>
+          <orth>grève</orth> <!-- strike -->
+        </form>
       </entry>
-      <entry type="hom" n="2">
-	<form>
-	  <orth>grève</orth> <!-- shore -->
-	</form>
+      <entry n="2">
+        <form>
+          <orth>grève</orth> <!-- shore -->
+        </form>
       </entry>
     </entry>
   </body>
@@ -325,8 +325,8 @@ treated as entries, optionally grouped in an outer <gi>entry</gi> element:
     </entry>
     <entry n="2" type="hom">
       <sense n="1">
-	<sense n="a"> <!-- ... --> </sense>
-	<sense n="b"> <!-- ... --> </sense>
+        <sense n="a"> <!-- ... --> </sense>
+        <sense n="b"> <!-- ... --> </sense>
       </sense>
       <sense n="2"> <!-- ... --> </sense>
       <sense n="3"> <!-- ... --> </sense>

--- a/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
+++ b/P5/Source/Guidelines/en/DI-PrintDictionaries.xml
@@ -208,6 +208,81 @@ grouping two homograph entries.
     </entry>
   </body>
 </egXML>
+The encoding of a traditional root-based dictionary
+which starts with the root as the main headword, followed by
+full-fledged lexicographic entries of derived headwords, might
+make use of an <gi>entry</gi> for the main headword grouping
+the entries for the derived headwords, as follows.
+<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="DIBO-egXML-fh" xml:lang="ar" source="#DIBO-egXML-lex0">
+  <entry type="wordFamily" xml:lang="ar" xml:id="syj">
+    <form type="root">
+      <orth>سيج</orth>
+    </form>
+    <pc>:</pc>
+    <!-- To fence (verb) -->
+    <entry type="mainEntry" xml:lang="ar" xml:id="syj1">
+     <form type="lemma">
+       <orth>سيّج</orth>
+     </form>
+     <sense xml:id="syj1_sense1">
+       <cit type="example">
+         <quote>الكرم</quote>
+       </cit>
+       <pc>:</pc>
+       <def>جعل له سياجا</def>
+     </sense>
+     <pc>٠</pc>
+    </entry>
+    <!-- A fence (noun) -->
+    <entry type="mainEntry" xml:lang="ar" xml:id="syj2">
+      <form type="lemma">
+        <orth>السياج</orth>
+      </form>
+      <form type="inflected">
+        <gramGrp>
+          <gram type="number" value="plural">ج</gram>
+        </gramGrp>
+        <form type="variant">
+          <orth>سيَاجات</orth>
+        </form>
+        <lbl>و</lbl>
+        <form type="variant">
+          <orth>أسْوِجة</orth>
+        </form>
+        <lbl>و</lbl>
+        <form type="variant">
+          <orth>أَسْوِجة</orth>
+        </form>
+        <lbl>و</lbl>
+        <form type="variant">
+          <orth>سُوج</orth>
+        </form>
+      </form>
+      <pc>:</pc>
+      <sense xml:id="syj2_sense1">
+        <def>الحائط</def>
+      </sense>
+      <pc>||</pc>
+      <sense xml:id="syj2_sense2">
+        <def>ما أُحيط بهِ على شيءٍ كالكرم و النخل</def>
+      </sense>
+    </entry>
+    <pc>٠</pc>
+    <!-- A kind of fish -->
+    <entry type="mainEntry" xml:lang="ar" xml:id="syj3">
+      <form type="lemma">
+        <orth>السيْجان</orth>
+      </form>
+      <pc>(</pc>
+      <usg type="domain" value="animal">ح</usg>
+      <pc>)</pc>
+      <pc>:</pc>
+      <sense xml:id="syj3_sense1">
+        <def>نوع من السمك</def>
+      </sense>
+    </entry>
+  </entry>
+</egXML>
 </p>
 
 <specGrpRef target="#DEDIMV"/> 


### PR DESCRIPTION
Per @bansp’s [request](#2718), we have fixed the `@type` values in an example and added a new example from LEX-0.
This work brought to you per TEI Council by @sydb, @ebeshero, and @martinascholger.