### PR TITLE
add `<gloss>` to `att.placment`

### DIFF
--- a/P5/Source/Specs/gloss.xml
+++ b/P5/Source/Specs/gloss.xml
@@ -20,6 +20,7 @@
     <memberOf key="att.cReferencing"/>
     <memberOf key="att.cmc"/>
     <memberOf key="att.declaring"/>
+    <memberOf key="att.placement"/>
     <memberOf key="att.pointing"/>
     <memberOf key="att.translatable"/>
     <memberOf key="att.typed"/>


### PR DESCRIPTION
This PR addresses #2892  and adds `<gloss>` to `att.placement`.