### PR TITLE
remodeling spGrp to self-nest for #2695

### DIFF
--- a/P5/Source/Guidelines/en/BIB-Bibliography.xml
+++ b/P5/Source/Guidelines/en/BIB-Bibliography.xml
@@ -764,8 +764,11 @@
       <!--L-->
 
       <bibl xml:id="RphCnd"><author>Lacy, M. Rophino</author>, <title level="m">Cinderella, 
-          Or the Fairy-Queen and the Glass Slipper: A Comic Opera, In Three Acts</title>. <pubPlace>London</pubPlace>: 
-          <publisher>Thomas Halles Lacy</publisher>, <date>1830</date>.</bibl>
+          Or the Fairy-Queen and the Glass Slipper: A Comic Opera, In Three Acts</title>.
+        <title level="s">Lacy's Acting Edition</title>, <biblScope unit="volume">volume 18</biblScope>:
+        <biblScope unit="number">No. 0262</biblScope>, <pubPlace>London</pubPlace>: 
+          <publisher>Thomas Hailes Lacy</publisher>, <biblScope unit="page">pp. 209–268</biblScope>. 
+        <date notBefore="1849">undated</date>.</bibl>
       <bibl xml:id="fr-ex-Lafayette-Cleves" xml:lang="fr"><author>La Fayette, Marie-Madeleine Pioche
           de La Vergne, comtesse de</author>, <title>La Princesse de Clèves</title>,
           <date>1678</date>.</bibl>

--- a/P5/Source/Guidelines/en/BIB-Bibliography.xml
+++ b/P5/Source/Guidelines/en/BIB-Bibliography.xml
@@ -1227,9 +1227,13 @@
       <bibl xml:id="biblzh-tw_n35-36" xml:lang="zh-TW">莎士比亞，《馬克白》。</bibl>
       <bibl xml:id="SAWS"><title level="m">Sharing Ancient Wisdoms</title>, <date>2013</date>,
         available: <ptr target="http://www.ancientwisdoms.ac.uk/"/>.</bibl>
-      <bibl xml:id="DR-eg-08"><author>Shaw, George Bernard</author>. <title level="m">Heartbreak
-          House: a fantasia in the Russian manner on English themes</title> (<date>1919</date>). </bibl>
-      <bibl xml:id="DRSP-eg-35"><author>Shaw, George Bernard</author>. <title level="m">Pygmalion</title>, <date>1913</date>.</bibl>
+      <bibl xml:id="DR-eg-08"><author>Shaw, George Bernard</author>. <title level="a">Heartbreak
+          House: a fantasia in the Russian manner on English themes</title>, 
+        <title level="m">Heartbreak House, Great Catherine, and playlets of the war</title>. 
+        <pubPlace>London</pubPlace>: <publisher>Constable &amp; co.</publisher>, <date>1919</date>.</bibl>
+      <bibl xml:id="DRSP-eg-35"><author>Shaw, George Bernard</author>. <title level="a">Pygmalion</title>, 
+        <title level="m">Androcles and the Lion; Overruled; Pygmalion</title>.
+        <pubPlace>London</pubPlace>: <publisher>Constable &amp; co.</publisher>,  <date>1916</date>.</bibl>
       <bibl xml:id="SASE-eg-32"><author>Shields, David</author>. <title level="m">Dead
           Languages</title>, <publisher>HarperCollins Canada</publisher>/<publisher>Perennial
           Rack</publisher>, rpt. <date>1990</date>, <biblScope unit="pp">p.10</biblScope>.</bibl>

--- a/P5/Source/Guidelines/en/BIB-Bibliography.xml
+++ b/P5/Source/Guidelines/en/BIB-Bibliography.xml
@@ -763,6 +763,9 @@
 
       <!--L-->
 
+      <bibl xml:id="RphCnd"><author>Lacy, M. Rophino</author>, <title level="m">Cinderella, 
+          Or the Fairy-Queen and the Glass Slipper: A Comic Opera, In Three Acts</title>. <pubPlace>London</pubPlace>: 
+          <publisher>Thomas Halles Lacy</publisher>, <date>1830</date>.</bibl>
       <bibl xml:id="fr-ex-Lafayette-Cleves" xml:lang="fr"><author>La Fayette, Marie-Madeleine Pioche
           de La Vergne, comtesse de</author>, <title>La Princesse de Clèves</title>,
           <date>1678</date>.</bibl>

