### PR TITLE
avoid ambiguous content in `<post>`

### DIFF
--- a/P5/Source/Specs/post.xml
+++ b/P5/Source/Specs/post.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright TEI Consortium.
-Dual-licensed under CC-by and BSD2 licences
-See the file COPYING.txt for details.
--->
+<!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="post" mode="add" xml:id="gi-post" module="cmc">
   <desc versionDate="2022-08-09" xml:lang="en">a written (or spoken) contribution to a CMC interaction which has been composed (or recorded) by its author in its entirety before being transmitted over a network (e.g., the internet) and made available on the monitor or screen of the other parties en bloc.</desc>
@@ -32,7 +28,14 @@ See the file COPYING.txt for details.
       <classRef key="model.global"/>
       <elementRef key="lg"/>
       <classRef key="model.lLike"/>
-      <classRef key="model.divBottom"/>
+      <!-- These are the components of model.divBottom, but without
+	   <address>, which is already available via model.phrase: -->
+      <elementRef key="closer"/>
+      <elementRef key="postscript"/>
+      <elementRef key="signed"/>
+      <elementRef key="trailer"/>
+      <classRef key="model.divWrapper"/>
+      <!-- end of model.divBottom without <address> -->
     </alternate>
   </content>
   <attList>
@@ -61,15 +64,15 @@ See the file COPYING.txt for details.
         <dataRef key="teidata.pointer"/>
       </datatype>
       <remarks versionDate="2024-07-07" xml:lang="en">
-	<p>This attribute should be used to encode <q>technical</q>
-	reply information that is due to a formal reply action (such
-	as activating a <q>reply</q> button in the client software)
-	and that is formally represented in the source, e.g. in the
-	<q>references</q> field of a Usenet message header or in the
-	subject line of a forum post. It should not be used for
-	inferred or interpreted reply relations based only on
-	ambiguous signs such as linguistic discourse markers or
-	indentation.</p>
+        <p>This attribute should be used to encode <q>technical</q>
+        reply information that is due to a formal reply action (such
+        as activating a <q>reply</q> button in the client software)
+        and that is formally represented in the source, e.g. in the
+        <q>references</q> field of a Usenet message header or in the
+        subject line of a forum post. It should not be used for
+        inferred or interpreted reply relations based only on
+        ambiguous signs such as linguistic discourse markers or
+        indentation.</p>
         <!--See Lüngen/Herzberg (2019)-->
       </remarks>
     </attDef>
@@ -188,10 +191,10 @@ See the file COPYING.txt for details.
       <post when="1990-10-11" who="#dmerritt" xml:id="sgml-tei-3" replyTo="#sgml-tei-1">
         <time generatedBy="system">04:37:51 UTC</time>
         <p>
-	  <seg generatedBy="system">In article
-	  <ref target="#sgml-tei-1">&lt;2****.**********0@m*******.***.*****.**c.uk&gt;</ref> S.*.*.*****z@e**.*****.**c.uk (Sebastian Rahtz) writes:</seg>
+          <seg generatedBy="system">In article
+          <ref target="#sgml-tei-1">&lt;2****.**********0@m*******.***.*****.**c.uk&gt;</ref> S.*.*.*****z@e**.*****.**c.uk (Sebastian Rahtz) writes:</seg>
           <cit>
-	    <bibl>[for] Lou Burnard:</bibl>
+            <bibl>[for] Lou Burnard:</bibl>
             <quote>the Text Encoding Initiative document is a many-splendoured thing,
             redolent of the mysterious east, caribbean evenings and the scent of
             fresh pine in the himalayas [...]</quote>
@@ -201,8 +204,8 @@ See the file COPYING.txt for details.
         <p>But really, what is it?</p>  
         <signed generatedBy="human">Doug</signed>
         <signed generatedBy="template">
-	  Doug Merritt ****@e***.********y.edu (ucbvax!eris!doug) or uunet.uu.net!crossck!dougm
-	</signed>
+          Doug Merritt ****@e***.********y.edu (ucbvax!eris!doug) or uunet.uu.net!crossck!dougm
+        </signed>
       </post>
     </egXML>
   </exemplum>


### PR DESCRIPTION
The recently merged #2790 introduced an ambiguous content model problem for `<post>`, because its content refers to both model.phrase (of which `<address>` is a member) and to model.divBottom (of which `<address>` is newly a member) within the same `<alternate>`.

The obviously correct way to fix this (IMHO) is to use `<classRef key="model.divBottom except="address">`, but when I tried that the entire class was dropped. (Perhaps due to TEIC/Stylesheets#454?)

Thus this PR introduces a mildly ugly hack to get around this problem: the reference to model.divBottom has been changed to a list of references to the components of model.divBottom *except* for `<address>`. Ugly, but it works.

