### PR TITLE
make "spec-in-module" test less confusing

### DIFF
--- a/P5/Source/Specs/att.identified.xml
+++ b/P5/Source/Specs/att.identified.xml
@@ -13,25 +13,27 @@
     <memberOf key="att.combinable"/>
   </classes>
   <constraintSpec ident="spec-in-module" scheme="schematron" xml:lang="en">
+    <!--
+      The @test below comprises three expressions in a disjunction.
+      Only if all three are false() is the error message generated;
+      i.e., if any one of the three is true() no message is
+      generated. The first two test for whether or not we are in a
+      circumstance in which the basic question, “does the module
+      @module exist?” can be meaningfully asked. The sub-tests are:
+      1) This specification element (which has a @module attr) is free-standing; i.e. it is NOT a descendant of <schemaSpec>, <TEI>, nor of <teiCorpus> — this is TRUE for the individual files in which we store the TEI P5 specifications, but false for p5.xml (or p5subset.xml) itself, and false for any proper customization file.
+      2) There are no <moduleSpec> nor <moduleRef> elements in this file.
+      3) In this file there is either a <moduleSpec>’s @ident or a <moduleRef>’s @key which matches this specification’s @module.
+    -->
     <constraint>
       <sch:rule context="tei:elementSpec[ @module ]
                         |tei:classSpec[ @module ]
                         |tei:macroSpec[ @module ] ">
         <sch:assert test="( not( ancestor::tei:schemaSpec | ancestor::tei:TEI | ancestor::tei:teiCorpus ) )
                           or
-                          (
-                            not( @module )
-                            or
-                            (
-                              not( //tei:moduleSpec )
-                              and
-                              not( //tei:moduleRef )
-                            )
-                            or
-                            ( //tei:moduleSpec[ @ident = current()/@module ] )
-                            or
-                            ( //tei:moduleRef[ @key = current()/@module ] )
-                          )">
+                          not( //tei:moduleSpec | //tei:moduleRef )
+                          or
+                          ( //tei:moduleSpec/@ident | //tei:moduleRef/@key ) = current()/@module
+                          ">
         Specification <sch:value-of select="@ident"/>: the value of
         the module attribute ("<sch:value-of select="@module"/>")
         should correspond to an existing module, via a moduleSpec or

--- a/P5/Source/Specs/att.identified.xml
+++ b/P5/Source/Specs/att.identified.xml
@@ -40,7 +40,7 @@
         <sch:assert test="( //tei:moduleSpec/@ident | //tei:moduleRef/@key ) = @module">
           Specification <sch:value-of select="@ident"/>: the value of the module attribute
           ("<sch:value-of select="@module"/>") should correspond to an existing module, via
-          a moduleSpec or moduleRef</sch:assert>
+          a moduleSpec or moduleRef.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/att.identified.xml
+++ b/P5/Source/Specs/att.identified.xml
@@ -14,30 +14,33 @@
   </classes>
   <constraintSpec ident="spec-in-module" scheme="schematron" xml:lang="en">
     <!--
-      The @test below comprises three expressions in a disjunction.
-      Only if all three are false() is the error message generated;
-      i.e., if any one of the three is true() no message is
-      generated. The first two test for whether or not we are in a
-      circumstance in which the basic question, “does the module
-      @module exist?” can be meaningfully asked. The sub-tests are:
-      1) This specification element (which has a @module attr) is free-standing; i.e. it is NOT a descendant of <schemaSpec>, <TEI>, nor of <teiCorpus> — this is TRUE for the individual files in which we store the TEI P5 specifications, but false for p5.xml (or p5subset.xml) itself, and false for any proper customization file.
-      2) There are no <moduleSpec> nor <moduleRef> elements in this file.
-      3) In this file there is either a <moduleSpec>’s @ident or a <moduleRef>’s @key which matches this specification’s @module.
+      The @context below is somewhat complicated, because we do not
+      want to test @module attributes that occur in a circumstance
+      where the module it refers to is almost certainly defined
+      elsewhere, so would not be in this file, anyway. So we test that
+      the @module is either
+      1) in a file that has at least a <schemaSpec>, if not a <TEI>
+         (or <teiCorpus); or
+      2) in a file that has at least one <moduleSpec> or <moduleRef>,
+         because if there are no <moduleSpec>s nor <moduleRef>s, there
+         cannot be one that is refered to by this @module attribute.
+      The result of (1) is that we ignore the various sub-files that
+      make up P5 (and other similar cases); the result of (2) is that
+      we ignore most customization files. The good news is that
+      ignoring these cases avoids a lot of false positives; the bad
+      news is that quite a few cases of @module will go unchecked by
+      this useful test.
     -->
     <constraint>
-      <sch:rule context="tei:elementSpec[ @module ]
-                        |tei:classSpec[ @module ]
-                        |tei:macroSpec[ @module ] ">
-        <sch:assert test="( not( ancestor::tei:schemaSpec | ancestor::tei:TEI | ancestor::tei:teiCorpus ) )
-                          or
-                          not( //tei:moduleSpec | //tei:moduleRef )
-                          or
-                          ( //tei:moduleSpec/@ident | //tei:moduleRef/@key ) = current()/@module
-                          ">
-        Specification <sch:value-of select="@ident"/>: the value of
-        the module attribute ("<sch:value-of select="@module"/>")
-        should correspond to an existing module, via a moduleSpec or
-        moduleRef</sch:assert>
+      <sch:rule context="( tei:elementSpec[@module] | tei:classSpec[@module] | tei:macroSpec[@module] )[
+                           ( ancestor::tei:schemaSpec | ancestor::tei:TEI | ancestor::tei:teiCorpus )
+                           and
+                           ( //tei:moduleSpec | //tei:moduleRef )
+                           ]">
+        <sch:assert test="( //tei:moduleSpec/@ident | //tei:moduleRef/@key ) = @module">
+          Specification <sch:value-of select="@ident"/>: the value of the module attribute
+          ("<sch:value-of select="@module"/>") should correspond to an existing module, via
+          a moduleSpec or moduleRef</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/att.identified.xml
+++ b/P5/Source/Specs/att.identified.xml
@@ -20,7 +20,7 @@
       elsewhere, so would not be in this file, anyway. So we test that
       the @module is either
       1) in a file that has at least a <schemaSpec>, if not a <TEI>
-         (or <teiCorpus); or
+         (or <teiCorpus); and
       2) in a file that has at least one <moduleSpec> or <moduleRef>,
          because if there are no <moduleSpec>s nor <moduleRef>s, there
          cannot be one that is refered to by this @module attribute.


### PR DESCRIPTION
Replace the `<constraint>` "spec-in-module" with that which was recommended on issue #2898.
