### PR TITLE
improve messages emitted from Makefiles

### DIFF
--- a/P5/Exemplars/Makefile
+++ b/P5/Exemplars/Makefile
@@ -45,6 +45,16 @@ ANT=ANT_OPTS="-Xss2m -Xmx752m -Djava.awt.headless=true" ant -lib ../Utilities/li
 
 default: schemas
 
+# Note on construction of this file:
+#   For every target that does stuff the target starts by echoing a
+#   blank line and a notification line about which target is being
+#   run. The “$@” variable is used, which writes out the file name of
+#   the target. If the target name contains a ‘%’ (and thus gets run
+#   over multiple matching files) the message says “target file”
+#   instead of just “target”. Thus the user sees the actual file being
+#   worked on, and can figure out the target from that name.
+# —Syd, 2025-09-21 (copied from 2021-08-20 msg in P5/Test/Makefile.)
+
 schemas: $(NORMALODDS) $(ODDSJUSTRELAX) $(SPECIALODDS) $(ADDITIONALXSDS) $(ODDSJRNCID)
 	echo Done
 
@@ -52,6 +62,8 @@ docschemas: $(DOCODDS) $(DOCONLYODDS)
 	echo Done schemas which needed doc
 
 %.special: %.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	xmllint --xinclude $*.odd > $*.odd.xinclude
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=$* -Dtestfile2=$*.template -Dtestfile=$*.tei -DoddFile=$*.odd.xinclude validateodd compileodd rng validaterng validatesecondrng isoschematron validateschematron exampleschema cleanup
 	../run-onvdl $*.nvdl $*.odd.xinclude
@@ -59,16 +71,22 @@ docschemas: $(DOCODDS) $(DOCONLYODDS)
 	${TRANG} $*.rng $*.rnc
 
 %.rng: %.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	@echo debug: run lots of stuff via Test/antruntest, normal
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=$* -Dtestfile=$*.tei -DoddFile=$*.odd validateodd compileodd dtd rng validaterng  isoschematron validateschematron cleanup
 	${TRANG}  $*.rng $*.rnc
 
 tei_customization.rng: tei_customization.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target $@ ---------"
 	@echo debug: run lots of stuff via Test/antruntest, DTDcompat=false
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=tei_customization -Dtestfile=tei_customization.tei -DoddFile=tei_customization.odd -DDTDcompat=false validateodd compileodd dtd rng validaterng  isoschematron validateschematron cleanup
 	${TRANG} tei_customization.rng tei_customization.rnc
 
 %.dtd: %.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=$* -Dtestfile=$*.tei -DoddFile=$*.odd validateodd compileodd rng dtd exampleschema isoschematron validateschematron cleanup
 	../run-onvdl $*.nvdl $*.odd
 	${TRANG}  $*.rng $*.rnc
@@ -85,15 +103,21 @@ tei_customization.rng: tei_customization.odd
 	xmllint --noout --dtdvalid $*.dtd $*.tei
 
 %.doc.pdf: %.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=$* -Dtestfile=$*.tei -DoddFile=$*.odd validateodd compileodd docepub docpdf dochtml cleanup
 
 %.doc.epub: %.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=$* -Dlang=`echo $* | sed 's/.*_//'` -Dtestfile=$*.tei -DoddFile=$*.odd validateodd compileodd rng docepub docpdf dochtml exampleschema cleanup
 	../run-onvdl $*.nvdl $*.odd
 	-rm $*.doc.xml
 	-rm $*.rng
 
 %.xsd: %.rng
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	${TRANG}   -o disable-abstract-elements $*.rng $*.xsd
 	-test -f xml.xsd && mv xml.xsd $*_xml.xsd                && perl -p -i -e "s+teix.xsd+$*_teix.xsd+;s+ns1.xsd+$*_ns1.xsd+" $*_xml.xsd && perl -p -i -e "s+xml.xsd+$*_xml.xsd+" $*.xsd
 	-test -f teix.xsd && mv teix.xsd $*_teix.xsd && perl -p -i -e "s+xml.xsd+$*_xml.xsd+;s+ns1.xsd+$*_ns1.xsd+" $*_teix.xsd      && perl -p -i -e "s/teix.xsd/$*_teix.xsd/" $*.xsd
