### PR TITLE
tweaks re: `<application>`

### DIFF
--- a/P5/Source/Guidelines/en/HD-Header.xml
+++ b/P5/Source/Guidelines/en/HD-Header.xml
@@ -1894,16 +1894,16 @@ Within the <gi>unitDef</gi>, a <gi>conversion</gi> element may be used to store 
 processing of an encoded resource within its header. Typical uses for
 such information might be:
 <list rend="bulleted">
-<item> to allow an
+<item>to allow an
   application to discover that it has previously
   opened or edited a file, and what version of itself was used
   to do that;</item>
-<item> to show (through a date) which
+<item>to show (through a date) which
   application last edited the file to allow for diagnosis of
   any problems that might have been caused by that
   application;</item>
-<item> to allow users to discover information
-  about an application used to edit the file</item>
+<item>to allow users to discover information
+  about an application used to edit the file;</item>
 <item>to allow
   the application to declare an interest in elements of
   the file which it has edited, so that other applications
@@ -1926,11 +1926,12 @@ the application and its major version number (for example,
 application should add a new <gi>application</gi> each time it touches
 the file.</p>
 <p>The following example shows how these elements might be used to
-document the fact that version 1.5 of an application called   <soCalled>Image Markup
-Tool</soCalled>  has an interest in two parts of a document
-which was last saved on June 6 2006. The parts concerned are
-accessible at the URLs given as target for the two <gi>ptr</gi>
-elements.     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="HDAPP-egXML-nq">
+document the fact that version 1.5 of an application called <name>Image Markup
+Tool</name> has an interest in two parts of a document
+which was last saved on 06 June 2006. The parts concerned are
+accessible at the URLs given as the <att>target</att> attributes of the two <gi>ptr</gi>
+elements.
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="HDAPP-egXML-nq">
       <appInfo>
         <application version="1.5" ident="ImageMarkupTool" notAfter="2006-06-01">
           <label>Image Markup Tool</label>

--- a/P5/Source/Specs/application.xml
+++ b/P5/Source/Specs/application.xml
@@ -53,10 +53,12 @@
         </application>
       </appInfo>
     </egXML>
-    <p>This example shows an appInfo element documenting the fact that version 1.5 of the Image
-      Markup Tool1 application has an interest in two parts of a document which was last saved on
-      June 6 2006. The parts concerned are accessible at the URLs given as target for the two
-        <gi>ptr</gi> elements. </p>
+    <p>This example shows an <gi>appInfo</gi> element documenting the
+    fact that version 1.5 of the Image Markup Tool application has an
+    interest in two parts of a document which was last saved on 06
+    June 2006. The parts concerned are accessible at the URLs given as
+    the <att>target</att> attributes of the two <gi>ptr</gi>
+    elements.</p>
   </exemplum>
   <exemplum versionDate="2008-04-06" xml:lang="fr">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-application-egXML-ox" source="#NONE">


### PR DESCRIPTION
Minor improvements to the wording, encoding, and punctuation of the discussion of the `<appInfo>` and `<application>` elements. I have made these changes and this PR as part of #1516, but it does not even come _close_ to closing that issue. These are just helpful tweaks.

In both the tagdoc for `<application>` and section 2.3.11 (#HDAPP) we find (emphasis added by me):

> … has an interest in two parts of **a** document which was last saved …

I am wondering if that indefinite article should be the definite article “the”, or even something like “the TEI document in which this `<appInfo>` appears”?