### PR TITLE
Clarifications on the use of the word 'prefix' for issue #2001.

### DIFF
--- a/P5/Source/Guidelines/en/SA-LinkingSegmentationAlignment.xml
+++ b/P5/Source/Guidelines/en/SA-LinkingSegmentationAlignment.xml
@@ -632,7 +632,7 @@ chapter and elsewhere in these Guidelines. </p>
         
         and document the meaning of the key using (for instance) a <gi>taxonomy</gi> element in the TEI header, as described in <ptr target="#CONARS"/>. However, such a link cannot be mechanically processed by an external system that does not know how to interpret it; a human will have to read the header explanation and write code explicitly to reconstruct the intended link.</p>
       
-      <p>A more robust alternative is to use a <term>private URI scheme</term>. This is a method of constructing a simple, key-like token which functions as a <ident type="datatype">teidata.pointer</ident>, and can therefore be used as the value of any attribute which has that datatype, such as <att>ref</att> and <att>target</att>. Such a scheme consists of a prefix with a colon, and then a value. You might, for example, use the prefix <val>psn</val> (for "person"), and structure your name tags like this:
+      <p>A more robust alternative is to use a <term>private URI scheme</term>. This is a method of constructing a simple, key-like token which functions as a <ident type="datatype">teidata.pointer</ident>, and can therefore be used as the value of any attribute which has that datatype, such as <att>ref</att> and <att>target</att>. Such a scheme consists of a prefix (technically a private URI scheme name, as defined in <ref target="https://datatracker.ietf.org/doc/html/rfc7595">RFC 7595</ref>) with a colon, and then a value. You might, for example, use the prefix <val>psn</val> (for "person"), and structure your name tags like this:
         
         <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="SAPU-egXML-da">
           <name ref="psn:fred">Fred</name>

--- a/P5/Source/Specs/prefixDef.xml
+++ b/P5/Source/Specs/prefixDef.xml
@@ -37,7 +37,12 @@
       </prefixDef>
     </egXML>
   </exemplum>
-  <remarks versionDate="2013-02-05" xml:lang="en">
+  <remarks versionDate="2026-04-16" xml:lang="en">
+    <p>Note that we used the term <q>prefix</q> in a general sense; in the context 
+      of a <ident type="datatype">teidata.pointer</ident> attribute, the prefix 
+      functions as a private URI scheme name as defined in 
+      <ref target="https://datatracker.ietf.org/doc/html/rfc7595">RFC 7595</ref>.
+    </p>
     <p>The abbreviated pointer may be dereferenced to produce either
     an absolute or a relative URI reference. In the latter case it is
     combined with the value of <att>xml:base</att> in force at the


### PR DESCRIPTION
I have limited the changes to two clarifications, one in the spec file for `<prefixDef>` and one in the chapter prose, since I believe the likelihood for confusion is small, and since the scheme name actually does function as a prefix, and the RFC itself uses the word "prefix".