### PR TITLE
Update prose on `<gloss>` to mention `att.placement` membership

### DIFF
--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -1053,7 +1053,7 @@ overshadows the historical content</quote>.</egXML>
       <att>place</att> attribute for indicating where the
       gloss is with respect to the text.
       <specList>
-        <specDesc key="att.placement" atts="place"/>
+        <specDesc key="att.placement"/>
       </specList>
       The most relevant suggested values of <att>place</att> for
       glosses that occur in the margin of the text are <val>top</val>, <val>bottom</val>,

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -1048,8 +1048,16 @@ overshadows the historical content</quote>.</egXML>
         <specDesc key="term"/>
         <specDesc key="gloss"/>
       </specList>
-      These elements are also members of
-      the class <ident type="class">model.emphLike</ident>.
+      These elements are members of
+      the class <ident type="class">model.emphLike</ident>. As a member of the class <ident type="class">att.placement</ident>, the <gi>gloss</gi> element also carries the
+      <att>place</att> attribute for indicating where the
+      gloss is with respect to the text.
+      <specList>
+        <specDesc key="att.placement" atts="place"/>
+      </specList>
+      The most relevant suggested values of <att>place</att> for
+      glosses that occur in the margin of the text are <val>top</val>, <val>bottom</val>,
+      and <val>margin</val>. The <att>place</att> values <val>above</val> and <val>below</val> may be used for glosses that occur above or below a line of text.
     </p>
     <p>A <gi>term</gi> may appear with or without a gloss, as may a
       <gi>mentioned</gi> element.  Where the <gi>gloss</gi> is present, it may
@@ -1218,7 +1226,7 @@ overshadows the historical content</quote>.</egXML>
             <specDesc key="rb"/>
             <specDesc key="rt"/>
           </specList>
-          The <gi>rt</gi> element is a member of <ident type="class">att.placement</ident>, and thus the
+C          The <gi>rt</gi> element is a member of <ident type="class">att.placement</ident>, and thus the
           <att>place</att> attribute may be used to indicate where the
           ruby gloss is with respect to the base text:
           <specList>

--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -1226,7 +1226,7 @@ overshadows the historical content</quote>.</egXML>
             <specDesc key="rb"/>
             <specDesc key="rt"/>
           </specList>
-C          The <gi>rt</gi> element is a member of <ident type="class">att.placement</ident>, and thus the
+          The <gi>rt</gi> element is a member of <ident type="class">att.placement</ident>, and thus the
           <att>place</att> attribute may be used to indicate where the
           ruby gloss is with respect to the base text:
           <specList>


### PR DESCRIPTION
This PR addresses issue #2892 by updating the [Terms and Glosses](https://tei-c.org/release/doc/tei-p5-doc/en/html/CO.html#COHTG) section of the Guidelines to state that the `<gloss>` element claims membership of `att.placement`. I also highlighted the suggested values which might be most relevant for encoding glosses that occur in the margins of a text as well as above or below a line of text. 