@@ -107,11 +131,15 @@ tei_customization.rng: tei_customization.odd
 tei_customization.odd: ../Utilities/TEI-to-tei_customization.xslt ../p5subset.xml
 #	Note that the "../p5subset.xml" in above line is the same as the definition
 #	of ${SOURCE}, but you can't use a variable as prerequisite (at least, it
-#	didn't work for me. :-)  Syd, 2017-11-05
+#	didn't work for me. :-)  — Syd, 2017-11-05
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target $@ ---------"
 	@echo generating tei_customization.odd from p5subset
 	$(SAXON) -s:${SOURCE} -xsl:../Utilities/TEI-to-tei_customization.xslt -o:tei_customization.odd
 
 dist: schemas docschemas
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target $@ ---------"
 	rm -rf tei[0-9]*.xml ../release/tei-p5-exemplars
 	rm -f *-teix*
 	rm -f *compiled* *.doc.tex
@@ -140,6 +168,8 @@ dist: schemas docschemas
 	cp ../catalog.p5.custom ../release/tei-p5-exemplars/share/xml/tei/custom/schema/catalog.xml
 
 clean:
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target $@ ---------"
 	mv tei_lite_fr.nvdl tei_lite_fr.nvdl.bak
 	rm -f *.processed *.xsd *.dtd *.doc.* *.rnc tei*.xsl tei*.rng *.compiled* *~ *.xi *.isosch *.epub *.pdf *.html *.nvdl *-teix*
 	mv tei_lite_fr.nvdl.bak tei_lite_fr.nvdl

--- a/P5/Makefile
+++ b/P5/Makefile
@@ -33,10 +33,13 @@ sinclude local.mk
 default: validate exemplars test html-web
 
 convert: schemas
+	@echo "--------- P5/Makefile target=$@"
 
 check: check.stamp  p5.xml
+	@echo "--------- P5/Makefile target=$@"
 
 check.stamp:
+	@echo "--------- P5/Makefile target=$@"
 	@echo Checking you have running XML tools and Perl before trying to run transform...
 	@echo -n Ant:
 	@command -v  ant || exit 1
