### PR TITLE
Add org, place, and person as members of att.datable

### DIFF
--- a/P5/Source/Guidelines/en/ND-NamesDates.xml
+++ b/P5/Source/Guidelines/en/ND-NamesDates.xml
@@ -1009,7 +1009,7 @@ target="#CONA"/>).  The tag -->The
         one for events. Each class may contain specific elements for common types of biographical information, and contains a
         generic element for other, user-defined, types of information.</p>
       <p>All the elements in these three classes also belong to the attribute class <ident type="class">att.datable</ident>
-        as discussed in <ptr target="#NDATTS"/> above.</p>
+        which is discussed in <ptr target="#NDATTS"/> above.</p>
 
       <div type="div4" xml:id="NDPERSEpc">
         <head>Personal Characteristics</head>

--- a/P5/Source/Guidelines/en/ND-NamesDates.xml
+++ b/P5/Source/Guidelines/en/ND-NamesDates.xml
@@ -956,6 +956,13 @@ target="#CONA"/>).  The tag -->The
           <specDesc key="personGrp"/>
         </specList></p>
 
+      <p>The <gi>person</gi> element is a member of the class <ident type="class">att.datable</ident>, which provides attributes for normalization of elements that contain dates, times, or datable events: 
+        <specList>
+          <specDesc key="att.datable.custom" atts="when-custom notBefore-custom notAfter-custom from-custom to-custom datingPoint datingMethod"/>
+          <specDesc key="att.datable.iso" atts="when-iso notBefore-iso notAfter-iso from-iso to-iso"/>
+          <specDesc key="att.datable.w3c" atts="when notBefore notAfter from to"/>
+        </specList></p>
+
       <p>These attributes are intended for use where only a small amount of data is to be encoded in a more or less normalized
         form, possibly for many person elements, for example when encoding basic facts about respondents to a questionnaire. When
         however a more detailed encoding is required for all kinds of information about a person, for example in a historical

--- a/P5/Source/Guidelines/en/ND-NamesDates.xml
+++ b/P5/Source/Guidelines/en/ND-NamesDates.xml
@@ -944,23 +944,27 @@ target="#CONA"/>).  The tag -->The
           </standOff>
         </egXML>
       </p>
+      
+      
 
       <p>The <gi>person</gi> element carries several attributes. As a member of the classes <ident type="class">att.global.responsibility</ident>, <ident type="class">att.editLike</ident>, and <ident type="class">att.global.source</ident> class, it carries the usual attributes for providing details about the information recorded
         for that person, such as its reliability or source: <specList>
           <specDesc key="att.global.responsibility" atts="cert resp"/>
           <specDesc key="att.editLike" atts="evidence"/>
           <specDesc key="att.global.source" atts="source"/>
-        </specList> In addition, a small number of very commonly used personal properties may be recorded using attributes
-        specific to <gi>person</gi> and <gi>personGrp</gi>: <specList>
-          <specDesc key="person" atts="role sex age"/>
-          <specDesc key="personGrp"/>
-        </specList></p>
-
-      <p>The <gi>person</gi> element is a member of the class <ident type="class">att.datable</ident>, which provides attributes for normalization of elements that contain dates, times, or datable events: 
+        </specList> </p>
+      
+      <p>The <gi>person</gi> element is also a member of the class <ident type="class">att.datable</ident>, which provides attributes for normalization of elements that contain dates, times, or datable events: 
         <specList>
           <specDesc key="att.datable.custom" atts="when-custom notBefore-custom notAfter-custom from-custom to-custom datingPoint datingMethod"/>
           <specDesc key="att.datable.iso" atts="when-iso notBefore-iso notAfter-iso from-iso to-iso"/>
           <specDesc key="att.datable.w3c" atts="when notBefore notAfter from to"/>
+        </specList></p>
+      
+      <p>In addition, a small number of very commonly used personal properties may be recorded using attributes
+        specific to <gi>person</gi> and <gi>personGrp</gi>: <specList>
+          <specDesc key="person" atts="role sex age"/>
+          <specDesc key="personGrp"/>
         </specList></p>
 
       <p>These attributes are intended for use where only a small amount of data is to be encoded in a more or less normalized
@@ -1004,10 +1008,8 @@ target="#CONA"/>).  The tag -->The
         grouped into three classes, corresponding with the tripartite division outlined above: one for traits, one for states and
         one for events. Each class may contain specific elements for common types of biographical information, and contains a
         generic element for other, user-defined, types of information.</p>
