### PR TITLE
Update oversight in 2 ⇒ 2 or 3 values for a point

### DIFF
--- a/P5/Source/Specs/teidata.point.xml
+++ b/P5/Source/Specs/teidata.point.xml
@@ -10,19 +10,20 @@
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="data-point-egXML-qa" source="#UND">
       <facsimile>
-	<surface ulx="0" uly="0" lrx="400" lry="280">
-	  <zone points="220,100 300,210 170,250 123,234">
-	    <graphic url="handwriting.png"/>
-	  </zone>
-	</surface>
+        <surface ulx="0" uly="0" lrx="400" lry="280">
+          <zone points="220,100 300,210 170,250 123,234">
+            <graphic url="handwriting.png"/>
+          </zone>
+        </surface>
       </facsimile>
     </egXML>
   </exemplum>
   <remarks versionDate="2019-02-24" xml:lang="en">
-    <p>A point is defined by two numeric values, which should be
-    expressed as decimal numbers. Neither number can end in a decimal
-    point. E.g., both <val>0.0,84.2</val> and <val>0,84</val> are
-    allowed, but <val>0.,84.</val> is not.
+    <p>A point is defined by two or three numeric values separated by
+    commas. The numeric values should be expressed as decimal numbers
+    which do not end in a decimal point. E.g., both
+    <val>0.0,84.2</val> and <val>0,84</val> are allowed, but
+    <val>0.,84.</val> is not.
     <!-- 51°45'45.63"N,  1°16'11.81"W -->
     </p>
   </remarks>


### PR DESCRIPTION
When data.point was changed from 2 values to 2 or 3 values the `<remarks>` were not changed to match.