### PR TITLE
Fix for issue #2876: deprecate the use of valList as a direct child of elementSpec

### DIFF
--- a/P5/Source/Specs/elementSpec.xml
+++ b/P5/Source/Specs/elementSpec.xml
@@ -134,6 +134,13 @@
       </elementSpec>
     </egXML>
   </exemplum>
+  <remarks xml:lang="en" versionDate="2026-04-16" validUntil="2027-09-01">
+    <p><gi>elementSpec</gi> currently allows <gi>valList</gi> as a direct child,
+    but this usage is deprecated and will be removed on 2027-09-01. 
+    If a <gi>valList</gi> is used to specify the content model of an element,
+    it should be placed inside the <gi>content</gi> child of the 
+    <gi>elementSpec</gi>.</p>
+  </remarks>
   <listRef>
     <ptr target="#TDTAG"/>
     <ptr target="#TD"/>

--- a/P5/Source/Specs/elementSpec.xml
+++ b/P5/Source/Specs/elementSpec.xml
@@ -62,6 +62,20 @@
       </sch:rule>
     </constraint>
   </constraintSpec>
+  <!-- NOTE: MH added 2026-06-29 per SB for issue #2876.
+    Remove the following when valList is removed from the content model. -->
+  <constraintSpec ident="child-valList-deprecated" scheme="schematron" xml:lang="en">
+    <constraint>
+      <sch:rule context="tei:elementSpec/tei:valList">
+        <sch:report test="true()">
+          Use of &lt;valList> as a direct child of &lt;elementSpec> is deprecated
+          and will be invalid after 2027-08-31. To express a controlled vocabulary
+          as the content model of an element, place the &lt;valList> inside a
+          &lt;content> element.
+        </sch:report>
+      </sch:rule>
+    </constraint>
+  </constraintSpec>
   <attList>
     <attDef ident="prefix" usage="opt">
       <desc versionDate="2010-06-23" xml:lang="en">specifies a default prefix which will be


### PR DESCRIPTION
This is the best solution I can think of for deprecation here.