@@ -49,8 +52,9 @@ check.stamp:
 	touch check.stamp
 
 p5.xml: ${DRIVER} Source/Specs/*.xml Source/Guidelines/en/*.xml p5odds.odd check.stamp
-	@echo get latest date:
-	@echo VCS is ${VCS}
+	@echo "--------- P5/Makefile target=$@"
+	@echo "Creating an XML file with the date last updated and commit number garnered from the VCS system (${VCS}),"
+	@echo "if available. (This XML file, repodate.xml, will be inserted into the <editionStmt> of the Guidelines)"
 	case ${VCS} in \
 	   svn) if [ ${INJENKINS} = "true" ] ; \
 	           then svn info --xml svn://svn.code.sf.net/p/tei/code/trunk/P5 ; \
@@ -69,11 +73,16 @@ p5.xml: ${DRIVER} Source/Specs/*.xml Source/Guidelines/en/*.xml p5odds.odd check
 	touch schemas.stamp
 
 schemas: schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
+
 schemas.stamp: p5.xml
+	@echo "--------- P5/Makefile target=$@"
 
 html-web: check.stamp p5.xml  html-web.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 html-web.stamp:  check.stamp p5.xml  Utilities/guidelines.xsl.model
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Making HTML Guidelines for language ${INPUTLANGUAGE}
 	@# remove vestiges of previous run
 	rm -rf Guidelines-web
@@ -101,6 +110,7 @@ html-web.stamp:  check.stamp p5.xml  Utilities/guidelines.xsl.model
 	touch html-web.stamp
 
 teiwebsiteguidelines:
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: make HTML version of Guidelines just for TEI web site
 	rm -rf teiwebsiteguidelines.zip
 	rm -f html-web.stamp
@@ -110,16 +120,19 @@ teiwebsiteguidelines:
 epub: Guidelines.epub
 
 Guidelines.epub: check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make epub version of Guidelines
 	${ANT} -f ${XSL}/epub3/build-to.xml -lib Utilities/lib/${SAXONJAR} -Dprofiledir=${XSL}/profiles -Dprofile=tei -DinputFile=`pwd`/p5.xml -DoutputFile=`pwd`/Guidelines.epub -Dcoverimage=`pwd`/Utilities/cover.jpg
 	java -jar Utilities/epubcheck3.jar Guidelines.epub
 	touch Guidelines.epub
 
 epub3: check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	${ANT}  -f ${XSL}/epub3/build-to.xml -lib Utilities/lib/${SAXONJAR} -Dprofiledir=${XSL}/profiles -Dprofile=tei -DinputFile=`pwd`/p5.xml -DoutputFile=`pwd`/Guidelines.epub -Dcoverimage=`pwd`/Utilities/cover.jpg
 	java -jar Utilities/epubcheck3.jar Guidelines.epub
 
 fonttest:
+	@echo "--------- P5/Makefile target=$@"
 	-xelatex --interaction=batchmode Utilities/fonttest
 	if [ -f "missfont.log" ]  ; then  \
 	  perl -p -i -e 's/(.*Minion)/%\1/;s/(.*Myriad)/%\1/' Utilities/guidelines.xsl ;\
@@ -130,6 +143,7 @@ fonttest:
 	rm -f fonttest.*
 
 pdf-init: check.stamp p5.xml Utilities/guidelines-latex.xsl
+	@echo "--------- P5/Makefile target=$@"
 	@echo check if XeLaTeX exist
 	@command -v xelatex || exit 1
 	java -jar Utilities/lib/${SAXONJAR} -s:Utilities/guidelines-latex.xsl -xsl:Utilities/guidelines_model_2_executable.xslt -o:Utilities/guidelines.xsl XSL="${XSL}"
@@ -138,11 +152,13 @@ pdf-init: check.stamp p5.xml Utilities/guidelines-latex.xsl
 	${ANT} -lib Utilities/lib/${SAXONJAR} -f antbuilder.xml -DXSL=${XSL} -DXELATEX=${XELATEX} pdfonce
 
 pdf: pdf-init
+	@echo "--------- P5/Makefile target=$@"
 	${ANT} -lib Utilities/lib/${SAXONJAR} -f antbuilder.xml -DXSL=${XSL} -DXELATEX=${XELATEX} pdfrest 2> pdfbuild.log 1> pdfbuild.log
 	grep -v "Failed to convert input string to UTF16" pdfbuild.log
 	for auxFile in Guidelines*aux; do perl -p -i -e 's/.*zf@fam.*//' $$auxFile; done
 
 rewraprnc:
+	@echo "--------- P5/Makefile target=$@"
 	for i in Guidelines-REF*tex; \
 	  do \
 	     perl Utilities/rewrapRNC-in-TeX.pl <$$i>$$i.new; \
@@ -152,6 +168,7 @@ rewraprnc:
 	done
 
 chapterpdfs: check
+	@echo "--------- P5/Makefile target=$@"
 	for i in `grep "\\include{" Guidelines.tex | sed 's/.*{\(.*\)}.*/\\1/'`; \
 	do echo PDF for chapter $$i; \
 	echo  $$i | ${XELATEX} Guidelines; \
@@ -161,9 +178,11 @@ chapterpdfs: check
 	done
 
 validate: schemas.stamp valid
