### PR TITLE
For issue #2860: make entryFree nestable, and also allow it as a chil…

### DIFF
--- a/P5/Source/Specs/entryFree.xml
+++ b/P5/Source/Specs/entryFree.xml
@@ -24,6 +24,8 @@
     <memberOf key="att.lexicographic"/>
     <memberOf key="att.sortable"/>
     <memberOf key="model.entryLike"/>
+    <memberOf key="model.entryPart"/>
+    <memberOf key="model.entryPart.top"/>
   </classes>
   <content>
     


### PR DESCRIPTION
…d of entry.

I've done this by adding it to both model.entryPart and model.entryPart.top. The rationale for making it available inside `<entry>` is this:

It's not unusual for a born-digital dictionary to be constructed around a historical print dictionary, as a sort of hybrid, where the transcription/encoding of the original source entries is accompanied by a more structured version of the data. With `<entryFree>` available in `<entry>`, the structured born-digital version of the data can also host a transcription of the source entry from which it was derived. I think this would be very useful, and I don't see any downsides.