### PR TITLE
Allowing optional third coordinate to `teidata.point` for #2816

### DIFF
--- a/P5/Source/Specs/teidata.point.xml
+++ b/P5/Source/Specs/teidata.point.xml
@@ -5,7 +5,7 @@
   <desc versionDate="2010-10-17" xml:lang="en">defines the data type used to express a point in cartesian space.</desc>
   <desc versionDate="2024-08-08" xml:lang="ja">デカルト空間内の点を表現するデータ型を定義する。</desc>
   <content>
-    <dataRef name="token" restriction="(-?[0-9]+(\.[0-9]+)?,-?[0-9]+(\.[0-9]+)?)"/>
+    <dataRef name="token" restriction="(-?[0-9]+(\.[0-9]+)?,-?[0-9]+(\.[0-9]+)?(,-?[0-9]+(\.[0-9]+)?)?)"/>
   </content>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="data-point-egXML-qa" source="#UND">


### PR DESCRIPTION
This PR addresses #2816 which requested allowing an optional third coordinate to `teidata.point`. I've tested the changes locally and it passes tests and I would welcome more eyes on this to check that all is well. 

It would also be helpful to include a good example of 3d encoding as well in this PR and Jun Ogawa will hopefully be able to supply us with one. 