+	@echo "--------- P5/Makefile target=$@"
 
 valid: jing_version=$(wordlist 1,3,$(shell jing))
 valid: check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Check validity with rnv \(https://github.com/dtolpin/RNV\) if we have it
 	-command -v  rnv && rnv -v p5odds.rnc p5.xml
 	@echo BUILD: Check validity with special-purpose XSL code, looking for bad links etc
@@ -176,14 +195,17 @@ valid: check.stamp p5.xml
 	./run-onvdl p5valid.nvdl v.xml
 
 test: schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD Run test cases for P5
 	(cd Test; make XSL=${XSL} VCS=${VCS})
 
 exemplars:  schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD TEI Exemplars
 	(cd Exemplars; make XSL=${XSL} PREFIX=${PREFIX} VCS=${VCS})
 
 dist-source.stamp: check.stamp p5.xml  schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for source
 	rm -rf release/tei-p5-source*
 	mkdir -p release/tei-p5-source/share/xml/tei/odd
@@ -231,6 +253,7 @@ dist-source.stamp: check.stamp p5.xml  schemas.stamp
 	rm p5subset*.json p5attlist.txt stripspace.xsl.model
 
 dist-schema.stamp:check.stamp p5.xml schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for schema
 	rm -rf release/tei-p5-schema*
 	mkdir -p release/tei-p5-schema/share/xml/tei/schema/dtd
@@ -243,6 +266,7 @@ dist-schema.stamp:check.stamp p5.xml schemas.stamp
 	touch dist-schema.stamp
 
 readus:
+	@echo "--------- P5/Makefile target=$@"
 	@echo Make just the README files for testing purposes only
 	@echo BUILD: Make distribution directory for doc
 	rm -rf release/tei-p5-doc*
@@ -255,6 +279,7 @@ readus:
 	done
 
 dist-doc.stamp:  check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for doc
 	rm -rf release/tei-p5-doc*
 	mkdir -p release/tei-p5-doc/share/doc/tei-p5-doc/en
@@ -275,6 +300,7 @@ dist-doc.stamp:  check.stamp p5.xml
 	touch dist-doc.stamp
 
 dist-test.stamp: check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for test
 	rm -rf release/tei-p5-test*
 	mkdir -p release/tei-p5-test/share/xml/tei
@@ -284,6 +310,7 @@ dist-test.stamp: check.stamp p5.xml
 	touch dist-test.stamp
 
 dist-exemplars.stamp: check.stamp p5.xml  schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for exemplars
 	(cd Exemplars; make XSL=${XSL} dist)
 	tar --exclude "*~" --exclude .svn -c -f - Exemplars \
@@ -291,6 +318,7 @@ dist-exemplars.stamp: check.stamp p5.xml  schemas.stamp
 	touch dist-exemplars.stamp
 
 dist-database.stamp: check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for database
 	rm -rf release/tei-p5-database*
 	mkdir -p release/tei-p5-database/share/xml/tei/xquery
@@ -299,18 +327,25 @@ dist-database.stamp: check.stamp p5.xml
 	touch dist-database.stamp
 
 dist-source: dist-source.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist-schema: dist-schema.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist-doc: dist-doc.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist-test: dist-test.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist-exemplars: dist-exemplars.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist-database: dist-database.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist: dist-source dist-schema dist-doc dist-test dist-exemplars dist-database
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make overall zip archive
 	rm -rf tei-*.zip release/xml release/doc
 	(cd release/tei-p5-database/share; tar cf - . | (cd ../../; tar xf - ))
@@ -330,6 +365,7 @@ dist: dist-source dist-schema dist-doc dist-test dist-exemplars dist-database
 	(cd release; zip -q -r tei-p5-test-${UPVERSION}.zip tei-p5-test )
 
 debversion:
+	@echo "--------- P5/Makefile target=$@"
 	sh ./mydch debian-tei-p5-database/debian/changelog
 	sh ./mydch debian-tei-p5-doc/debian/changelog
 	sh ./mydch debian-tei-p5-exemplars/debian/changelog
@@ -338,6 +374,7 @@ debversion:
 	sh ./mydch debian-tei-p5-test/debian/changelog
 
 deb: debversion
+	@echo "--------- P5/Makefile target=$@"
 	rm -f tei-p5-*_*deb
 	rm -f tei-p5-*_*changes
 	rm -f tei-p5-*_*build
@@ -355,32 +392,40 @@ deb: debversion
 	(cd debian-tei-p5-test; debclean;debuild -eXSL=${XSL} -eVCS=${VCS} -eINJENKINS=${INJENKINS} --no-lintian  -nc  -b  -i.svn -I.svn -uc -us)
 
 install-schema: dist-schema
+	@echo "--------- P5/Makefile target=$@"
 	@echo Making schema release in ${PREFIX}
 	(cd release/tei-p5-schema; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-doc: dist-doc
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make doc release in ${PREFIX}
 	(cd release/tei-p5-doc; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-source: dist-source
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Making source release in ${PREFIX}
 	(cd release/tei-p5-source; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-test: dist-test
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Making testfiles release in ${PREFIX}
 	(cd release/tei-p5-test; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-exemplars: dist-exemplars
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Making exemplars release in ${PREFIX}
 	(cd release/tei-p5-exemplars; tar cf - share) | (cd ${PREFIX}; tar xf -)
 
 install-database: dist-database
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Making database release in ${PREFIX}
 	(cd release/tei-p5-database; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install: clean install-schema install-doc install-test install-exemplars install-source install-database
+	@echo "--------- P5/Makefile target=$@"
 
 dependencies:
+	@echo "--------- P5/Makefile target=$@"
 	@echo to make this thing build under Ubuntu/Debian, here are all the packages you will need:
 	@echo	msttcorefonts
 	@echo	rnv
@@ -389,7 +434,9 @@ dependencies:
 	@echo	zip
 	@echo   ttf-linux-libertine
 	@echo 	fonts-noto-cjk
+
 clean:
+	@echo "--------- P5/Makefile target=$@"
 	(cd Exemplars; make clean)
 	(cd Test; make clean)
 	rm -f repodate.xml

--- a/P5/Makefile
+++ b/P5/Makefile
@@ -32,14 +32,27 @@ sinclude local.mk
 
 default: validate exemplars test html-web
 
+# Note on construction of this file:
+#   For every target that does stuff the target starts by echoing a
+#   blank line and a notification line about which target is being
+#   run. The “$@” variable is used, which writes out the file name of
+#   the target. If the target name contains a ‘%’ (and thus gets run
+#   over multiple matching files) the message says “target file”
+#   instead of just “target”. Thus the user sees the actual file being
+#   worked on, and can figure out the target from that name.
+# —Syd, 2025-09-21 (copied from 2021-08-20 msg in P5/Test/Makefile.)
+
 convert: schemas
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 check: check.stamp  p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 check.stamp:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo Checking you have running XML tools and Perl before trying to run transform...
 	@echo -n Ant:
 	@command -v  ant || exit 1
@@ -52,7 +65,8 @@ check.stamp:
 	touch check.stamp
 
 p5.xml: ${DRIVER} Source/Specs/*.xml Source/Guidelines/en/*.xml p5odds.odd check.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo "Creating an XML file with the date last updated and commit number garnered from the VCS system (${VCS}),"
 	@echo "if available. (This XML file, repodate.xml, will be inserted into the <editionStmt> of the Guidelines)"
 	case ${VCS} in \
@@ -73,16 +87,20 @@ p5.xml: ${DRIVER} Source/Specs/*.xml Source/Guidelines/en/*.xml p5odds.odd check
 	touch schemas.stamp
 
 schemas: schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 schemas.stamp: p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 html-web: check.stamp p5.xml  html-web.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 html-web.stamp:  check.stamp p5.xml  Utilities/guidelines.xsl.model
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Making HTML Guidelines for language ${INPUTLANGUAGE}
 	@# remove vestiges of previous run
 	rm -rf Guidelines-web
@@ -110,7 +128,8 @@ html-web.stamp:  check.stamp p5.xml  Utilities/guidelines.xsl.model
 	touch html-web.stamp
 
 teiwebsiteguidelines:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: make HTML version of Guidelines just for TEI web site
 	rm -rf teiwebsiteguidelines.zip
 	rm -f html-web.stamp
@@ -120,19 +139,22 @@ teiwebsiteguidelines:
 epub: Guidelines.epub
 
 Guidelines.epub: check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make epub version of Guidelines
 	${ANT} -f ${XSL}/epub3/build-to.xml -lib Utilities/lib/${SAXONJAR} -Dprofiledir=${XSL}/profiles -Dprofile=tei -DinputFile=`pwd`/p5.xml -DoutputFile=`pwd`/Guidelines.epub -Dcoverimage=`pwd`/Utilities/cover.jpg
 	java -jar Utilities/epubcheck3.jar Guidelines.epub
 	touch Guidelines.epub
 
 epub3: check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	${ANT}  -f ${XSL}/epub3/build-to.xml -lib Utilities/lib/${SAXONJAR} -Dprofiledir=${XSL}/profiles -Dprofile=tei -DinputFile=`pwd`/p5.xml -DoutputFile=`pwd`/Guidelines.epub -Dcoverimage=`pwd`/Utilities/cover.jpg
 	java -jar Utilities/epubcheck3.jar Guidelines.epub
 
 fonttest:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	-xelatex --interaction=batchmode Utilities/fonttest
 	if [ -f "missfont.log" ]  ; then  \
 	  perl -p -i -e 's/(.*Minion)/%\1/;s/(.*Myriad)/%\1/' Utilities/guidelines.xsl ;\
@@ -143,7 +165,8 @@ fonttest:
 	rm -f fonttest.*
 
 pdf-init: check.stamp p5.xml Utilities/guidelines-latex.xsl
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo check if XeLaTeX exist
 	@command -v xelatex || exit 1
 	java -jar Utilities/lib/${SAXONJAR} -s:Utilities/guidelines-latex.xsl -xsl:Utilities/guidelines_model_2_executable.xslt -o:Utilities/guidelines.xsl XSL="${XSL}"
@@ -152,13 +175,15 @@ pdf-init: check.stamp p5.xml Utilities/guidelines-latex.xsl
 	${ANT} -lib Utilities/lib/${SAXONJAR} -f antbuilder.xml -DXSL=${XSL} -DXELATEX=${XELATEX} pdfonce
 
 pdf: pdf-init
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	${ANT} -lib Utilities/lib/${SAXONJAR} -f antbuilder.xml -DXSL=${XSL} -DXELATEX=${XELATEX} pdfrest 2> pdfbuild.log 1> pdfbuild.log
 	grep -v "Failed to convert input string to UTF16" pdfbuild.log
 	for auxFile in Guidelines*aux; do perl -p -i -e 's/.*zf@fam.*//' $$auxFile; done
 
 rewraprnc:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	for i in Guidelines-REF*tex; \
 	  do \
 	     perl Utilities/rewrapRNC-in-TeX.pl <$$i>$$i.new; \
@@ -168,7 +193,8 @@ rewraprnc:
 	done
 
 chapterpdfs: check
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	for i in `grep "\\include{" Guidelines.tex | sed 's/.*{\(.*\)}.*/\\1/'`; \
 	do echo PDF for chapter $$i; \
 	echo  $$i | ${XELATEX} Guidelines; \
@@ -178,11 +204,13 @@ chapterpdfs: check
 	done
 
 validate: schemas.stamp valid
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 valid: jing_version=$(wordlist 1,3,$(shell jing))
 valid: check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Check validity with rnv \(https://github.com/dtolpin/RNV\) if we have it
 	-command -v  rnv && rnv -v p5odds.rnc p5.xml
 	@echo BUILD: Check validity with special-purpose XSL code, looking for bad links etc
@@ -195,17 +223,20 @@ valid: check.stamp p5.xml
 	./run-onvdl p5valid.nvdl v.xml
 
 test: schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD Run test cases for P5
 	(cd Test; make XSL=${XSL} VCS=${VCS})
 
 exemplars:  schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD TEI Exemplars
 	(cd Exemplars; make XSL=${XSL} PREFIX=${PREFIX} VCS=${VCS})
 
 dist-source.stamp: check.stamp p5.xml  schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for source
 	rm -rf release/tei-p5-source*
 	mkdir -p release/tei-p5-source/share/xml/tei/odd
@@ -253,7 +284,8 @@ dist-source.stamp: check.stamp p5.xml  schemas.stamp
 	rm p5subset*.json p5attlist.txt stripspace.xsl.model
 
 dist-schema.stamp:check.stamp p5.xml schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for schema
 	rm -rf release/tei-p5-schema*
 	mkdir -p release/tei-p5-schema/share/xml/tei/schema/dtd
@@ -266,7 +298,8 @@ dist-schema.stamp:check.stamp p5.xml schemas.stamp
 	touch dist-schema.stamp
 
 readus:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo Make just the README files for testing purposes only
 	@echo BUILD: Make distribution directory for doc
 	rm -rf release/tei-p5-doc*
@@ -279,7 +312,8 @@ readus:
 	done
 
 dist-doc.stamp:  check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for doc
 	rm -rf release/tei-p5-doc*
 	mkdir -p release/tei-p5-doc/share/doc/tei-p5-doc/en
@@ -300,7 +334,8 @@ dist-doc.stamp:  check.stamp p5.xml
 	touch dist-doc.stamp
 
 dist-test.stamp: check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for test
 	rm -rf release/tei-p5-test*
 	mkdir -p release/tei-p5-test/share/xml/tei
@@ -310,7 +345,8 @@ dist-test.stamp: check.stamp p5.xml
 	touch dist-test.stamp
 
 dist-exemplars.stamp: check.stamp p5.xml  schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for exemplars
 	(cd Exemplars; make XSL=${XSL} dist)
 	tar --exclude "*~" --exclude .svn -c -f - Exemplars \
@@ -318,7 +354,8 @@ dist-exemplars.stamp: check.stamp p5.xml  schemas.stamp
 	touch dist-exemplars.stamp
 
 dist-database.stamp: check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for database
 	rm -rf release/tei-p5-database*
 	mkdir -p release/tei-p5-database/share/xml/tei/xquery
@@ -327,25 +364,32 @@ dist-database.stamp: check.stamp p5.xml
 	touch dist-database.stamp
 
 dist-source: dist-source.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist-schema: dist-schema.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist-doc: dist-doc.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist-test: dist-test.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist-exemplars: dist-exemplars.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist-database: dist-database.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist: dist-source dist-schema dist-doc dist-test dist-exemplars dist-database
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make overall zip archive
 	rm -rf tei-*.zip release/xml release/doc
 	(cd release/tei-p5-database/share; tar cf - . | (cd ../../; tar xf - ))
@@ -365,7 +409,8 @@ dist: dist-source dist-schema dist-doc dist-test dist-exemplars dist-database
 	(cd release; zip -q -r tei-p5-test-${UPVERSION}.zip tei-p5-test )
 
 debversion:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	sh ./mydch debian-tei-p5-database/debian/changelog
 	sh ./mydch debian-tei-p5-doc/debian/changelog
 	sh ./mydch debian-tei-p5-exemplars/debian/changelog
@@ -374,7 +419,8 @@ debversion:
 	sh ./mydch debian-tei-p5-test/debian/changelog
 
 deb: debversion
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	rm -f tei-p5-*_*deb
 	rm -f tei-p5-*_*changes
 	rm -f tei-p5-*_*build
@@ -392,40 +438,48 @@ deb: debversion
 	(cd debian-tei-p5-test; debclean;debuild -eXSL=${XSL} -eVCS=${VCS} -eINJENKINS=${INJENKINS} --no-lintian  -nc  -b  -i.svn -I.svn -uc -us)
 
 install-schema: dist-schema
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo Making schema release in ${PREFIX}
 	(cd release/tei-p5-schema; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-doc: dist-doc
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make doc release in ${PREFIX}
 	(cd release/tei-p5-doc; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-source: dist-source
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Making source release in ${PREFIX}
 	(cd release/tei-p5-source; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-test: dist-test
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Making testfiles release in ${PREFIX}
 	(cd release/tei-p5-test; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-exemplars: dist-exemplars
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Making exemplars release in ${PREFIX}
 	(cd release/tei-p5-exemplars; tar cf - share) | (cd ${PREFIX}; tar xf -)
 
 install-database: dist-database
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Making database release in ${PREFIX}
 	(cd release/tei-p5-database; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install: clean install-schema install-doc install-test install-exemplars install-source install-database
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dependencies:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo to make this thing build under Ubuntu/Debian, here are all the packages you will need:
 	@echo	msttcorefonts
 	@echo	rnv
@@ -436,7 +490,8 @@ dependencies:
 	@echo 	fonts-noto-cjk
 
 clean:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	(cd Exemplars; make clean)
 	(cd Test; make clean)
 	rm -f repodate.xml

--- a/P5/Test/Makefile
+++ b/P5/Test/Makefile
@@ -41,7 +41,7 @@ checkrnv:
 
 testall.examples: testall.xsd
 	@echo " "
-	@echo "--------- work on target $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target $@ ---------"
 	$(SAXON) -o:testall-ex.odd -s:testall.odd -xsl:../Utilities/odd2exodd.xsl
 	$(ANT) -f antruntest.xml -Doutputname=testall-examples -DoddFile=testall-ex.odd compileodd rng cleanup
 	@echo check egXML in testall.odd
@@ -50,14 +50,14 @@ testall.examples: testall.xsd
 
 %.dtd: %.odd
 	@echo " "
-	@echo "--------- work on target file $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target file $@ ---------"
 	$(ANT) -f antruntest.xml -Doutputname=$* -Dtestfile=$*.xml -DoddFile=$*.odd validateodd compileodd dtd rng validaterng cleanup
 	@echo Check file using DOCTYPE in instance
 	xmllint --noout --valid $*.xml
 
 %.xsd: %.odd
 	@echo " "
-	@echo "--------- work on target file $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target file $@ ---------"
 	$(ANT) -f antruntest.xml -Doutputname=$* -Dtestfile=$*.xml -DoddFile=$*.odd validateodd compileodd rng validaterng  isoschematron validateschematron cleanup
 	${TRANG}   -o disable-abstract-elements $*.rng $*.xsd
 	-test -f xml.xsd && cp xml.xsd $*_xml.xsd    && perl -p -i -e "s+xml.xsd+$*_xml.xsd+;s+ns1.xsd+$*_ns1.xsd+;s+teix.xsd+$*_teix.xsd+" $*.xsd
@@ -69,7 +69,7 @@ testall.examples: testall.xsd
 
 %.special: %.odd checkrnv
 	@echo " "
-	@echo "--------- work on target file $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target file $@ ---------"
 	@echo "BUILD:  Test schema from (special) $<"
 	xmllint --xinclude $< > xi_$<
 	$(ANT) -f antruntest.xml -Dtestfile=$*.xml -DoddFile=xi_$*.odd -Doutputname=$* validateodd compileodd rng validaterng cleanup
@@ -79,7 +79,7 @@ testall.examples: testall.xsd
 
 testmeta2010:
 	@echo " "
-	@echo "--------- work on target $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target $@ ---------"
 	@echo check that TEI web site is up and responding ...
 	-TEISITE=`curl -s --head http://www.tei-c.org/Vault/P5/1.5.0/xml/tei/odd/p5subset.xml`
 ifdef TEISITE
@@ -97,14 +97,14 @@ endif
 
 test-frag: checkrnv
 	@echo " "
-	@echo "--------- work on target $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target $@ ---------"
 	@echo BUILD: Testing files which exercise inclusion of fragments
 	${JING} -t -c frag.rnc testfrag.xml
 	rnv frag.rnc testfrag.xml
 
 detest: checkrnv
 	@echo " "
-	@echo "--------- work on target $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target $@ ---------"
 	@echo BUILD: Test file with deliberate mistakes
 	@echo "--- run ant to validate ODD file (./detest.odd) against p5odds.rng & p5odds.isosch:"
 	$(ANT) -f antruntest.xml -Doutputname=detest -DoddFile=detest.odd validateodd > detest_odd_schematron.log 2>&1


### PR DESCRIPTION
Back in 2021 I added little “I am running this target” messages to P5/Test/Makefile. I think it has made debugging a lot easier, and has not caused any problems (that I am aware of). So I did the same thing with P5/Exemplars/Makefile and P5/Makefile itself.
I did not do this to Source/Guidelines/en/Images/Makefile both because it only has 3 non-interdependent targets and (mostly) because I forgot it existed.