--- a/P5/Source/Guidelines/en/DR-PerformanceTexts.xml
+++ b/P5/Source/Guidelines/en/DR-PerformanceTexts.xml
@@ -655,8 +655,8 @@ disguise, as in the following examples:
    <castItem><role xml:id="hh">Henry Higgins</role></castItem>
 </castList>
 <sp who="#hh">
-   <speaker>The Notetaker</speaker>
-   <p> ... </p>
+   <speaker>The Note Taker</speaker>
+   <p>Live where you like; but stop that noise.</p>
 </sp></egXML>
 <!-- GB Shaw, Pygmalion --></p>
 <p>If the speaker attributions are completely regular (and may thus be
@@ -744,6 +744,72 @@ Levant</head>
 </spGrp>
 </egXML></p>
 </div>
+  <div type="div3" xml:id="DRSIM"><head>Simultaneous Action</head>
+    <p>In printed or written versions of performance texts, a variety of
+      techniques may be used to indicate the temporal alignment of speeches or
+      actions.  Speeches may be printed vertically aligned on the page, or
+      braced together; stage directions (e.g. <q>Speaking at the same
+        time</q>) are also often used.  In operatic or musical works in
+      particular, the need to indicate timing and alignment of individual
+      parts of a song may lead to very complex layout.</p>
+    <p>One simple method of indicating the temporal alignment of speeches or
+      actions is to use the <gi>spGrp</gi> element discussed in
+      section <ptr target="#DRSPG"/>, with a <att>type</att> attribute to specify the 
+      reason for grouping, as in the following example:
+      <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="DRSIM-egXML-sj" source="#DR-eg-08"><sp> <speaker>Mangan</speaker>
+          <stage type="delivery">wildly</stage>
+          <p>Look here: I'm going to take off all my clothes.</p>
+          <stage type="action">he begins tearing off his coat.</stage>
+      </sp>
+        <spGrp org="parallel" rend="braced">
+          <sp> <speaker>Lady Utterword</speaker>
+            <p>Mr Mangan!</p>
+          </sp>
+          <sp> <speaker>Captain Shotover</speaker>
+            <p>Whats that?</p>
+          </sp>
+          <sp> <speaker>Hector</speaker>
+            <p>Ha! ha! Do. Do.</p>
+          </sp>
+          <sp> <speaker>Ellie</speaker>
+            <p>Please dont.</p>
+          </sp>
+          <stage type="delivery">in consternation</stage>
+        </spGrp>
+        <sp> <speaker>Mrs. Hushabye</speaker>
+          <stage type="action">catching his arm and stopping him</stage>
+          <p>Alfred: for shame! Are you mad?</p>
+        </sp></egXML></p>
+    <!-- martindholmes says: I believe there is a typo above: "dont"
+       should be "don't". However, I don't have access to a 1916
+       edition to confirm this. No edition I can find has "dont". -->
+    <!-- I think the correct date should be 1919. The lack of apostrophes
+is one of Shaw's quirks, represented faithfully in the standard
+Constable edition of 1931, and in reprints of that such as the Penguin
+Classics 2000 edition available at Google Books (LB) 
+EBB: Confirmed on checking 1919 Constable edition of Heartbreak House. Updating BIB accordingly. -->
+    
+    <p>In the original, the stage direction <q>in consternation</q> is
+      printed opposite a brace grouping all four speeches, indicating that all
+      four characters speak at once, and that the stage direction applies to
+      all of them. Rather than attempting to represent the appearance of the
+      source, this example encoding represents its presumed meaning: the
+      <gi>stage</gi> element is placed arbitrarily after the last relevant
+      speech,  and the four speeches with which it is to be associated are 
+      grouped by means of the <gi>spGrp</gi> element. The <att>rend</att> 
+      attribute is used to specify the fact that the three speeches were 
+      grouped by the brace in the copy text. Producing a readable version 
+      of the text which simulates the original printed effect may however
+      require more complex markup and processing.
+    </p>
+    <p>More powerful and more precise mechanisms for temporal alignment are
+      defined in chapter <ptr target="#TS"/>.  These would be appropriate for
+      encodings the focus of which is on the actual performance of a text
+      rather than its structure or formal properties.  The module described
+      in that chapter includes a large number of other detailed proposals for
+      the encoding of such features as voice quality, prosody, etc., which
+      might be relevant to such a treatment of performance texts.
+    </p></div>
 <div type="div3" xml:id="DRSTA"><head>Stage Directions</head>
 <p>Both between and within the speeches of a written performance text,
 it is normal practice to include a wide variety of descriptive
@@ -1196,72 +1262,7 @@ have it close to the fragments it unifies.</p>
 <p>Like the <att>next</att> and <att>prev</att> attributes, the
 <gi>join</gi> element requires the additional module for linking, which
 is selected as shown above.</p></div>
-<div type="div3" xml:id="DRSIM"><head>Simultaneous Action</head>
-<p>In printed or written versions of performance texts, a variety of
-techniques may be used to indicate the temporal alignment of speeches or
-actions.  Speeches may be printed vertically aligned on the page, or
-braced together; stage directions (e.g. <q>Speaking at the same
-time</q>) are also often used.  In operatic or musical works in
-particular, the need to indicate timing and alignment of individual
-parts of a song may lead to very complex layout.</p>
-<p>One simple method of indicating the temporal alignment of speeches or
-actions is to use the <gi>spGrp</gi> element discussed in
-section <ptr target="#DRSPG"/>, with a <att>type</att> attribute to specify the 
-reason for grouping, as in the following example:
-<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="DRSIM-egXML-sj" source="#DR-eg-08"><sp> <speaker>Mangan</speaker>
-  <stage type="delivery">wildly</stage>
-  <p>Look here: I'm going to take off all my clothes.</p>
-  <stage type="action">he begins tearing off his coat.</stage>
-</sp>
-  <spGrp type="simultaneous" rend="braced">
-<sp> <speaker>Lady Utterword</speaker>
-  <p>Mr Mangan!</p>
-</sp>
-<sp> <speaker>Captain Shotover</speaker>
-  <p>Whats that?</p>
-</sp>
-<sp> <speaker>Hector</speaker>
-  <p>Ha! ha! Do. Do.</p>
-</sp>
-<sp> <speaker>Ellie</speaker>
-  <p>Please dont.</p>
-</sp>
-<stage type="delivery">in consternation</stage>
-</spGrp>
-<sp> <speaker>Mrs. Hushabye</speaker>
-  <stage type="action">catching his arm and stopping him</stage>
-  <p>Alfred: for shame! Are you mad?</p>
-</sp></egXML></p>
-  <!-- martindholmes says: I believe there is a typo above: "dont"
-       should be "don't". However, I don't have access to a 1916
-       edition to confirm this. No edition I can find has "dont". -->
-
-<!-- I think the correct date should be 1919. The lack of apostrophes
-is one of Shaw's quirks, represented faithfully in the standard
-Constable edition of 1931, and in reprints of that such as the Penguin
-Classics 2000 edition available at Google Books (LB) -->
-
-<p>In the original, the stage direction <q>in consternation</q> is
-printed opposite a brace grouping all four speeches, indicating that all
-four characters speak at once, and that the stage direction applies to
-all of them. Rather than attempting to represent the appearance of the
-source, this example encoding represents its presumed meaning: the
-<gi>stage</gi> element is placed arbitrarily after the last relevant
-speech,  and the four speeches with which it is to be associated are 
-grouped by means of the <gi>spGrp</gi> element. The <att>rend</att> 
-attribute is used to specify the fact that the three speeches were 
-grouped by the brace in the copy text. Producing a readable version 
-of the text which simulates the original printed effect may however
-require more complex markup and processing.
-</p>
-<p>More powerful and more precise mechanisms for temporal alignment are
-defined in chapter <ptr target="#TS"/>.  These would be appropriate for
-encodings the focus of which is on the actual performance of a text
-rather than its structure or formal properties.  The module described
-in that chapter includes a large number of other detailed proposals for
-the encoding of such features as voice quality, prosody, etc., which
-might be relevant to such a treatment of performance texts.
-</p></div></div>
+</div>
 <div type="div2" xml:id="DROTH"><head>Other Types of Performance Text</head>
 <p>Most of the elements and structures identified thus far are derived
 from traditional theatrical texts.  Although other performance texts,

--- a/P5/Source/Guidelines/en/DR-PerformanceTexts.xml
+++ b/P5/Source/Guidelines/en/DR-PerformanceTexts.xml
@@ -804,7 +804,7 @@ EBB: Confirmed on checking 1919 Constable edition of Heartbreak House. Updating 
     </p>
     <p>More powerful and more precise mechanisms for temporal alignment are
       defined in chapter <ptr target="#TS"/>.  These would be appropriate for
-      encodings the focus of which is on the actual performance of a text
+      encodings which focus on the actual performance of a text
       rather than its structure or formal properties.  The module described
       in that chapter includes a large number of other detailed proposals for
       the encoding of such features as voice quality, prosody, etc., which

--- a/P5/Source/Specs/att.divLike.xml
+++ b/P5/Source/Specs/att.divLike.xml
@@ -63,9 +63,6 @@ les composants de cet élément sont à considérer comme formant une unité
 logique et doivent être traités dans l'ordre séquentiel</desc>
           <desc versionDate="2007-01-21" xml:lang="it">contenuto uniforme: i contenuti dell'elemento costituiscono un'unità logica che va elaborata in sequenza</desc>
         </valItem>
-        <valItem ident="unison">
-          <desc versionDate="2026-01-19" xml:lang="en">the contents of this element are intended to indicate agreement or harmony with each other.</desc>
-        </valItem>
       </valList>
     </attDef>
     <attDef ident="sample" usage="opt">

--- a/P5/Source/Specs/att.divLike.xml
+++ b/P5/Source/Specs/att.divLike.xml
@@ -47,6 +47,9 @@ composants de cette division doivent être traités ou bien quant à leurs
 corrélations</desc>
           <desc versionDate="2007-01-21" xml:lang="it">non viene specificato quale sia l'ordine in cui debbano essere elaborati i contenuti della partizione, né viene indicato il rapporto in cui questi si trovano tra loro</desc>
         </valItem>
+        <valItem ident="parallel">
+          <desc versionDate="2026-01-19" xml:lang="en">the contents of this element are intended to represent simultaneous or side-by-side delivery.</desc>
+        </valItem>
         <valItem ident="uniform">
           <desc versionDate="2013-03-18" xml:lang="en">the immediate contents of this
 		  element are regarded as forming a logical unit, to be
@@ -59,6 +62,9 @@ corrélations</desc>
 les composants de cet élément sont à considérer comme formant une unité
 logique et doivent être traités dans l'ordre séquentiel</desc>
           <desc versionDate="2007-01-21" xml:lang="it">contenuto uniforme: i contenuti dell'elemento costituiscono un'unità logica che va elaborata in sequenza</desc>
+        </valItem>
+        <valItem ident="unison">
+          <desc versionDate="2026-01-19" xml:lang="en">the contents of this element are intended to indicate agreement or harmony with each other.</desc>
         </valItem>
       </valList>
     </attDef>

--- a/P5/Source/Specs/spGrp.xml
+++ b/P5/Source/Specs/spGrp.xml
@@ -3,29 +3,86 @@
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="drama" xml:id="gi-spGrp" ident="spGrp">
   <gloss versionDate="2011-11-19" xml:lang="en">speech group</gloss>
-  <desc versionDate="2012-12-27" xml:lang="en">contains a group of speeches or songs in a performance text presented
+  <desc versionDate="2026-01-19" xml:lang="en">contains a group of speeches, speech groups, or songs in a performance text presented
   in a source as constituting a single unit or
   <soCalled>number</soCalled>.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.ascribed.directed"/>
+    <memberOf key="att.divLike"/>
     <memberOf key="att.typed"/>
     <memberOf key="model.divPart"/>
   </classes>
   <content>
-    <sequence>
-      
+    <sequence>     
         <classRef key="model.headLike" minOccurs="0" maxOccurs="unbounded"/>
-      
-      
         <alternate minOccurs="1" maxOccurs="unbounded">
           <classRef key="model.global"/>
           <elementRef key="sp"/>
+          <elementRef key="spGrp"/>
           <classRef key="model.stageLike"/>
-        </alternate>
-      
+        </alternate>   
     </sequence>
   </content>
+  <exemplum xml:lang="en">
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-spGrp-egXML-RophCind" source="#RphCnd">
+      
+      <stage>A Page brings a seat, which is placed next to the throne, on its R., Cinderella occupies
+        it, the sisters sit on her R. H., and the fête continues. A fanciful dance by appropriate
+        characters, followed by a party of Tyrolese singers and dancers, who enter dressed in the
+        costume of their nation. While some dance, the others accompany them by their voices
+        alone.</stage>
+
+      <spGrp>
+        <head>TYROLIENNE.</head>
+        <spGrp org="parallel">  
+          <sp>
+            <speaker>Men.</speaker>
+            <l>Whilst to joy we sing inviting, </l>
+            <l>With our strains thy steps uniting </l>
+            <l>With thy smiles our pains requiting </l>
+            <l>Lovely maid, our eyes delight.</l>
+          </sp>
+          <sp>
+            <speaker>Women.</speaker>
+            <l>Swift as the flash </l>
+            <l>That mocks the sight </l>
+            <l>Thou seem'st a bird </l>
+            <l>In airy flight.</l>
+          </sp>
+        </spGrp>
+        <sp>
+          <speaker>Together.</speaker>
+          <l>When, home returning, </l>
+          <l>   We leave these cool fountains, </l>
+          <l>   In our native mountains </l>
+          <l>Thy praise we'll recite.</l>
+        </sp>
+        <spGrp org="parallel">  
+          <sp>
+            <speaker>Men.</speaker>
+            <l>Fresh flowers </l>
+            <l>Washed by showers </l>
+            <l>In Love's bowers, </l>
+            <l>Are less fair and bright.</l>
+          </sp>
+          <sp >
+            <speaker>Women.</speaker>
+            <l>Thy steps so light, </l>
+            <l>Our songs invite; </l>
+            <l>Come, fairy sprite, </l>
+            <l>Our eyes delight.</l>
+          </sp></spGrp>
+        <sp>
+          <speaker>Together.</speaker>
+          <l>When, home returning, </l>
+          <l> We leave these cool fountains, </l>
+          <l>   In our native mountains </l>
+          <l>Thy praise we'll recite.</l>
+        </sp>
+      </spGrp>     
+    </egXML>
+  </exemplum>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-spGrp-egXML-lm" source="#MasCab">
       <sp>

--- a/P5/Source/Specs/spGrp.xml
+++ b/P5/Source/Specs/spGrp.xml
@@ -25,7 +25,7 @@
     </sequence>
   </content>
   <exemplum xml:lang="en">
-    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-spGrp-egXML-RophCind" source="#RphCnd">
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-spGrp-egXML-rc" source="#RphCnd">
       
       <stage>A Page brings a seat, which is placed next to the throne, on its R., Cinderella occupies
         it, the sisters sit on her R. H., and the fête continues. A fanciful dance by appropriate
@@ -38,46 +38,46 @@
         <spGrp org="parallel">  
           <sp>
             <speaker>Men.</speaker>
-            <l>Whilst to joy we sing inviting, </l>
-            <l>With our strains thy steps uniting </l>
-            <l>With thy smiles our pains requiting </l>
+            <l>Whilst to joy we sing inviting,</l>
+            <l>With our strains thy steps uniting</l>
+            <l>With thy smiles our pains requiting</l>
             <l>Lovely maid, our eyes delight.</l>
           </sp>
           <sp>
             <speaker>Women.</speaker>
-            <l>Swift as the flash </l>
-            <l>That mocks the sight </l>
-            <l>Thou seem'st a bird </l>
+            <l>Swift as the flash</l>
+            <l>That mocks the sight</l>
+            <l>Thou seem'st a bird</l>
             <l>In airy flight.</l>
           </sp>
         </spGrp>
         <sp>
           <speaker>Together.</speaker>
-          <l>When, home returning, </l>
-          <l>   We leave these cool fountains, </l>
-          <l>   In our native mountains </l>
+          <l>When, home returning,</l>
+          <l>We leave these cool fountains,</l>
+          <l>In our native mountains</l>
           <l>Thy praise we'll recite.</l>
         </sp>
         <spGrp org="parallel">  
           <sp>
             <speaker>Men.</speaker>
-            <l>Fresh flowers </l>
-            <l>Washed by showers </l>
-            <l>In Love's bowers, </l>
+            <l>Fresh flowers</l>
+            <l>Washed by showers</l>
+            <l>In Love's bowers,</l>
             <l>Are less fair and bright.</l>
           </sp>
-          <sp >
+          <sp>
             <speaker>Women.</speaker>
-            <l>Thy steps so light, </l>
-            <l>Our songs invite; </l>
-            <l>Come, fairy sprite, </l>
+            <l>Thy steps so light,</l>
+            <l>Our songs invite;</l>
+            <l>Come, fairy sprite,</l>
             <l>Our eyes delight.</l>
           </sp></spGrp>
         <sp>
           <speaker>Together.</speaker>
-          <l>When, home returning, </l>
-          <l> We leave these cool fountains, </l>
-          <l>   In our native mountains </l>
+          <l>When, home returning,</l>
+          <l>We leave these cool fountains,</l>
+          <l>In our native mountains</l>
           <l>Thy praise we'll recite.</l>
         </sp>
       </spGrp>     
@@ -87,9 +87,9 @@
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-spGrp-egXML-lm" source="#MasCab">
       <sp>
         <speaker>FRAULEIN SCHNEIDER:</speaker>
-        <p> Herr Schultz! Can I believe what I see? <stage>(HERR SCHULTZ nods 
+        <p>Herr Schultz! Can I believe what I see? <stage>(HERR SCHULTZ nods 
 proudly)</stage> But this is — too much to accept. So rare — so costly —
-so luxurious. </p>
+so luxurious.</p>
       </sp>
       <stage>(She sings)</stage>
       <spGrp n="4">
@@ -104,14 +104,14 @@ so luxurious. </p>
         </sp>
         <sp>
           <speaker>SCHULTZ:</speaker>
-          <stage>(Singing) </stage>
-          <l>If, in your emotion, </l>
-          <l>You began to sway, </l>
-          <l>Went to get some air, </l>
-          <l>Or grabbed a chair </l>
-          <l>To keep from fainting dead away, </l>
-          <l>It couldn't please me more </l>
-          <l>Than to see you cling </l>
+          <stage>(Singing)</stage>
+          <l>If, in your emotion,</l>
+          <l>You began to sway,</l>
+          <l>Went to get some air,</l>
+          <l>Or grabbed a chair</l>
+          <l>To keep from fainting dead away,</l>
+          <l>It couldn't please me more</l>
+          <l>Than to see you cling</l>
           <l>To the pineapple I bring.</l>
         </sp>
         <sp>
@@ -123,7 +123,7 @@ BOTH:</speaker>
         <stage>(They dance)</stage>
       </spGrp>
       <sp>
-        <speaker>FRAULEIN SCHNEIDER: </speaker>
+        <speaker>FRAULEIN SCHNEIDER:</speaker>
         <p>But you must not bring me
 any more pineapples! Do you hear? It is not proper.  It is a gift a
 young man would present to his lady love. It makes me blush!


### PR DESCRIPTION
See if you agree with how I modified the content model and description of `<spGrp>` and the somewhat more generalized new values I've added for `@org` on `att.divLike`.

Right now, this branch isn't passing tests because I haven't added the new source for the example to BIBL. But when I build the Guidelines schema (with `make exemplars`) I'm validating a test file with @lb42 's example on the ticket. I notice that my new values for `@org` are breaking test1 and test2 in Stylesheets so we'll need to do some repairs—but we should review them anyway. 