### PR TITLE
Remove rend attribute from list in French example in item spec page for #2736

### DIFF
--- a/P5/Source/Specs/item.xml
+++ b/P5/Source/Specs/item.xml
@@ -35,7 +35,7 @@
   </exemplum>
   <exemplum versionDate="2008-04-06" xml:lang="fr">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-item-egXML-fz" source="#fr-ex-Perec-vie">
-      <list rend="bulleted">
+      <list>
         <head>Tentative d'inventaire de quelques-unes des choses qui ont été trouvées dans
               les escaliers au fil des ans.</head>
         <item>Plusieurs photos, dont celle d'une jeune fille de quinze<lb/> ans vêtue d'un slip


### PR DESCRIPTION
As discussed by @ebeshero, @sydb, and myself at Stylesheets meeting 2025-03-23. This PR removes the `@rend` attribute from the French example listed in the `<item>` spec page as outlined in issue #2736. This PR also clears the path for approving and merging Stylesheets PR [745](https://github.com/TEIC/Stylesheets/pull/745).