### PR TITLE
simplify content model of `<arc>` and `<node>`

### DIFF
--- a/P5/Source/Specs/arc.xml
+++ b/P5/Source/Specs/arc.xml
@@ -15,10 +15,7 @@
     <memberOf key="att.global"/>
   </classes>
   <content>
-    <sequence minOccurs="0">
-      <elementRef key="label"/>
-      <elementRef key="label" minOccurs="0"/>
-    </sequence>
+    <elementRef key="label" minOccurs="0" maxOccurs="2"/>
   </content>
   <attList>
     <attDef ident="from" usage="req">

--- a/P5/Source/Specs/node.xml
+++ b/P5/Source/Specs/node.xml
@@ -16,10 +16,7 @@
     <memberOf key="att.typed"/>
   </classes>
   <content>
-    <sequence minOccurs="0">
-      <elementRef key="label"/>
-      <elementRef key="label" minOccurs="0"/>
-    </sequence>
+    <elementRef key="label" minOccurs="0" maxOccurs="2"/>
   </content>
   <attList>
     <attDef ident="value" usage="opt">


### PR DESCRIPTION
Use
~~~xml
<elementRef key="label" minOccurs="0" maxOccurs="2"/>
~~~
rather than 
~~~xml
    <sequence minOccurs="0">
      <elementRef key="label"/>
      <elementRef key="label" minOccurs="0"/>
    </sequence>
~~~
This is a fix for #2761, but is blocked until TEIC/Stylesheets#773 is fixed, perhaps by TEIC/Stylesheets#774.