### PR TITLE
easier-to-read Schematron for nested `<standOff>`

### DIFF
--- a/P5/Source/Specs/standOff.xml
+++ b/P5/Source/Specs/standOff.xml
@@ -15,10 +15,10 @@
   </content>
   <constraintSpec ident="nested_standOff_should_be_typed" scheme="schematron" xml:lang="en">
     <constraint>
-      <sch:rule context="tei:standOff">
-        <sch:assert test="@type or not(ancestor::tei:standOff)">This
-        <sch:name/> element must have a @type attribute, since it is
-        nested inside a <sch:name/></sch:assert>
+      <sch:rule context="tei:standOff//tei:standOff">
+        <sch:assert test="@type">This <sch:name/> element must have a
+        @type attribute, since it is nested inside a
+        <sch:name/>.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>


### PR DESCRIPTION
I am very sure this replacement is easier to read.
I am reasonably sure this replacement does exactly the same thing.
But I am not at all sure this constraint makes any sense in the first place. Can a `<standOff>` ever appear as a descendant of a `<standOff>`?
In my current tired state I think the answer is “no”, and that this entire constraint specification ("nested_standOff_should_be_typed") should be deleted.