-      <p>All the elements in these three classes belong to the attribute class <ident type="class">att.datable</ident>, which
-        provides the following attributes: <specList>
-          <specDesc key="att.datable.w3c" atts="when notBefore notAfter from to"/>
-        </specList> as discussed in <ptr target="#NDATTS"/> above.</p>
+      <p>All the elements in these three classes also belong to the attribute class <ident type="class">att.datable</ident>
+        as discussed in <ptr target="#NDATTS"/> above.</p>
 
       <div type="div4" xml:id="NDPERSEpc">
         <head>Personal Characteristics</head>

--- a/P5/Source/Guidelines/en/ND-NamesDates.xml
+++ b/P5/Source/Guidelines/en/ND-NamesDates.xml
@@ -954,7 +954,7 @@ target="#CONA"/>).  The tag -->The
           <specDesc key="att.global.source" atts="source"/>
         </specList> </p>
       
-      <p>The <gi>person</gi> element is also a member of the class <ident type="class">att.datable</ident>, which provides attributes for normalization of elements that contain dates, times, or datable events: 
+      <p>As a member of the class <ident type="class">att.datable</ident>, the <gi>person</gi> element also provides attributes for normalization of elements that contain dates, times, or datable events: 
         <specList>
           <specDesc key="att.datable.custom" atts="when-custom notBefore-custom notAfter-custom from-custom to-custom datingPoint datingMethod"/>
           <specDesc key="att.datable.iso" atts="when-iso notBefore-iso notAfter-iso from-iso to-iso"/>

--- a/P5/Source/Guidelines/en/ND-NamesDates.xml
+++ b/P5/Source/Guidelines/en/ND-NamesDates.xml
@@ -954,7 +954,7 @@ target="#CONA"/>).  The tag -->The
           <specDesc key="att.global.source" atts="source"/>
         </specList> </p>
       
-      <p>As a member of the class <ident type="class">att.datable</ident>, the <gi>person</gi> element also provides attributes for normalization of elements that contain dates, times, or datable events: 
+      <p>As a member of the class <ident type="class">att.datable</ident>, the <gi>person</gi> element also carries attributes for specifying dates and times: 
         <specList>
           <specDesc key="att.datable.custom" atts="when-custom notBefore-custom notAfter-custom from-custom to-custom datingPoint datingMethod"/>
           <specDesc key="att.datable.iso" atts="when-iso notBefore-iso notAfter-iso from-iso to-iso"/>

--- a/P5/Source/Specs/org.xml
+++ b/P5/Source/Specs/org.xml
@@ -23,6 +23,7 @@
   qualsiasi altro raggruppamento di persone</desc>
   <classes>
     <memberOf key="att.global"/>
+    <memberOf key="att.datable"/>
     <memberOf key="att.editLike"/>
     <memberOf key="att.sortable"/>
     <memberOf key="att.typed"/>

--- a/P5/Source/Specs/person.xml
+++ b/P5/Source/Specs/person.xml
@@ -17,6 +17,7 @@
         persone identificate da una fonte storica</desc>
   <classes>
     <memberOf key="att.global"/>
+    <memberOf key="att.datable"/>
     <memberOf key="att.editLike"/>
     <memberOf key="att.sortable"/>
     <memberOf key="model.personLike"/>

--- a/P5/Source/Specs/place.xml
+++ b/P5/Source/Specs/place.xml
@@ -12,6 +12,7 @@
   <desc versionDate="2007-11-06" xml:lang="it">contiene informazioni relative a un luogo geografico</desc>
   <classes>
     <memberOf key="att.global"/>
+    <memberOf key="att.datable"/>
     <memberOf key="att.editLike"/>
     <memberOf key="att.sortable"/>
     <memberOf key="att.typed"/>


### PR DESCRIPTION
This PR is for adding `att.datable` to `org`, `place`, and `person`. I've added you @jamescummings as a reviewer as well since you were the original poster and were willing to implement the changes across all named entities. 

To do: 

- [x] Include reference to att.datable membership to the prose of section [14.3.2 The Person Element](https://tei-c.org/release/doc/tei-p5-doc/en/html/ND.html#NDPERSE)
- [x] Include reference to att.datable membership to the prose of section [14.3.4 Places](https://tei-c.org/release/doc/tei-p5-doc/en/html/ND.html#NDGEOG)?
- [x] Include reference to att.datable membership to the prose of section [14.3.3 Organizational Data](https://tei-c.org/release/doc/tei-p5-doc/en/html/ND.html#ND-org)?

