### PR TITLE
remove extraneous never-used constraint

### DIFF
--- a/P5/Source/Specs/standOff.xml
+++ b/P5/Source/Specs/standOff.xml
@@ -13,15 +13,6 @@
   <content>
     <classRef key="model.standOffPart" minOccurs="1" maxOccurs="unbounded"/>
   </content>
-  <constraintSpec ident="nested_standOff_should_be_typed" scheme="schematron" xml:lang="en">
-    <constraint>
-      <sch:rule context="tei:standOff">
-        <sch:assert test="@type or not(ancestor::tei:standOff)">This
-        <sch:name/> element must have a @type attribute, since it is
-        nested inside a <sch:name/></sch:assert>
-      </sch:rule>
-    </constraint>
-  </constraintSpec>
   <exemplum versionDate="2019-12-25" xml:lang="en">
     <p>This example shows an encoding of morphosyntactic features similar to the encoding
     system used by <ref target="#ISO24611">ISO 24611 (MAF)</ref>.</p>


### PR DESCRIPTION
Per conversation on #2767, remove requirement for `@type` on a nested `<standOff>`, because there is no such thing as a nested `<standOff>`. 