### PR TITLE
regularize Schematron msgs that do not end in dot

### DIFF
--- a/P5/Source/Guidelines/en/TD-DocumentationElements.xml
+++ b/P5/Source/Guidelines/en/TD-DocumentationElements.xml
@@ -874,7 +874,7 @@ to mark any technical term, thus:
           <constraintSpec ident="ref-or-key-or-name" scheme="schematron">
             <constraint>
               <sch:rule context="tei:relation">
-                <sch:assert test="@ref or @key or @name">One of the attributes @name, @ref, or @key must be supplied</sch:assert>
+                <sch:assert test="@ref or @key or @name">One of the attributes @name, @ref, or @key must be supplied.</sch:assert>
               </sch:rule>
             </constraint>
           </constraintSpec>
@@ -882,7 +882,7 @@ to mark any technical term, thus:
           <constraintSpec ident="active-mutual" scheme="schematron">
             <constraint>
               <sch:rule context="tei:relation">
-                <sch:report test="@active and @mutual">Only one of the attributes @active and @mutual may be supplied</sch:report>
+                <sch:report test="@active and @mutual">Only one of the attributes @active and @mutual may be supplied.</sch:report>
               </sch:rule>
             </constraint>
           </constraintSpec>
@@ -890,7 +890,7 @@ to mark any technical term, thus:
           <constraintSpec ident="active-passive" scheme="schematron">
             <constraint>
               <sch:rule context="tei:relation">
-                <sch:report test="@passive and not(@active)">the attribute @passive may be supplied only if the attribute @active is supplied</sch:report>
+                <sch:report test="@passive and not(@active)">the attribute @passive may be supplied only if the attribute @active is supplied.</sch:report>
               </sch:rule>
             </constraint>
           </constraintSpec>
@@ -906,13 +906,13 @@ to mark any technical term, thus:
       whose <att>scheme</att> matches that of the
       <gi>constraintDecl</gi>.
         <egXML xmlns="http://www.tei-c.org/ns/Examples" source="#NONE">
-	  <constraintDecl scheme="schematron" queryBinding="xslt3">
-	    <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
-	    <sch:ns prefix="xi" uri="http://www.w3.org/2001/XInclude"/>
-	    <sch:let name="edition" value="substring-before( /*/tei:teiHeader//tei:editionStmt/tei:edition/@n, '.')"/>
-	    <sch:let name="uses_old_encoding" value="$edition cast as xs:integer lt 3"/>
-      	  </constraintDecl>
-	</egXML>
+          <constraintDecl scheme="schematron" queryBinding="xslt3">
+            <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
+            <sch:ns prefix="xi" uri="http://www.w3.org/2001/XInclude"/>
+            <sch:let name="edition" value="substring-before( /*/tei:teiHeader//tei:editionStmt/tei:edition/@n, '.')"/>
+            <sch:let name="uses_old_encoding" value="$edition cast as xs:integer lt 3"/>
+          </constraintDecl>
+        </egXML>
       In this example the Schematron query language binding is set (to
       <val>xslt3</val>) for use by a Schematron processor, two
       namespace prefixes are bound to namespace URIs for later use within
@@ -939,8 +939,8 @@ to mark any technical term, thus:
           <constraintSpec ident="subclauses" scheme="schematron">
             <constraint>
               <sch:rule context="tei:div">
-                <sch:report test="count( tei:div | xi:include[ contains( @href, 'sect') ] ) eq 1">if it contains any
-		subdivisions, a division must contain at least two of them</sch:report>
+                <sch:report test="count( tei:div | xi:include[ contains( @href, 'sect') ] ) eq 1">If it contains any
+                subdivisions, a division must contain at least two of them.</sch:report>
               </sch:rule>
             </constraint>
           </constraintSpec>
@@ -953,17 +953,23 @@ to mark any technical term, thus:
           <constraintSpec ident="introtitle" scheme="schematron">
             <constraint>
               <sch:rule context="tei:teiHeader">
-                <sch:assert test="tei:fileDesc/tei:titleStmt/tei:title[@type='introductory']"> an introductory component of the title is expected</sch:assert>
+                <sch:assert test="tei:fileDesc/tei:titleStmt/tei:title[@type='introductory']">
+                  An introductory component of the title is expected.
+                </sch:assert>
               </sch:rule>
             </constraint>
           </constraintSpec>
           <constraintSpec ident="maintitle" scheme="schematron">
             <constraint>
               <sch:rule context="tei:teiHeader[ $uses_old_encoding ]">
-                <sch:assert test="tei:fileDesc/tei:titleStmt/tei:title[@type eq 'main']"> a main title must be supplied</sch:assert>
+                <sch:assert test="tei:fileDesc/tei:titleStmt/tei:title[@type eq 'main']">
+                  A main title must be supplied.
+                </sch:assert>
               </sch:rule>
               <sch:rule context="tei:teiHeader[ not( $uses_old_encoding ) ]">
-                <sch:assert test="tei:fileDesc/tei:titleStmt/tei:title[ not( @type eq 'sub' ) ]"> a main title must be supplied</sch:assert>
+                <sch:assert test="tei:fileDesc/tei:titleStmt/tei:title[ not( @type eq 'sub' ) ]">
+                  A main title must be supplied.
+                </sch:assert>
               </sch:rule>
             </constraint>
           </constraintSpec>
@@ -978,8 +984,10 @@ to mark any technical term, thus:
             <constraint>
               <sch:pattern id="altTags">
                 <sch:rule context="tei:figure">
-                  <sch:assert test="tei:figDesc or tei:head"> You should provide information in a figure from
-                    which we can construct an alt attribute in HTML </sch:assert>
+                  <sch:assert test="tei:figDesc or tei:head">
+                    You should provide information in a &lt;figure> from
+                    which we can construct an @alt attribute in HTML.
+                  </sch:assert>
                 </sch:rule>
               </sch:pattern>
             </constraint>
@@ -992,8 +1000,8 @@ to mark any technical term, thus:
             <constraint>
               <sch:pattern id="Tables">
                 <sch:rule context="tei:table">
-                  <sch:assert test="tei:head">A &lt;table&gt; should have a caption, using a &lt;head&gt; element</sch:assert>
-		  <sch:report test="parent::tei:body">Do not use tables to lay out the document body</sch:report>
+                  <sch:assert test="tei:head">A &lt;table&gt; should have a caption, using a &lt;head&gt; element.</sch:assert>
+                  <sch:report test="parent::tei:body">Do not use tables to lay out the document body.</sch:report>
                 </sch:rule>
               </sch:pattern>
             </constraint>
@@ -1147,7 +1155,7 @@ to mark any technical term, thus:
               <constraintSpec ident="lessThan150" scheme="schematron">
                 <constraint>
                   <sch:rule context="@ageAtDeath">
-                    <sch:assert test=". le 150">age at death must be an integer less than 150</sch:assert>
+                    <sch:assert test=". le 150">Age at death must be an integer less than 150.</sch:assert>
                   </sch:rule>
                 </constraint>
               </constraintSpec>

--- a/P5/Source/Specs/alternate.xml
+++ b/P5/Source/Specs/alternate.xml
@@ -18,7 +18,7 @@
   <constraintSpec ident="alternatechilden" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:alternate">
-        <sch:assert test="count(*) gt 1">The alternate element must have at least two child elements</sch:assert>
+        <sch:assert test="count(*) gt 1">The alternate element must have at least two child elements.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/att.deprecated.xml
+++ b/P5/Source/Specs/att.deprecated.xml
@@ -26,10 +26,11 @@
             <sch:let name="advance_warning_period" value="current-date() + xs:dayTimeDuration('P60D')"/>
             <sch:let name="me_phrase" value="if (@ident) then concat('The ', @ident ) else concat('This ', local-name(.), ' of ', ancestor::tei:*[@ident][1]/@ident )"/>
             <sch:assert test="@validUntil cast as xs:date ge current-date()">
-              <sch:value-of select="concat( $me_phrase, ' construct is outdated (as of ', @validUntil, '); ODD processors may ignore it, and its use is no longer supported' )"/></sch:assert>
-              <sch:assert role="warning" test="@validUntil cast as xs:date ge $advance_warning_period">
-                <sch:value-of select="concat( $me_phrase, ' construct becomes outdated on ', @validUntil )"/>
-              </sch:assert>
+              <sch:value-of select="concat( $me_phrase, ' construct is outdated (as of ', @validUntil, '); ODD processors may ignore it, and its use is no longer supported.' )"/>
+            </sch:assert>
+            <sch:assert role="warning" test="@validUntil cast as xs:date ge $advance_warning_period">
+              <sch:value-of select="concat( $me_phrase, ' construct becomes outdated on ', @validUntil, '.')"/>
+            </sch:assert>
           </sch:rule>
         </constraint>
       </constraintSpec>
@@ -37,7 +38,7 @@
         <constraint>
           <sch:rule context="tei:*[@validUntil][ not( self::tei:valDesc | self::tei:valList | self::tei:defaultVal | self::tei:remarks )]">
             <sch:assert test="child::tei:desc[ @type eq 'deprecationInfo']">
-              A deprecated construct should include, whenever possible, an explanation, but this <sch:value-of select="name(.)"/> does not have a child &lt;desc type="deprecationInfo"&gt;</sch:assert>
+              A deprecated construct should include, whenever possible, an explanation, but this <sch:value-of select="name(.)"/> does not have a child &lt;desc type="deprecationInfo">.</sch:assert>
           </sch:rule>
         </constraint>
       </constraintSpec>

--- a/P5/Source/Specs/att.global.source.xml
+++ b/P5/Source/Specs/att.global.source.xml
@@ -26,7 +26,7 @@
                                   and
                                   $srcs[2]">
               When used on a schema description element (like
-              <sch:value-of select="name(.)"/>), the @source attribute
+              &lt;<sch:value-of select="name(.)"/>>), the @source attribute
               should have only 1 value. (This one has <sch:value-of
                 select="count($srcs)"/>.)
             </sch:report>

--- a/P5/Source/Specs/att.repeatable.xml
+++ b/P5/Source/Specs/att.repeatable.xml
@@ -17,10 +17,10 @@
       <sch:rule context="tei:*[ @minOccurs and @maxOccurs ]">
         <sch:let name="min" value="@minOccurs cast as xs:integer"/>
         <sch:let name="max" value="if ( normalize-space( @maxOccurs ) eq 'unbounded') then -1 else @maxOccurs cast as xs:integer"/>
-        <sch:assert test="$max eq -1 or $max ge $min">@maxOccurs should be greater than or equal to @minOccurs</sch:assert>
+        <sch:assert test="$max eq -1 or $max ge $min">@maxOccurs should be greater than or equal to @minOccurs.</sch:assert>
       </sch:rule>
       <sch:rule context="tei:*[ @minOccurs and not( @maxOccurs ) ]">
-        <sch:assert test="@minOccurs cast as xs:integer lt 2">When @maxOccurs is not specified, @minOccurs must be 0 or 1</sch:assert>
+        <sch:assert test="@minOccurs cast as xs:integer lt 2">When @maxOccurs is not specified, @minOccurs must be 0 or 1.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>
@@ -33,11 +33,8 @@
       <gloss versionDate="2007-11-06" xml:lang="it">numero minimo di occorrenze</gloss>
       <gloss versionDate="2007-05-04" xml:lang="es">número mínimo de apariciones</gloss>
       <gloss versionDate="2023-09-27" xml:lang="ja">最小出現数</gloss>
-      <desc versionDate="2013-11-21" xml:lang="en">indicates the smallest number of times this
-      component may occur.</desc>
+      <desc versionDate="2013-11-21" xml:lang="en">indicates the smallest number of times this component may occur.</desc>
       <desc versionDate="2023-09-27" xml:lang="ja">この部品が出現し得る最小回数を示す。</desc>
-      
-      
       <datatype>
         <dataRef key="teidata.count"/>
       </datatype>
@@ -51,8 +48,7 @@
       <gloss versionDate="2007-11-06" xml:lang="it">numero minimo di occorrenze</gloss>
       <gloss versionDate="2007-05-04" xml:lang="es">número máximo de apariciones.</gloss>
       <gloss versionDate="2023-09-27" xml:lang="ja">最大出現数</gloss>
-      <desc versionDate="2013-11-21" xml:lang="en">indicates the largest number of times this
-      component may occur.</desc>
+      <desc versionDate="2013-11-21" xml:lang="en">indicates the largest number of times this component may occur.</desc>
       <desc versionDate="2023-09-27" xml:lang="ja">概算推量のための最大推定値を与える。</desc>
       <datatype>
         <dataRef key="teidata.unboundedCount"/>

--- a/P5/Source/Specs/att.spanning.xml
+++ b/P5/Source/Specs/att.spanning.xml
@@ -24,7 +24,7 @@
         <constraint>
           <sch:rule context="tei:*[ starts-with( @spanTo, '#') ]">
             <sch:assert test="id( substring( @spanTo, 2 ) ) >> .">
-              The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow the current <sch:name/> element 
+              The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow the current &lt;<sch:name/>> element.
             </sch:assert>
           </sch:rule>
         </constraint>

--- a/P5/Source/Specs/att.typed.xml
+++ b/P5/Source/Specs/att.typed.xml
@@ -6,14 +6,15 @@
   <desc versionDate="2007-12-20" xml:lang="ko">요소의 분류 또는 하위분류에서 사용될 수 있는 속성을 제공한다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">提供可依任何方法將元素分類或次要分類的一般屬性。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">要素を分類するための属性を示す。</desc>
-  <desc versionDate="2009-05-29" xml:lang="fr">fournit des attributs qui peuvent être
-      utilisés pour classer ou interclasser des éléments de n'importe quelle façon.</desc>
+  <desc versionDate="2009-05-29" xml:lang="fr">fournit des attributs qui peuvent être utilisés pour classer ou interclasser des éléments de n'importe quelle façon.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">proporciona atributos genéricos utilizables para cualquier clasificación o subclasificación de elementos.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">assegna degli attributi generici utilizzabili per qualsiasi classificazione e sottoclassificazione di elementi.</desc>
   <constraintSpec scheme="schematron" ident="subtypeTyped" xml:lang="en">
     <constraint>
       <sch:rule context="tei:*[@subtype]">
-        <sch:assert test="@type">The <sch:name/> element should not be categorized in detail with @subtype unless also categorized in general with @type</sch:assert>
+        <sch:assert test="@type">
+          The &lt;<sch:name/>> element should not be categorized in detail with @subtype unless also categorized in general with @type.
+        </sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>
@@ -22,8 +23,7 @@
       <!-- Any time changes are made to this @type attribute, you should change the definitions in att.entryLike 
            and att.textCritical if needed for consistency.
        -->
-      <desc versionDate="2005-10-10" xml:lang="en">characterizes the element in some sense, using any convenient
- classification scheme or typology.</desc>
+      <desc versionDate="2005-10-10" xml:lang="en">characterizes the element in some sense, using any convenient classification scheme or typology.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">다양한 분류 스키마 또는 유형을 사용해서 요소의 특성을 기술한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">用合適的分類標準或類型來描述該元素。</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">当該要素の分類を示す。</desc>
@@ -48,8 +48,8 @@
       </exemplum>
       <remarks versionDate="2012-04-21" xml:lang="en">
         <p>The <att>type</att> attribute is present on a number of
-	elements, not all of which are members of <ident type="class">att.typed</ident>, usually because these elements
-	restrict the possible values for the attribute in a specific way.</p>
+        elements, not all of which are members of <ident type="class">att.typed</ident>, usually because these elements
+        restrict the possible values for the attribute in a specific way.</p>
       </remarks>
     </attDef>
     <attDef ident="subtype" usage="opt">
@@ -59,8 +59,7 @@
       <desc versionDate="2007-12-20" xml:lang="ko">필요하다면 요소의 하위범주를 제시한다.</desc>
       <desc versionDate="2007-05-02" xml:lang="zh-TW">若有需要，提供該元素的次要分類</desc>
       <desc versionDate="2008-04-05" xml:lang="ja">必要であれば、当該要素の下位分類を示す。</desc>
-      <desc versionDate="2007-06-12" xml:lang="fr">fournit une sous-catégorisation de l'élément, si
-          c'est nécessaire.</desc>
+      <desc versionDate="2007-06-12" xml:lang="fr">fournit une sous-catégorisation de l'élément, si c'est nécessaire.</desc>
       <desc versionDate="2007-05-04" xml:lang="es">proporciona, si es necesario, una subcategorización del elemento.</desc>
       <desc versionDate="2007-01-21" xml:lang="it">stabilisce, se necessario, una sottocategorizzazione dell'elemento.</desc>
       <datatype><dataRef key="teidata.enumerated"/></datatype>
@@ -80,7 +79,7 @@ sub-classification for the element additional to that provided by its
       </remarks>
       <remarks versionDate="2008-04-05" xml:lang="ja">
         <p>
-	属性<att>subtype</att>は、属性<att>type</att>に加えて、当該要
+        属性<att>subtype</att>は、属性<att>type</att>に加えて、当該要
     素の下位分類を示すために使われる。
     </p>
       </remarks>

--- a/P5/Source/Specs/attDef.xml
+++ b/P5/Source/Specs/attDef.xml
@@ -47,10 +47,11 @@
                        or tei:datatype
                        or tei:valList[ @type eq 'closed']">
           Attribute: the definition of the @<sch:value-of select="@ident"/> attribute in the
-          <sch:value-of select="ancestor::*[@ident][1]/@ident"/>
-          <sch:value-of select="'&#x20;'"/>
-          <sch:value-of select="local-name(ancestor::*[@ident][1])"/> should
-          have a closed valList or a datatype
+          "<sch:value-of select="ancestor::*[@ident][1]/@ident"/>"
+          <sch:value-of select="'&#x20;&lt;'"/>
+          <sch:value-of select="local-name(ancestor::*[@ident][1])"/>>
+          should have a child &lt;valList> with a @type of "closed" or
+          a child &lt;datatype>.
         </sch:assert>
       </sch:rule>
     </constraint>
@@ -58,7 +59,7 @@
   <constraintSpec ident="noDefault4Required" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:attDef[@usage eq 'req']">
-        <sch:report test="tei:defaultVal">Since the @<sch:value-of select="@ident"/> attribute is required, it will always be specified. Thus the default value (of "<sch:value-of select="normalize-space(tei:defaultVal)"/>") will never be used. Either change the definition of the attribute so it is not required ("rec" or "opt"), or remove the defaultVal element.</sch:report>
+        <sch:report test="tei:defaultVal">Since the @<sch:value-of select="@ident"/> attribute is required, it will always be specified. Thus the default value (of "<sch:value-of select="normalize-space(tei:defaultVal)"/>") will never be used. Either change the definition of the attribute so it is not required ("rec" or "opt"), or remove the &lt;defaultVal> element.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>
@@ -79,10 +80,10 @@
                                      and tei:valList[ @type eq 'closed']
                                      and tei:datatype[ @maxOccurs &gt; 1  or  @minOccurs &gt; 1  or  @maxOccurs eq 'unbounded']
                                    ]">
-        <sch:assert test="tokenize(normalize-space(tei:defaultVal),'&#x20;') = tei:valList/tei:valItem/@ident">In the <sch:value-of select="local-name(ancestor::*[@ident][1])"/> defining
-        <sch:value-of select="ancestor::*[@ident][1]/@ident"/> the default value of the
+        <sch:assert test="tokenize(normalize-space(tei:defaultVal),'&#x20;') = tei:valList/tei:valItem/@ident">In the &lt;<sch:value-of select="local-name(ancestor::*[@ident][1])"/>> defining
+        "<sch:value-of select="ancestor::*[@ident][1]/@ident"/>" the default value of the
         @<sch:value-of select="@ident"/> attribute is not among the closed list of possible
-        values</sch:assert>
+        values.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>
@@ -95,10 +96,13 @@
                                         or  ( if ( @maxOccurs castable as xs:integer ) then ( @maxOccurs cast as xs:integer eq 1 ) else false() )
                                                      ]
                                    ]">
-        <sch:assert test="string(tei:defaultVal) = tei:valList/tei:valItem/@ident">In the <sch:value-of select="local-name(ancestor::*[@ident][1])"/> defining
-        <sch:value-of select="ancestor::*[@ident][1]/@ident"/> the default value of the
-        @<sch:value-of select="@ident"/> attribute is not among the closed list of possible
-        values</sch:assert>
+        <sch:assert test="string(tei:defaultVal) = tei:valList/tei:valItem/@ident">
+          In the &lt;<sch:value-of
+          select="local-name(ancestor::*[@ident][1])"/>> defining
+          "<sch:value-of select="ancestor::*[@ident][1]/@ident"/>" the
+          default value of the @<sch:value-of select="@ident"/>
+          attribute is not among the closed list of possible
+          values.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/constraint.xml
+++ b/P5/Source/Specs/constraint.xml
@@ -20,7 +20,7 @@
       <constraintSpec ident="isoconstraint" scheme="schematron">
         <constraint>
           <sch:rule context="tei:constraint">
-            <sch:assert test="tei:fileDesc/tei:titleStmt/tei:title[ @type eq 'main']">a main title must be supplied</sch:assert>
+            <sch:assert test="tei:fileDesc/tei:titleStmt/tei:title[ @type eq 'main']">A main title must be supplied.</sch:assert>
           </sch:rule>
         </constraint>
       </constraintSpec>

--- a/P5/Source/Specs/constraintSpec.xml
+++ b/P5/Source/Specs/constraintSpec.xml
@@ -45,9 +45,9 @@
     <constraint>
       <sch:rule context="tei:constraintSpec">
         <sch:report test="tei:constraint/sch1x:* and @scheme = ('isoschematron','schematron')">Rules
-        in the Schematron 1.* language must be inside a constraintSpec
-        with a value other than 'schematron' or 'isoschematron' on the
-        scheme attribute</sch:report>
+        in the Schematron 1.* language must be inside a &lt;constraintSpec>
+        with a value other than "schematron" or "isoschematron" on the
+        @scheme attribute.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>
@@ -56,8 +56,8 @@
     <constraint>
       <sch:rule context="tei:constraintSpec[ @mode = ('add','replace') or not( @mode ) ]">
         <sch:report test="tei:constraint/sch:* and not( @scheme eq 'schematron')">Rules
-          in the ISO Schematron language must be inside a constraintSpec
-          with the value 'schematron' on the scheme attribute</sch:report>
+          in the ISO Schematron language must be inside a &lt;constraintSpec>
+          with the value "schematron" on the @scheme attribute.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>
@@ -74,8 +74,8 @@
       <sch:rule context="(tei:constraintSpec|tei:constraintDecl)[ @scheme eq 'schematron'][ .//sch:assert | .//sch:report ]">
         <sch:let name="assertsHaveContext" value="for $a in .//sch:assert return exists( $a/ancestor::sch:rule/@context )"/>
         <sch:let name="reportsHaveContext" value="for $r in .//sch:report return exists( $r/ancestor::sch:rule/@context )"/>
-        <sch:report test="( $assertsHaveContext, $reportsHaveContext ) = false()">An &lt;sch:assert&gt; or &lt;sch:report&gt;
-          element must be a descendant of an &lt;sch:rule&gt; that has a @context; one or more inside this
+        <sch:report test="( $assertsHaveContext, $reportsHaveContext ) = false()">An &lt;sch:assert> or &lt;sch:report>
+          element must be a descendant of an &lt;sch:rule> that has a @context; one or more inside this
           <sch:value-of select="local-name(.)"/> are not.</sch:report>
       </sch:rule>
     </constraint>
@@ -85,7 +85,9 @@
       <sch:rule context="tei:constraintSpec[ @mode eq 'add' or not( @mode ) ]">
         <sch:let name="myIdent" value="normalize-space(@ident)"/>
         <sch:report test="preceding::tei:constraintSpec[ normalize-space(@ident) eq $myIdent ]">
-        The @ident of 'constraintSpec' should be unique; this one (<sch:value-of select="$myIdent"/>) is the same as that of a previous 'constraintSpec'.
+        The @ident of &lt;constraintSpec> should be unique; this one
+        (<sch:value-of select="$myIdent"/>) is the same as that of a
+        previous &lt;constraintSpec>.
         </sch:report>
       </sch:rule>
     </constraint>
@@ -105,7 +107,10 @@
       <constraintSpec scheme="schematron" ident="usage_based_on_mode" xml:lang="en">
         <constraint>
           <sch:rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]">
-            <sch:assert test="@scheme">The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is <sch:value-of select="if (@mode) then concat('&quot;',@mode,'&quot;') else 'not specified'"/> (here on "<sch:value-of select="@ident"/>")</sch:assert>
+            <sch:assert test="@scheme">
+            The @scheme attribute of &lt;constraintSpec> is required when the @mode is
+            <sch:value-of select="if (@mode) then concat('&quot;',@mode,'&quot;') else 'not specified'"/>
+            (here on "<sch:value-of select="@ident"/>").</sch:assert>
           </sch:rule>
         </constraint>
       </constraintSpec>
@@ -173,7 +178,7 @@
           <sch:rule context="tei:figure">
             <sch:report test="not( tei:figDesc | tei:head )">You should
             provide information in a figure from which
-            we can construct an alt attribute in HTML</sch:report>
+            we can construct an @alt attribute in HTML.</sch:report>
           </sch:rule>
         </constraint>
       </constraintSpec>

--- a/P5/Source/Specs/dimensions.xml
+++ b/P5/Source/Specs/dimensions.xml
@@ -31,13 +31,13 @@
     <constraint>
       <sch:rule context="tei:dimensions">
         <sch:report test="count(tei:width) gt 1">
-          The element <sch:name/> may appear once only
+          The element &lt;<sch:name/>> may appear once only.
         </sch:report>
         <sch:report test="count(tei:height) gt 1">
-          The element <sch:name/> may appear once only
+          The element &lt;<sch:name/>> may appear once only.
         </sch:report>
         <sch:report test="count(tei:depth) gt 1">
-          The element <sch:name/> may appear once only
+          The element &lt;<sch:name/>> may appear once only.
         </sch:report>
       </sch:rule>
     </constraint>
@@ -63,8 +63,7 @@
           <desc versionDate="2007-01-21" xml:lang="it">le dimensioni si riferiscono a uno o più fogli (per esempio un foglio, una raccolta, o una parte rilegata separatamente).</desc>
         </valItem>
         <valItem ident="ruled">
-          <desc versionDate="2007-06-27" xml:lang="en">dimensions relate to the area of a leaf which has been ruled in
-preparation for writing.</desc>
+          <desc versionDate="2007-06-27" xml:lang="en">dimensions relate to the area of a leaf which has been ruled in preparation for writing.</desc>
           <desc versionDate="2007-12-20" xml:lang="ko">글쓰기를 준비하기 위해 줄 그은 종이 부분과 관련된 차원</desc>
           <desc versionDate="2007-05-02" xml:lang="zh-TW">頁面上劃好線以備書寫的範圍大小。</desc>
           <desc versionDate="2008-04-06" xml:lang="es">las dimensiones se refieren al área de una hoja que se ha preparado para la escritura.</desc>

--- a/P5/Source/Specs/interleave.xml
+++ b/P5/Source/Specs/interleave.xml
@@ -14,7 +14,7 @@
   <constraintSpec ident="interleavechilden" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:interleave">
-        <sch:assert test="count(*) gt 1">The interleave element must have at least two child elements</sch:assert>
+        <sch:assert test="count(*) gt 1">The &lt;interleave> element must have at least two child elements.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/join.xml
+++ b/P5/Source/Specs/join.xml
@@ -28,7 +28,7 @@
     <constraint>
       <sch:rule context="tei:join">
         <sch:assert test="contains( normalize-space( @target ),' ')">
-          You must supply at least two values for @target on <sch:name/>
+          You must supply at least two values for @target on &lt;<sch:name/>>.
         </sch:assert>
       </sch:rule>
     </constraint>

--- a/P5/Source/Specs/link.xml
+++ b/P5/Source/Specs/link.xml
@@ -22,16 +22,16 @@
   <constraintSpec ident="linkTargets3" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:link">
-        <sch:assert test="contains(normalize-space(@target),' ')">You must supply at least two values for @target or  on <sch:name/></sch:assert>
+        <sch:assert test="contains(normalize-space(@target),'&#x20;')">You must supply at least two values for @target on &lt;<sch:name/>>.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-link-egXML-rx">
       <s n="1">The state Supreme Court has refused to release <rs xml:id="R1"><rs xml:id="R2">Rahway State Prison</rs> inmate</rs> 
-            <rs xml:id="R3">James Scott</rs> on bail.</s>
+        <rs xml:id="R3">James Scott</rs> on bail.</s>
       <s n="2"><rs xml:id="R4">The fighter</rs> is serving 30-40 years
-      for a 1975 armed robbery conviction in <rs xml:id="R5">the penitentiary</rs>.</s>
+        for a 1975 armed robbery conviction in <rs xml:id="R5">the penitentiary</rs>.</s>
       <!-- ... -->
       <linkGrp type="periphrasis">
         <link target="#R1 #R3 #R4"/>

--- a/P5/Source/Specs/list.xml
+++ b/P5/Source/Specs/list.xml
@@ -10,11 +10,9 @@
   <desc versionDate="2007-05-02" xml:lang="zh-TW">包含以列表方式呈現的任何連續項目。</desc>
   <desc versionDate="2008-04-05" xml:lang="ja">リストのような、項目列を示す。</desc>
   <desc versionDate="2007-06-12" xml:lang="fr">contient une suite d'items ordonnés dans une liste.</desc>
-  <desc versionDate="2007-05-04" xml:lang="es">contiene cualquier secuencia de ítems o elementos
-    organizados en una lista.</desc>
-  <desc versionDate="2007-01-21" xml:lang="it">contiene una qualsiasi sequenza di voci organizzate in
-    una lista.</desc>
-    <desc versionDate="2016-11-25" xml:lang="de">enthält eine Reihe von Listenpunkten, die als Liste organisiert sind.</desc>
+  <desc versionDate="2007-05-04" xml:lang="es">contiene cualquier secuencia de ítems o elementos organizados en una lista.</desc>
+  <desc versionDate="2007-01-21" xml:lang="it">contiene una qualsiasi sequenza di voci organizzate in una lista.</desc>
+  <desc versionDate="2016-11-25" xml:lang="de">enthält eine Reihe von Listenpunkten, die als Liste organisiert sind.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.cmc"/>
@@ -22,71 +20,58 @@
     <memberOf key="att.typed"/>
     <memberOf key="model.listLike"/>
   </classes>
-  <!-- 	    <rng:zeroOrMore>
+  <!--      <rng:zeroOrMore>
               <rng:ref name="model.global"/>
               </rng:zeroOrMore> -->
-  <!-- The removal of this component (and the same one after <headItem> is-->
-  <!-- wrong, and breaks the content model. The right thing to do, IMHO,-->
-  <!-- is to leave these in, and either-->
-  <!-- * improve the ODD -> DTD process so that it does the right thing-->
-  <!--   (which would probably be very hard)-->
-  <!-- * require the user to fix the content model if & when she removes-->
-  <!--   <headItem> or <headLabel>-->
-  <!-- I haven't fixed this particular instance yet, because we hope to-->
-  <!-- completely revamp the content of <list>, anyway, hopefully-->
-  <!-- removing the special-purpose <headItem> and <headLabel>. -Syd -->
+  <!--
+      The removal of this component (and the same one after <headItem> is
+      wrong, and breaks the content model. The right thing to do, IMHO,
+      is to leave these in, and either
+      * improve the ODD -> DTD process so that it does the right thing
+      (which would probably be very hard)
+      * require the user to fix the content model if & when she removes
+      <headItem> or <headLabel>
+      I haven't fixed this particular instance yet, because we hope to
+      completely revamp the content of <list>, anyway, hopefully
+      removing the special-purpose <headItem> and <headLabel>. —Syd
+  -->
   <content>
     <sequence>
-      
-        <alternate minOccurs="0" maxOccurs="unbounded">
-          
-            <classRef key="model.divTop"/>
-            <classRef key="model.global"/>
-            <elementRef key="desc" minOccurs="0" maxOccurs="unbounded"/>          
-        </alternate>
-      
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.divTop"/>
+        <classRef key="model.global"/>
+        <elementRef key="desc" minOccurs="0" maxOccurs="unbounded"/>          
+      </alternate>      
       <alternate>
         <sequence minOccurs="1" maxOccurs="unbounded">
           <elementRef key="item"/>
-          
-            <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-          
+          <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
         </sequence>
         <sequence>
-          
-            <elementRef key="headLabel" minOccurs="0"/>
-          
-          
-            <elementRef key="headItem" minOccurs="0"/>
-          
+          <elementRef key="headLabel" minOccurs="0"/>
+          <elementRef key="headItem" minOccurs="0"/>
           <sequence minOccurs="1" maxOccurs="unbounded">
             <elementRef key="label"/>
-            
-              <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-            
+            <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
             <elementRef key="item"/>
-            
-              <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-            
+            <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
           </sequence>
         </sequence>
       </alternate>
-      
-        <sequence minOccurs="0" maxOccurs="unbounded">
-          
-            <classRef key="model.divBottom"/>
-          
-          
-            <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
-          
-        </sequence>
-      
+      <sequence minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.divBottom"/>
+        <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
+      </sequence>
     </sequence>
   </content>
   <constraintSpec xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="gloss-list-must-have-labels" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:list[@type='gloss']">
-	<sch:assert test="tei:label">The content of a "gloss" list should include a sequence of one or more pairs of a label element followed by an item element</sch:assert>
+        <sch:assert test="tei:label">
+          The content of a "gloss" list should include a sequence of
+          one or more pairs of a &lt;label> element followed by an
+          &lt;item> element.
+        </sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>
@@ -96,7 +81,6 @@
         @type and the new recommendation to use @rend, but the general consensus is that providing suggestions
         in the prose is better than formalizing them in the ODD.
     -->
-    
     <attDef ident="type" usage="opt" mode="change">
       <gloss versionDate="2017-06-25" xml:lang="en">type</gloss>
       <gloss versionDate="2017-06-25" xml:lang="de">Typ</gloss>
@@ -193,7 +177,7 @@
         <item>a butcher</item>
         <item>a baker</item>
         <item>a candlestick maker, with 
-	  <list rend="bulleted"><item>rings on his fingers</item><item>bells on his toes</item></list>
+          <list rend="bulleted"><item>rings on his fingers</item><item>bells on his toes</item></list>
             </item>
       </list>
     </egXML>

--- a/P5/Source/Specs/model.xml
+++ b/P5/Source/Specs/model.xml
@@ -2,8 +2,7 @@
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="gi-model" ident="model" module="tagdocs">
-  <desc versionDate="2015-05-15" xml:lang="en">describes the processing intended for a specified
-    element.</desc>
+  <desc versionDate="2015-05-15" xml:lang="en">describes the processing intended for a specified element.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.predicate"/>
@@ -19,9 +18,7 @@
     </sequence>
   </content>
   <constraintSpec scheme="schematron" ident="no_dup_default_models" xml:lang="en">
-    <desc versionDate="2016-10-01" xml:lang="en">It is ambigous to have 2 <gi>model</gi>s
-      that have both the same <att>output</att> and have no <att>predicate</att>
-      (and thus select the same set of nodes).</desc>
+    <desc versionDate="2016-10-01" xml:lang="en">It is ambigous to have 2 <gi>model</gi>s that have both the same <att>output</att> and have no <att>predicate</att> (and thus select the same set of nodes).</desc>
     <!-- We cannot possibly check, in general, that two
          <att>predicate</att>s select the same set of nodes or not.
          But if two <att>predicate</att>s are equal (or two
@@ -31,9 +28,11 @@
       <sch:rule context="tei:model[ not( parent::tei:modelSequence ) ][ not( @predicate ) ]">
         <sch:let name="output" value="normalize-space( @output )"/>
         <sch:report test="following-sibling::tei:model [ not( @predicate )] [ normalize-space( @output ) eq $output ]">
-          There are 2 (or more) 'model' elements in this '<sch:value-of select="local-name(..)"/>'
-          that have no predicate, but are targeted to the same output
-          ("<sch:value-of select="( $output, parent::modelGrp/@output, 'all')[1]"/>")</sch:report>
+          There are 2 (or more) &lt;model> elements in this
+          &lt;<sch:value-of select="local-name(..)"/>> that have no
+          predicate, but are targeted to the same output
+          ("<sch:value-of select="( $output, parent::modelGrp/@output, 'all')[1]"/>").
+        </sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>
@@ -46,25 +45,23 @@
         <sch:let name="predicate" value="normalize-space( @predicate )"/>
         <sch:let name="output" value="normalize-space( @output )"/>
         <sch:report test="following-sibling::tei:model [ normalize-space( @predicate ) eq $predicate ] [ normalize-space( @output ) eq $output ]">
-          There are 2 (or more) 'model' elements in this
-          '<sch:value-of select="local-name(..)"/>' that have
+          There are 2 (or more) &lt;model> elements in this
+          &lt;<sch:value-of select="local-name(..)"/>> that have
           the same predicate, and are targeted to the same output
-          ("<sch:value-of select="( $output, parent::modelGrp/@output, 'all')[1]"/>")</sch:report>
+          ("<sch:value-of select="( $output, parent::modelGrp/@output, 'all')[1]"/>").
+        </sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>
   <attList>
     <attDef ident="behaviour" usage="req">
-      <desc versionDate="2015-08-21" xml:lang="en">names the process or function which this
-        processing model uses in order to produce output.</desc>
+      <desc versionDate="2015-08-21" xml:lang="en">names the process or function which this processing model uses in order to produce output.</desc>
       <datatype>
         <dataRef key="teidata.enumerated"/>
       </datatype>
       <valList type="semi">
         <valItem ident="alternate">
-          <desc versionDate="2015-08-21" xml:lang="en">support display of alternative
-            visualisations, for example by displaying the preferred content, by displaying both in
-            parallel, or by toggling between the two.</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">support display of alternative visualisations, for example by displaying the preferred content, by displaying both in parallel, or by toggling between the two.</desc>
           <paramList>
             <paramSpec ident="default">
               <desc versionDate="2015-08-21" xml:lang="en">supplies the preferred content</desc>
@@ -75,12 +72,10 @@
           </paramList>
         </valItem>
         <valItem ident="anchor">
-          <desc versionDate="2015-08-21" xml:lang="en">create an identifiable anchor point in the
-            output.</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">create an identifiable anchor point in the output.</desc>
           <paramList>
             <paramSpec ident="id">
-              <desc versionDate="2016-01-22" xml:lang="en">supplies an identifier for the anchor
-                point</desc>
+              <desc versionDate="2016-01-22" xml:lang="en">supplies an identifier for the anchor point</desc>
             </paramSpec>
           </paramList>
           <!-- why wouldnt this be xml:id ? -->
@@ -100,8 +95,7 @@
           </paramList>
         </valItem>
         <valItem ident="break">
-          <desc versionDate="2015-08-21" xml:lang="en">create a line, column, or page break
-            according to the value of <ident>type</ident></desc>
+          <desc versionDate="2015-08-21" xml:lang="en">create a line, column, or page break according to the value of <ident>type</ident></desc>
           <paramList>
             <paramSpec ident="type"/>
             <paramSpec ident="label"/>
@@ -144,8 +138,7 @@
           </paramList>
         </valItem>
         <valItem ident="graphic">
-          <desc versionDate="2015-08-21" xml:lang="en">if <ident>url</ident> is present, uses it to
-            display graphic, else display a placeholder image.</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">if <ident>url</ident> is present, uses it to display graphic, else display a placeholder image.</desc>
           <equiv name="img"/>
           <paramList>
             <paramSpec ident="url">
@@ -161,8 +154,7 @@
               <desc versionDate="2015-08-21" xml:lang="en">scaling for image</desc>
             </paramSpec>
             <paramSpec ident="title">
-              <desc versionDate="2015-08-21" xml:lang="en">title of figure (usually not displayed
-                directly)</desc>
+              <desc versionDate="2015-08-21" xml:lang="en">title of figure (usually not displayed directly)</desc>
             </paramSpec>
           </paramList>
         </valItem>
@@ -175,17 +167,15 @@
           </paramList>
         </valItem>
         <valItem ident="index">
-          <desc versionDate="2015-08-21" xml:lang="en">generate list according to
-              <ident>type</ident>.</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">generate list according to <ident>type</ident>.</desc>
           <paramList>
             <paramSpec ident="type"/>
           </paramList>
         </valItem>
         <valItem ident="inline">
-          <desc versionDate="2015-08-21" xml:lang="en">creates inline element out of
-              <ident>content</ident>
-            <!--if there's something in <gi>outputRendition</gi>, use that
-            formatting otherwise just show text of selected content.--></desc>
+          <desc versionDate="2015-08-21" xml:lang="en">creates inline element out of <ident>content</ident></desc>
+          <!--if there's something in <gi>outputRendition</gi>, use that
+              formatting otherwise just show text of selected content.-->
           <equiv name="span"/>
           <paramList>
             <paramSpec ident="content"/>
@@ -228,8 +218,7 @@
           </paramList>
         </valItem>
         <valItem ident="note">
-          <desc versionDate="2015-08-21" xml:lang="en">create a note, often out of line, depending
-            on the value of <ident>place</ident>; could be margin, footnote, endnote, inline</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">create a note, often out of line, depending on the value of <ident>place</ident>; could be margin, footnote, endnote, inline</desc>
           <paramList>
             <paramSpec ident="content"/>
             <paramSpec ident="place"/>
@@ -240,8 +229,7 @@
           <desc versionDate="2015-08-21" xml:lang="en">do nothing, do not process children</desc>
         </valItem>
         <valItem ident="paragraph">
-          <desc versionDate="2015-08-21" xml:lang="en">create a paragraph out of
-              <ident>content</ident>.</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">create a paragraph out of <ident>content</ident>.</desc>
           <equiv name="p"/>
           <paramList>
             <paramSpec ident="content"/>
@@ -256,8 +244,7 @@
           </paramList>
         </valItem>
         <valItem ident="section">
-          <desc versionDate="2015-08-21" xml:lang="en">create a new section of the output
-            document</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">create a new section of the output document</desc>
           <paramList>
             <paramSpec ident="content"/>
           </paramList>
@@ -285,8 +272,7 @@
       </valList>
     </attDef>
     <attDef ident="useSourceRendition" usage="opt">
-      <desc versionDate="2015-08-21" xml:lang="en">whether to obey any rendition attribute that is
-        present.</desc>
+      <desc versionDate="2015-08-21" xml:lang="en">whether to obey any rendition attribute that is present.</desc>
       <datatype>
         <dataRef key="teidata.truthValue"/>
       </datatype>
@@ -303,26 +289,21 @@
       </datatype>
       <valList type="open">
         <valItem ident="web">
-          <desc versionDate="2015-08-21" xml:lang="en">the output is intended for presentation in a
-            web format</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">the output is intended for presentation in a web format</desc>
         </valItem>
         <valItem ident="print">
-          <desc versionDate="2015-08-21" xml:lang="en">the output is intended for presentation in a
-            print format</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">the output is intended for presentation in a print format</desc>
         </valItem>
         <valItem ident="plain">
-          <desc versionDate="2015-08-21" xml:lang="en">the output is intended for presentation in a
-            plain text format</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">the output is intended for presentation in a plain text format</desc>
         </valItem>
       </valList>
       <remarks versionDate="2016-02-23" xml:lang="en">
-        <p>If the <att>output</att> attribute is not specified, this model is assumed to apply for
-          all forms of output. </p>
+        <p>If the <att>output</att> attribute is not specified, this model is assumed to apply for all forms of output.</p>
       </remarks>
     </attDef>
     <attDef ident="cssClass" usage="opt">
-      <desc versionDate="2015-08-21" xml:lang="en">the name of a CSS class which should be
-        associated with this element</desc>
+      <desc versionDate="2015-08-21" xml:lang="en">the name of a CSS class which should be associated with this element</desc>
       <datatype maxOccurs="unbounded">
         <dataRef key="teidata.name"/>
       </datatype>
@@ -337,12 +318,10 @@
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-model-egXML-hb">
       <elementSpec mode="change" ident="quote">
         <model predicate="ancestor::p" behaviour="inline">
-          <desc versionDate="2015-08-21" xml:lang="en">If it's inside a paragraph then it's
-            inline</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">If it's inside a paragraph then it's inline</desc>
         </model>
         <model predicate="not(ancestor::p)" behaviour="block">
-          <desc versionDate="2015-08-21" xml:lang="en">If it's not inside a paragraph then it is
-            block level</desc>
+          <desc versionDate="2015-08-21" xml:lang="en">If it's not inside a paragraph then it is block level</desc>
         </model>
       </elementSpec>
     </egXML>
@@ -350,8 +329,7 @@
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-model-egXML-qy">
       <model predicate="parent::person" behaviour="inline">
-        <desc versionDate="2015-08-21" xml:lang="en">If it is a child of a person element, treat as
-          inline</desc>
+        <desc versionDate="2015-08-21" xml:lang="en">If it is a child of a person element, treat as inline</desc>
       </model>
     </egXML>
   </exemplum>

--- a/P5/Source/Specs/modelSequence.xml
+++ b/P5/Source/Specs/modelSequence.xml
@@ -18,9 +18,9 @@
   <constraintSpec scheme="schematron" ident="no_outputs_nor_predicates_4_my_kids" xml:lang="en">
     <constraint>
       <sch:rule context="tei:modelSequence">
-        <sch:report test="tei:model[@output]" role="warning">The 'model' children
-        of a 'modelSequence' element inherit the @output attribute of the
-        parent 'modelSequence', and thus should not have their own</sch:report>
+        <sch:report test="tei:model[@output]" role="warning">The &lt;model> children
+        of a &lt;modelSequence> element inherit the @output attribute of the
+        parent &lt;modelSequence>, and thus should not have their own.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/moduleRef.xml
+++ b/P5/Source/Specs/moduleRef.xml
@@ -25,7 +25,7 @@
     <constraint>
       <sch:rule context="tei:moduleRef">
         <sch:report test="* and @key">
-          Child elements of <sch:name/> are only allowed when an external module is being loaded
+          Child elements of &lt;<sch:name/>> are only allowed when an external module is being loaded.
         </sch:report>
       </sch:rule>
     </constraint>
@@ -37,16 +37,17 @@
       <constraintSpec scheme="schematron" ident="not-same-prefix" xml:lang="en">
         <constraint>
           <sch:rule context="tei:moduleRef">
-            <sch:report test="//*[ not( generate-id(.) eq generate-id( current() ) ) ]/@prefix = @prefix">The prefix attribute
-            of <sch:name/> should not match that of any other
-            element (it would defeat the purpose)</sch:report>
+            <sch:report test="//*[ not( generate-id(.) eq generate-id( current() ) ) ]/@prefix = @prefix">
+              The @prefix attribute of &lt;<sch:name/>> should not
+              match that of any other element (it would defeat the
+              purpose).</sch:report>
           </sch:rule>
         </constraint>
       </constraintSpec>
       <constraintSpec scheme="schematron" ident="not-except-and-include" xml:lang="en">
         <constraint>
           <sch:rule context="tei:moduleRef">
-            <sch:report test="@except and @include">It is an error to supply both the @include and @except attributes</sch:report>
+            <sch:report test="@except and @include">It is an error to supply both the @include and @except attributes.</sch:report>
           </sch:rule>
         </constraint>
       </constraintSpec>

--- a/P5/Source/Specs/quotation.xml
+++ b/P5/Source/Specs/quotation.xml
@@ -31,7 +31,7 @@
     <constraint>
       <sch:rule context="tei:quotation">
         <sch:report test="not( @marks )  and  not( tei:p )">
-          On <sch:name/>, either the @marks attribute should be used, or a paragraph of description provided
+          On &lt;<sch:name/>>, either the @marks attribute should be used, or a paragraph of description provided.
         </sch:report>
       </sch:rule>
     </constraint>

--- a/P5/Source/Specs/rdgGrp.xml
+++ b/P5/Source/Specs/rdgGrp.xml
@@ -11,8 +11,7 @@
   <desc versionDate="2005-01-14" xml:lang="en">within a textual variation, groups two or more readings perceived to have a genetic relationship or other affinity.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">텍스트 변이형 내에서 계통 관계 또는 유사 관계로 이해되는 둘 이상의 독법을 모아 놓는다.</desc>
   <desc versionDate="2007-05-02" xml:lang="zh-TW">原文變異中，匯集兩個或多個認為具有根源關係或於其他方面性質類似的對應本。</desc>
-  <desc versionDate="2008-04-05" xml:lang="ja">異なるテキストで、系統関係や類縁性があるとされる、二つ以上の読みをま
-  とめる。</desc>
+  <desc versionDate="2008-04-05" xml:lang="ja">異なるテキストで、系統関係や類縁性があるとされる、二つ以上の読みをま とめる。</desc>
   <desc versionDate="2007-06-12" xml:lang="fr">regroupe deux leçons ou plus qui sont perçues comme ayant une relation génétique ou une autre affinité.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">agrupa al interno de una variante textual dos o más lecturas consideradas emparentadas o afines.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">all'interno di una variante testuale raggruppa due o più letture considerate imparentate o affini.</desc>
@@ -35,7 +34,7 @@
   <constraintSpec scheme="schematron" ident="only1lem" xml:lang="en">
     <constraint xmlns:sch="http://purl.oclc.org/dsdl/schematron">
       <sch:rule context="tei:rdgGrp">
-        <sch:assert test="count(tei:lem) lt 2">Only one &lt;lem&gt; element may appear within a &lt;rdgGrp&gt;</sch:assert>
+        <sch:assert test="count(tei:lem) lt 2">Only one &lt;lem> element may appear within a &lt;rdgGrp>.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/relatedItem.xml
+++ b/P5/Source/Specs/relatedItem.xml
@@ -24,8 +24,8 @@
   <constraintSpec ident="targetorcontent1" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:relatedItem">
-        <sch:report test="@target and count( child::* ) &gt; 0">If the @target attribute on <sch:name/> is used, the relatedItem element must be empty</sch:report>
-        <sch:assert test="@target or child::*">A relatedItem element should have either a @target attribute or a child element to indicate the related bibliographic item</sch:assert>
+        <sch:report test="@target and count( child::* ) &gt; 0">If the @target attribute on <sch:name/> is used, the relatedItem element must be empty.</sch:report>
+        <sch:assert test="@target or child::*">A relatedItem element should have either a @target attribute or a child element to indicate the related bibliographic item.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/relation.xml
+++ b/P5/Source/Specs/relation.xml
@@ -29,7 +29,7 @@
   <constraintSpec ident="ref-or-key-or-name" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:relation">
-        <sch:assert test="@ref or @key or @name">One of the attributes @name, @ref or @key must be supplied</sch:assert>
+        <sch:assert test="@ref or @key or @name">One of the attributes @name, @ref or @key must be supplied.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>
@@ -43,14 +43,14 @@
          — Syd, 2018-05-01 -->
     <constraint>
       <sch:rule context="tei:relation">
-        <sch:report test="@active and @mutual">Only one of the attributes @active and @mutual may be supplied</sch:report>
+        <sch:report test="@active and @mutual">Only one of the attributes @active and @mutual may be supplied.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>
   <constraintSpec ident="active-passive" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:relation">
-        <sch:report test="@passive and not(@active)">the attribute @passive may be supplied only if the attribute @active is supplied</sch:report>
+        <sch:report test="@passive and not(@active)">the attribute @passive may be supplied only if the attribute @active is supplied.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/s.xml
+++ b/P5/Source/Specs/s.xml
@@ -35,7 +35,7 @@
   <constraintSpec ident="noNestedS" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:s">
-        <sch:report test="tei:s">You may not nest one s element within another: use seg instead</sch:report>
+        <sch:report test="tei:s">You may not nest one &lt;s> element within another: use &lt;seg> instead.</sch:report>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/sequence.xml
+++ b/P5/Source/Specs/sequence.xml
@@ -14,7 +14,7 @@
   <constraintSpec ident="sequencechilden" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:sequence">
-        <sch:assert test="count(*) gt 1">The sequence element must have at least two child elements</sch:assert>
+        <sch:assert test="count(*) gt 1">The &lt;sequence> element must have at least two child elements.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Source/Specs/span.xml
+++ b/P5/Source/Specs/span.xml
@@ -23,7 +23,7 @@
     <constraint>
       <sch:rule context="tei:span">
         <sch:report test="@from and @target">
-          Only one of the attributes @target and @from may be supplied on <sch:name/>
+          Only one of the attributes @target and @from may be supplied on &lt;<sch:name/>>.
         </sch:report>
       </sch:rule>
     </constraint>
@@ -32,7 +32,7 @@
     <constraint>
       <sch:rule context="tei:span">
         <sch:report test="@to and @target">
-          Only one of the attributes @target and @to may be supplied on <sch:name/>
+          Only one of the attributes @target and @to may be supplied on &lt;<sch:name/>>.
         </sch:report>
       </sch:rule>
     </constraint>
@@ -41,7 +41,7 @@
     <constraint>
       <sch:rule context="tei:span">
         <sch:report test="@to and not(@from)">
-          If @to is supplied on <sch:name/>, @from must be supplied as well
+          If @to is supplied on &lt;<sch:name/>>, @from must be supplied as well.
         </sch:report>
       </sch:rule>
     </constraint>
@@ -50,7 +50,7 @@
     <constraint>
       <sch:rule context="tei:span">
         <sch:report test="contains(normalize-space(@to),' ') or contains(normalize-space(@from),' ')">
-          The attributes @to and @from on <sch:name/> may each contain only a single value
+          The attributes @to and @from on &lt;<sch:name/>> may each contain only a single value.
         </sch:report>
       </sch:rule>
     </constraint>

--- a/P5/Source/Specs/subst.xml
+++ b/P5/Source/Specs/subst.xml
@@ -30,7 +30,8 @@
   <constraintSpec ident="substContents1" scheme="schematron" xml:lang="en">
     <constraint>
       <sch:rule context="tei:subst">
-        <sch:assert test="child::tei:add and (child::tei:del or child::tei:surplus)"><sch:name/> must have at least one child add and at least one child del or surplus</sch:assert>
+        <sch:assert test="child::tei:add and (child::tei:del or child::tei:surplus)">
+        &lt;<sch:name/>> must have at least one child &lt;add> and at least one child &lt;del> or &lt;surplus>.</sch:assert>
       </sch:rule>
     </constraint>
   </constraintSpec>

--- a/P5/Test/expected-results/detest_odd_schematron.svrl
+++ b/P5/Test/expected-results/detest_odd_schematron.svrl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svrl:schematron-output xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"
-                        xmlns:esp-d2e92362="http://www.example.org/cannot/really/use/XInclude"
-                        xmlns:esp-d2e92419="http://www.example.org/cannot/really/use/XInclude"
+                        xmlns:esp-d2e91928="http://www.example.org/cannot/really/use/XInclude"
+                        xmlns:esp-d2e91985="http://www.example.org/cannot/really/use/XInclude"
                         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                         xmlns:rna="http://relaxng.org/ns/compatibility/annotations/1.0"
                         xmlns:rng="http://relaxng.org/ns/structure/1.0"
@@ -21,9 +21,9 @@
    <svrl:ns-prefix-in-attribute-values prefix="sch" uri="http://purl.oclc.org/dsdl/schematron"/>
    <svrl:ns-prefix-in-attribute-values prefix="sch1x" uri="http://www.ascc.net/xml/schematron"/>
    <svrl:ns-prefix-in-attribute-values prefix="teix" uri="http://www.tei-c.org/ns/Examples"/>
-   <svrl:ns-prefix-in-attribute-values prefix="esp-d2e92362"
+   <svrl:ns-prefix-in-attribute-values prefix="esp-d2e91928"
                                        uri="http://www.example.org/cannot/really/use/XInclude"/>
-   <svrl:ns-prefix-in-attribute-values prefix="esp-d2e92419"
+   <svrl:ns-prefix-in-attribute-values prefix="esp-d2e91985"
                                        uri="http://www.example.org/cannot/really/use/XInclude"/>
    <svrl:metadata xmlns:dct="http://purl.org/dc/terms/"
                   xmlns:skos="http://www.w3.org/2004/02/skos/core#">
@@ -32,7 +32,7 @@
             <skos:prefLabel>SAXON/HE 10.3</skos:prefLabel>
          </dct:Agent>
       </dct:creator>
-      <dct:created>2026-01-02T22:30:53.164511762-05:00</dct:created>
+      <dct:created>2026-05-15T21:09:21.131151Z</dct:created>
       <dct:source>
          <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
             <dct:creator>
@@ -41,16 +41,16 @@
                   <schxslt.compile.typed-variables xmlns="https://doi.org/10.5281/zenodo.1495494#">true</schxslt.compile.typed-variables>
                </dct:Agent>
             </dct:creator>
-            <dct:created>2026-01-02T22:30:16.436963437-05:00</dct:created>
+            <dct:created>2026-05-15T21:08:39.712599Z</dct:created>
          </rdf:Description>
       </dct:source>
    </svrl:metadata>
    <svrl:active-pattern name="schematron-constraint-CMC_generatedBy_within_post-1"
                         id="schematron-constraint-CMC_generatedBy_within_post-1"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-att-datable-w3c-when-2"
                         id="schematron-constraint-att-datable-w3c-when-2"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:*[@when]"/>
    <svrl:fired-rule context="tei:*[@when]"/>
    <svrl:fired-rule context="tei:*[@when]"/>
@@ -61,33 +61,30 @@
    <svrl:fired-rule context="tei:*[@when]"/>
    <svrl:active-pattern name="schematron-constraint-att-datable-w3c-from-3"
                         id="schematron-constraint-att-datable-w3c-from-3"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-att-datable-w3c-to-4"
                         id="schematron-constraint-att-datable-w3c-to-4"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-only_1_ODD_source-5"
                         id="schematron-constraint-only_1_ODD_source-5"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:*[@source]"/>
    <svrl:fired-rule context="tei:*[@source]"/>
-   <svrl:active-pattern name="schematron-constraint-att-measurement-unitRef-6"
-                        id="schematron-constraint-att-measurement-unitRef-6"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-targetLang-7"
-                        id="schematron-constraint-targetLang-7"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-spanTo-points-to-following-8"
-                        id="schematron-constraint-spanTo-points-to-following-8"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-schemeVersionRequiresScheme-9"
-                        id="schematron-constraint-schemeVersionRequiresScheme-9"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-subtypeTyped-10"
-                        id="schematron-constraint-subtypeTyped-10"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-not_in_future-11"
-                        id="schematron-constraint-not_in_future-11"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-targetLang-6"
+                        id="schematron-constraint-targetLang-6"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-spanTo-points-to-following-7"
+                        id="schematron-constraint-spanTo-points-to-following-7"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-schemeVersionRequiresScheme-8"
+                        id="schematron-constraint-schemeVersionRequiresScheme-8"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-subtypeTyped-9"
+                        id="schematron-constraint-subtypeTyped-9"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-not_in_future-10"
+                        id="schematron-constraint-not_in_future-10"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="*[@versionDate]"/>
    <svrl:fired-rule context="*[@versionDate]"/>
    <svrl:fired-rule context="*[@versionDate]"/>
@@ -132,12 +129,12 @@
    <svrl:fired-rule context="*[@versionDate]"/>
    <svrl:fired-rule context="*[@versionDate]"/>
    <svrl:fired-rule context="*[@versionDate]"/>
-   <svrl:active-pattern name="schematron-constraint-calendar_attr_on_empty_element-12"
-                        id="schematron-constraint-calendar_attr_on_empty_element-12"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-p-in-ab-or-p-13"
-                        id="schematron-constraint-abstractModel-structure-p-in-ab-or-p-13"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-calendar_attr_on_empty_element-11"
+                        id="schematron-constraint-calendar_attr_on_empty_element-11"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-p-in-ab-or-p-12"
+                        id="schematron-constraint-abstractModel-structure-p-in-ab-or-p-12"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:p"/>
    <svrl:fired-rule context="tei:p"/>
    <svrl:fired-rule context="tei:p"/>
@@ -164,78 +161,78 @@
    <svrl:fired-rule context="tei:p"/>
    <svrl:fired-rule context="tei:p"/>
    <svrl:fired-rule context="tei:p"/>
-   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-p-in-l-14"
-                        id="schematron-constraint-abstractModel-structure-p-in-l-14"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-deprecationInfo-only-in-deprecated-15"
-                        id="schematron-constraint-deprecationInfo-only-in-deprecated-15"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-rt-target-not-span-16"
-                        id="schematron-constraint-rt-target-not-span-16"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-rt-from-17"
-                        id="schematron-constraint-rt-from-17"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-rt-to-18"
-                        id="schematron-constraint-rt-to-18"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-ptrAtts-19"
-                        id="schematron-constraint-ptrAtts-19"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-p-in-l-13"
+                        id="schematron-constraint-abstractModel-structure-p-in-l-13"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-deprecationInfo-only-in-deprecated-14"
+                        id="schematron-constraint-deprecationInfo-only-in-deprecated-14"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-rt-target-not-span-15"
+                        id="schematron-constraint-rt-target-not-span-15"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-rt-from-16"
+                        id="schematron-constraint-rt-from-16"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-rt-to-17"
+                        id="schematron-constraint-rt-to-17"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-ptrAtts-18"
+                        id="schematron-constraint-ptrAtts-18"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:ptr"/>
-   <svrl:active-pattern name="schematron-constraint-refAtts-20"
-                        id="schematron-constraint-refAtts-20"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-refAtts-19"
+                        id="schematron-constraint-refAtts-19"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:ref"/>
    <svrl:fired-rule context="tei:ref"/>
    <svrl:fired-rule context="tei:ref"/>
    <svrl:fired-rule context="tei:ref"/>
-   <svrl:active-pattern name="schematron-constraint-gloss-list-must-have-labels-21"
-                        id="schematron-constraint-gloss-list-must-have-labels-21"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-targetorcontent1-22"
-                        id="schematron-constraint-targetorcontent1-22"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-l-in-l-23"
-                        id="schematron-constraint-abstractModel-structure-l-in-l-23"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-atleast1oflggapl-24"
-                        id="schematron-constraint-atleast1oflggapl-24"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-lg-in-l-25"
-                        id="schematron-constraint-abstractModel-structure-lg-in-l-25"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-quotationContents-26"
-                        id="schematron-constraint-quotationContents-26"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-citestructure-outer-match-27"
-                        id="schematron-constraint-citestructure-outer-match-27"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-citestructure-inner-match-28"
-                        id="schematron-constraint-citestructure-inner-match-28"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-ref-or-key-or-name-29"
-                        id="schematron-constraint-ref-or-key-or-name-29"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-active-mutual-30"
-                        id="schematron-constraint-active-mutual-30"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-active-passive-31"
-                        id="schematron-constraint-active-passive-31"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-must-have-attglobal-32"
-                        id="schematron-constraint-must-have-attglobal-32"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-div-in-l-33"
-                        id="schematron-constraint-abstractModel-structure-div-in-l-33"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-div-in-ab-or-p-34"
-                        id="schematron-constraint-abstractModel-structure-div-in-ab-or-p-34"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-gloss-list-must-have-labels-20"
+                        id="schematron-constraint-gloss-list-must-have-labels-20"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-targetorcontent1-21"
+                        id="schematron-constraint-targetorcontent1-21"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-l-in-l-22"
+                        id="schematron-constraint-abstractModel-structure-l-in-l-22"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-atleast1oflggapl-23"
+                        id="schematron-constraint-atleast1oflggapl-23"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-lg-in-l-24"
+                        id="schematron-constraint-abstractModel-structure-lg-in-l-24"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-quotationContents-25"
+                        id="schematron-constraint-quotationContents-25"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-citestructure-outer-match-26"
+                        id="schematron-constraint-citestructure-outer-match-26"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-citestructure-inner-match-27"
+                        id="schematron-constraint-citestructure-inner-match-27"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-ref-or-key-or-name-28"
+                        id="schematron-constraint-ref-or-key-or-name-28"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-active-mutual-29"
+                        id="schematron-constraint-active-mutual-29"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-active-passive-30"
+                        id="schematron-constraint-active-passive-30"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-must-have-attglobal-31"
+                        id="schematron-constraint-must-have-attglobal-31"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-div-in-l-32"
+                        id="schematron-constraint-abstractModel-structure-div-in-l-32"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-abstractModel-structure-div-in-ab-or-p-33"
+                        id="schematron-constraint-abstractModel-structure-div-in-ab-or-p-33"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:div"/>
-   <svrl:active-pattern name="schematron-constraint-require-translatability-35"
-                        id="schematron-constraint-require-translatability-35"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-require-translatability-34"
+                        id="schematron-constraint-require-translatability-34"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="  tei:elementSpec/tei:desc                                  | tei:elementSpec/tei:gloss                                  | tei:elementSpec/tei:remarks                                  | tei:classSpec/tei:desc                                  | tei:classSpec/tei:gloss                                  | tei:classSpec/tei:remarks                                  | tei:macroSpec/tei:desc                                  | tei:macroSpec/tei:gloss                                  | tei:macroSpec/tei:remarks                                  | tei:attDef/tei:desc                                  | tei:attDef/tei:gloss                                  | tei:attDef/tei:remarks                                  | tei:valItem/tei:desc                                  | tei:valItem/tei:gloss                                  | tei:valItem/tei:remarks                                  | tei:moduleSpec/tei:desc                                  | tei:moduleSpec/tei:gloss                                  | tei:moduleSpec/tei:remarks                                  "/>
    <svrl:fired-rule context="  tei:elementSpec/tei:desc                                  | tei:elementSpec/tei:gloss                                  | tei:elementSpec/tei:remarks                                  | tei:classSpec/tei:desc                                  | tei:classSpec/tei:gloss                                  | tei:classSpec/tei:remarks                                  | tei:macroSpec/tei:desc                                  | tei:macroSpec/tei:gloss                                  | tei:macroSpec/tei:remarks                                  | tei:attDef/tei:desc                                  | tei:attDef/tei:gloss                                  | tei:attDef/tei:remarks                                  | tei:valItem/tei:desc                                  | tei:valItem/tei:gloss                                  | tei:valItem/tei:remarks                                  | tei:moduleSpec/tei:desc                                  | tei:moduleSpec/tei:gloss                                  | tei:moduleSpec/tei:remarks                                  "/>
    <svrl:fired-rule context="  tei:elementSpec/tei:desc                                  | tei:elementSpec/tei:gloss                                  | tei:elementSpec/tei:remarks                                  | tei:classSpec/tei:desc                                  | tei:classSpec/tei:gloss                                  | tei:classSpec/tei:remarks                                  | tei:macroSpec/tei:desc                                  | tei:macroSpec/tei:gloss                                  | tei:macroSpec/tei:remarks                                  | tei:attDef/tei:desc                                  | tei:attDef/tei:gloss                                  | tei:attDef/tei:remarks                                  | tei:valItem/tei:desc                                  | tei:valItem/tei:gloss                                  | tei:valItem/tei:remarks                                  | tei:moduleSpec/tei:desc                                  | tei:moduleSpec/tei:gloss                                  | tei:moduleSpec/tei:remarks                                  "/>
@@ -304,9 +301,9 @@
    <svrl:fired-rule context="  tei:elementSpec/tei:desc                                  | tei:elementSpec/tei:gloss                                  | tei:elementSpec/tei:remarks                                  | tei:classSpec/tei:desc                                  | tei:classSpec/tei:gloss                                  | tei:classSpec/tei:remarks                                  | tei:macroSpec/tei:desc                                  | tei:macroSpec/tei:gloss                                  | tei:macroSpec/tei:remarks                                  | tei:attDef/tei:desc                                  | tei:attDef/tei:gloss                                  | tei:attDef/tei:remarks                                  | tei:valItem/tei:desc                                  | tei:valItem/tei:gloss                                  | tei:valItem/tei:remarks                                  | tei:moduleSpec/tei:desc                                  | tei:moduleSpec/tei:gloss                                  | tei:moduleSpec/tei:remarks                                  "/>
    <svrl:fired-rule context="  tei:elementSpec/tei:desc                                  | tei:elementSpec/tei:gloss                                  | tei:elementSpec/tei:remarks                                  | tei:classSpec/tei:desc                                  | tei:classSpec/tei:gloss                                  | tei:classSpec/tei:remarks                                  | tei:macroSpec/tei:desc                                  | tei:macroSpec/tei:gloss                                  | tei:macroSpec/tei:remarks                                  | tei:attDef/tei:desc                                  | tei:attDef/tei:gloss                                  | tei:attDef/tei:remarks                                  | tei:valItem/tei:desc                                  | tei:valItem/tei:gloss                                  | tei:valItem/tei:remarks                                  | tei:moduleSpec/tei:desc                                  | tei:moduleSpec/tei:gloss                                  | tei:moduleSpec/tei:remarks                                  "/>
    <svrl:fired-rule context="  tei:elementSpec/tei:desc                                  | tei:elementSpec/tei:gloss                                  | tei:elementSpec/tei:remarks                                  | tei:classSpec/tei:desc                                  | tei:classSpec/tei:gloss                                  | tei:classSpec/tei:remarks                                  | tei:macroSpec/tei:desc                                  | tei:macroSpec/tei:gloss                                  | tei:macroSpec/tei:remarks                                  | tei:attDef/tei:desc                                  | tei:attDef/tei:gloss                                  | tei:attDef/tei:remarks                                  | tei:valItem/tei:desc                                  | tei:valItem/tei:gloss                                  | tei:valItem/tei:remarks                                  | tei:moduleSpec/tei:desc                                  | tei:moduleSpec/tei:gloss                                  | tei:moduleSpec/tei:remarks                                  "/>
-   <svrl:active-pattern name="schematron-constraint-en-first-36"
-                        id="schematron-constraint-en-first-36"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-en-first-35"
+                        id="schematron-constraint-en-first-35"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="  tei:elementSpec/tei:desc[1]                                  | tei:elementSpec/tei:gloss[1]                                  | tei:elementSpec/tei:remarks[1]                                  | tei:classSpec/tei:desc[1]                                  | tei:classSpec/tei:gloss[1]                                  | tei:classSpec/tei:remarks[1]                                  | tei:macroSpec/tei:desc[1]                                  | tei:macroSpec/tei:gloss[1]                                  | tei:macroSpec/tei:remarks[1]                                  | tei:attDef/tei:desc[1]                                  | tei:attDef/tei:gloss[1]                                  | tei:attDef/tei:remarks[1]                                  | tei:valItem/tei:desc[1]                                  | tei:valItem/tei:gloss[1]                                  | tei:valItem/tei:remarks[1]                                  | tei:moduleSpec/tei:desc[1]                                  | tei:moduleSpec/tei:gloss[1]                                  | tei:moduleSpec/tei:remarks[1]                                   "/>
    <svrl:fired-rule context="  tei:elementSpec/tei:desc[1]                                  | tei:elementSpec/tei:gloss[1]                                  | tei:elementSpec/tei:remarks[1]                                  | tei:classSpec/tei:desc[1]                                  | tei:classSpec/tei:gloss[1]                                  | tei:classSpec/tei:remarks[1]                                  | tei:macroSpec/tei:desc[1]                                  | tei:macroSpec/tei:gloss[1]                                  | tei:macroSpec/tei:remarks[1]                                  | tei:attDef/tei:desc[1]                                  | tei:attDef/tei:gloss[1]                                  | tei:attDef/tei:remarks[1]                                  | tei:valItem/tei:desc[1]                                  | tei:valItem/tei:gloss[1]                                  | tei:valItem/tei:remarks[1]                                  | tei:moduleSpec/tei:desc[1]                                  | tei:moduleSpec/tei:gloss[1]                                  | tei:moduleSpec/tei:remarks[1]                                   "/>
    <svrl:fired-rule context="  tei:elementSpec/tei:desc[1]                                  | tei:elementSpec/tei:gloss[1]                                  | tei:elementSpec/tei:remarks[1]                                  | tei:classSpec/tei:desc[1]                                  | tei:classSpec/tei:gloss[1]                                  | tei:classSpec/tei:remarks[1]                                  | tei:macroSpec/tei:desc[1]                                  | tei:macroSpec/tei:gloss[1]                                  | tei:macroSpec/tei:remarks[1]                                  | tei:attDef/tei:desc[1]                                  | tei:attDef/tei:gloss[1]                                  | tei:attDef/tei:remarks[1]                                  | tei:valItem/tei:desc[1]                                  | tei:valItem/tei:gloss[1]                                  | tei:valItem/tei:remarks[1]                                  | tei:moduleSpec/tei:desc[1]                                  | tei:moduleSpec/tei:gloss[1]                                  | tei:moduleSpec/tei:remarks[1]                                   "/>
@@ -355,12 +352,12 @@
    <svrl:fired-rule context="  tei:elementSpec/tei:desc[1]                                  | tei:elementSpec/tei:gloss[1]                                  | tei:elementSpec/tei:remarks[1]                                  | tei:classSpec/tei:desc[1]                                  | tei:classSpec/tei:gloss[1]                                  | tei:classSpec/tei:remarks[1]                                  | tei:macroSpec/tei:desc[1]                                  | tei:macroSpec/tei:gloss[1]                                  | tei:macroSpec/tei:remarks[1]                                  | tei:attDef/tei:desc[1]                                  | tei:attDef/tei:gloss[1]                                  | tei:attDef/tei:remarks[1]                                  | tei:valItem/tei:desc[1]                                  | tei:valItem/tei:gloss[1]                                  | tei:valItem/tei:remarks[1]                                  | tei:moduleSpec/tei:desc[1]                                  | tei:moduleSpec/tei:gloss[1]                                  | tei:moduleSpec/tei:remarks[1]                                   "/>
    <svrl:fired-rule context="  tei:elementSpec/tei:desc[1]                                  | tei:elementSpec/tei:gloss[1]                                  | tei:elementSpec/tei:remarks[1]                                  | tei:classSpec/tei:desc[1]                                  | tei:classSpec/tei:gloss[1]                                  | tei:classSpec/tei:remarks[1]                                  | tei:macroSpec/tei:desc[1]                                  | tei:macroSpec/tei:gloss[1]                                  | tei:macroSpec/tei:remarks[1]                                  | tei:attDef/tei:desc[1]                                  | tei:attDef/tei:gloss[1]                                  | tei:attDef/tei:remarks[1]                                  | tei:valItem/tei:desc[1]                                  | tei:valItem/tei:gloss[1]                                  | tei:valItem/tei:remarks[1]                                  | tei:moduleSpec/tei:desc[1]                                  | tei:moduleSpec/tei:gloss[1]                                  | tei:moduleSpec/tei:remarks[1]                                   "/>
    <svrl:fired-rule context="  tei:elementSpec/tei:desc[1]                                  | tei:elementSpec/tei:gloss[1]                                  | tei:elementSpec/tei:remarks[1]                                  | tei:classSpec/tei:desc[1]                                  | tei:classSpec/tei:gloss[1]                                  | tei:classSpec/tei:remarks[1]                                  | tei:macroSpec/tei:desc[1]                                  | tei:macroSpec/tei:gloss[1]                                  | tei:macroSpec/tei:remarks[1]                                  | tei:attDef/tei:desc[1]                                  | tei:attDef/tei:gloss[1]                                  | tei:attDef/tei:remarks[1]                                  | tei:valItem/tei:desc[1]                                  | tei:valItem/tei:gloss[1]                                  | tei:valItem/tei:remarks[1]                                  | tei:moduleSpec/tei:desc[1]                                  | tei:moduleSpec/tei:gloss[1]                                  | tei:moduleSpec/tei:remarks[1]                                   "/>
-   <svrl:active-pattern name="schematron-constraint-only-one-each-lang-37"
-                        id="schematron-constraint-only-one-each-lang-37"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-all-sibling-parent-desc-38"
-                        id="schematron-constraint-all-sibling-parent-desc-38"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-only-one-each-lang-36"
+                        id="schematron-constraint-only-one-each-lang-36"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-all-sibling-parent-desc-37"
+                        id="schematron-constraint-all-sibling-parent-desc-37"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="*[tei:desc[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:desc[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:desc[@versionDate]]"/>
@@ -391,9 +388,9 @@
    <svrl:fired-rule context="*[tei:desc[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:desc[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:desc[@versionDate]]"/>
-   <svrl:active-pattern name="schematron-constraint-all-sibling-parent-gloss-39"
-                        id="schematron-constraint-all-sibling-parent-gloss-39"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-all-sibling-parent-gloss-38"
+                        id="schematron-constraint-all-sibling-parent-gloss-38"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="*[tei:gloss[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:gloss[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:gloss[@versionDate]]"/>
@@ -402,50 +399,50 @@
    <svrl:fired-rule context="*[tei:gloss[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:gloss[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:gloss[@versionDate]]"/>
-   <svrl:active-pattern name="schematron-constraint-all-sibling-parent-remarks-40"
-                        id="schematron-constraint-all-sibling-parent-remarks-40"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-all-sibling-parent-remarks-39"
+                        id="schematron-constraint-all-sibling-parent-remarks-39"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="*[tei:remarks[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:remarks[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:remarks[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:remarks[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:remarks[@versionDate]]"/>
    <svrl:fired-rule context="*[tei:remarks[@versionDate]]"/>
-   <svrl:active-pattern name="schematron-constraint-all-sibling-parent-valDesc-41"
-                        id="schematron-constraint-all-sibling-parent-valDesc-41"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-all-sibling-parent-valDesc-40"
+                        id="schematron-constraint-all-sibling-parent-valDesc-40"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-MINandMAXoccurs-41"
+                        id="schematron-constraint-MINandMAXoccurs-41"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
+   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
+   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
+   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
+   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
+   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
+   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
+   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
+   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
+   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
    <svrl:active-pattern name="schematron-constraint-MINandMAXoccurs-42"
                         id="schematron-constraint-MINandMAXoccurs-42"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
-   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
-   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
-   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
-   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
-   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
-   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
-   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
-   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
-   <svrl:fired-rule context="tei:*[ @minOccurs and @maxOccurs ]"/>
-   <svrl:active-pattern name="schematron-constraint-MINandMAXoccurs-43"
-                        id="schematron-constraint-MINandMAXoccurs-43"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-spec-in-module-44"
-                        id="schematron-constraint-spec-in-module-44"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:fired-rule context="tei:elementSpec[@module]|tei:classSpec[@module]|tei:macroSpec[@module]"/>
-   <svrl:active-pattern name="schematron-constraint-deprecation-two-month-warning-45"
-                        id="schematron-constraint-deprecation-two-month-warning-45"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-deprecation-should-be-explained-46"
-                        id="schematron-constraint-deprecation-should-be-explained-46"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-no_leading_nor_trailing_new_newlines-47"
-                        id="schematron-constraint-no_leading_nor_trailing_new_newlines-47"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-spec-in-module-43"
+                        id="schematron-constraint-spec-in-module-43"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:fired-rule context="( tei:elementSpec[@module] | tei:classSpec[@module] | tei:macroSpec[@module] )[                            ( ancestor::tei:schemaSpec | ancestor::tei:TEI | ancestor::tei:teiCorpus )                            and                            ( //tei:moduleSpec | //tei:moduleRef )                            ]"/>
+   <svrl:active-pattern name="schematron-constraint-deprecation-two-month-warning-44"
+                        id="schematron-constraint-deprecation-two-month-warning-44"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-deprecation-should-be-explained-45"
+                        id="schematron-constraint-deprecation-should-be-explained-45"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-no_leading_nor_trailing_new_newlines-46"
+                        id="schematron-constraint-no_leading_nor_trailing_new_newlines-46"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-only_sensible_attrs-32"
                         id="schematron-constraint-only_sensible_attrs-32"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:elementRef[ parent::tei:schemaSpec | parent::tei:specGrp ]"/>
    <svrl:successful-report location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}specGrp[1]/Q{http://www.tei-c.org/ns/1.0}elementRef[1]"
                            role="error"
@@ -460,9 +457,9 @@
       <svrl:text>An element reference within a content model must refer to a locally defined element specification (and thus this &lt;elementRef&gt; should not have @source).</svrl:text>
    </svrl:successful-report>
    <svrl:fired-rule context="tei:content//tei:elementRef"/>
-   <svrl:active-pattern name="schematron-constraint-modref-50"
-                        id="schematron-constraint-modref-50"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-modref-49"
+                        id="schematron-constraint-modref-49"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
@@ -476,9 +473,9 @@
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
-   <svrl:active-pattern name="schematron-constraint-not-same-prefix-51"
-                        id="schematron-constraint-not-same-prefix-51"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-not-same-prefix-50"
+                        id="schematron-constraint-not-same-prefix-50"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
@@ -492,9 +489,9 @@
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
-   <svrl:active-pattern name="schematron-constraint-not-except-and-include-52"
-                        id="schematron-constraint-not-except-and-include-52"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-not-except-and-include-51"
+                        id="schematron-constraint-not-except-and-include-51"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
@@ -508,12 +505,12 @@
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
    <svrl:fired-rule context="tei:moduleRef"/>
+   <svrl:active-pattern name="schematron-constraint-child-constraint-based-on-mode-52"
+                        id="schematron-constraint-child-constraint-based-on-mode-52"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-child-constraint-based-on-mode-53"
                         id="schematron-constraint-child-constraint-based-on-mode-53"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-child-constraint-based-on-mode-54"
-                        id="schematron-constraint-child-constraint-based-on-mode-54"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:elementSpec[ @mode = ('add','change','replace') ]"/>
    <svrl:fired-rule context="tei:elementSpec[ @mode = ('add','change','replace') ]"/>
    <svrl:fired-rule context="tei:elementSpec[ @mode = ('add','change','replace') ]"/>
@@ -531,29 +528,29 @@
    <svrl:fired-rule context="tei:elementSpec[ @mode = ('add','change','replace') ]"/>
    <svrl:fired-rule context="tei:elementSpec[ @mode = ('add','change','replace') ]"/>
    <svrl:fired-rule context="tei:elementSpec[ @mode = ('add','change','replace') ]"/>
-   <svrl:active-pattern name="schematron-constraint-no_elements_in_data_content-55"
-                        id="schematron-constraint-no_elements_in_data_content-55"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-only-one-remark-per-lang-56"
-                        id="schematron-constraint-only-one-remark-per-lang-56"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-no_elements_in_data_content-54"
+                        id="schematron-constraint-no_elements_in_data_content-54"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-only-one-remark-per-lang-55"
+                        id="schematron-constraint-only-one-remark-per-lang-55"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:remarks[@xml:lang]"/>
    <svrl:fired-rule context="tei:remarks[@xml:lang]"/>
    <svrl:fired-rule context="tei:remarks[@xml:lang]"/>
    <svrl:fired-rule context="tei:remarks[@xml:lang]"/>
    <svrl:fired-rule context="tei:remarks[@xml:lang]"/>
    <svrl:fired-rule context="tei:remarks[@xml:lang]"/>
-   <svrl:active-pattern name="schematron-constraint-TagDocsNestinglistRef-57"
-                        id="schematron-constraint-TagDocsNestinglistRef-57"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-TagDocsNestinglistRef-56"
+                        id="schematron-constraint-TagDocsNestinglistRef-56"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="( tei:classSpec | tei:dataSpec | tei:elementSpec | tei:macroSpec | tei:moduleSpec | tei:schemaSpec | tei:specGrp )/tei:listRef"/>
    <svrl:successful-report location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[10]/Q{http://www.tei-c.org/ns/1.0}listRef[1]"
                            test="tei:listRef">
       <svrl:text>In the context of tagset documentation, the listRef element must not self-nest.</svrl:text>
    </svrl:successful-report>
-   <svrl:active-pattern name="schematron-constraint-TagDocslistRefChildren-58"
-                        id="schematron-constraint-TagDocslistRefChildren-58"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-TagDocslistRefChildren-57"
+                        id="schematron-constraint-TagDocslistRefChildren-57"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="( tei:classSpec | tei:dataSpec | tei:elementSpec | tei:macroSpec | tei:moduleSpec | tei:schemaSpec | tei:specGrp )/tei:listRef/tei:ptr | ( tei:classSpec | tei:dataSpec | tei:elementSpec | tei:macroSpec | tei:moduleSpec | tei:schemaSpec | tei:specGrp )/tei:listRef/tei:ref"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[10]/Q{http://www.tei-c.org/ns/1.0}listRef[1]/Q{http://www.tei-c.org/ns/1.0}ref[1]"
                        test="@target and not( matches( @target,'\s') )">
@@ -566,9 +563,9 @@
                        test="@target and not( matches( @target,'\s') )">
       <svrl:text>In the context of tagset documentation, each ptr or ref element inside a listRef must have a target attribute with only 1 pointer as its value.</svrl:text>
    </svrl:failed-assert>
-   <svrl:active-pattern name="schematron-constraint-order_of_membership-59"
-                        id="schematron-constraint-order_of_membership-59"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-order_of_membership-58"
+                        id="schematron-constraint-order_of_membership-58"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:classes"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[5]/Q{http://www.tei-c.org/ns/1.0}classes[1]"
                        test="string-join( $keys_as_specified ) eq string-join( $keys_in_order )">
@@ -584,45 +581,48 @@
    <svrl:fired-rule context="tei:classes"/>
    <svrl:fired-rule context="tei:classes"/>
    <svrl:fired-rule context="tei:classes"/>
-   <svrl:active-pattern name="schematron-constraint-restricted-altIdent-placement-60"
-                        id="schematron-constraint-restricted-altIdent-placement-60"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-no_dup_default_models-61"
-                        id="schematron-constraint-no_dup_default_models-61"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-no_dup_models-62"
-                        id="schematron-constraint-no_dup_models-62"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-no_outputs_nor_predicates_4_my_kids-63"
-                        id="schematron-constraint-no_outputs_nor_predicates_4_my_kids-63"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-sequencechilden-64"
-                        id="schematron-constraint-sequencechilden-64"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-alternatechilden-65"
-                        id="schematron-constraint-alternatechilden-65"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-restricted-altIdent-placement-59"
+                        id="schematron-constraint-restricted-altIdent-placement-59"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-no_dup_default_models-60"
+                        id="schematron-constraint-no_dup_default_models-60"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-no_dup_models-61"
+                        id="schematron-constraint-no_dup_models-61"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-no_outputs_nor_predicates_4_my_kids-62"
+                        id="schematron-constraint-no_outputs_nor_predicates_4_my_kids-62"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-sequencechilden-63"
+                        id="schematron-constraint-sequencechilden-63"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern name="schematron-constraint-alternatechilden-64"
+                        id="schematron-constraint-alternatechilden-64"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:alternate"/>
+   <svrl:active-pattern name="schematron-constraint-interleavechilden-65"
+                        id="schematron-constraint-interleavechilden-65"
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-one-constraintDecl-per-scheme-66"
                         id="schematron-constraint-one-constraintDecl-per-scheme-66"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-empty-based-on-mode-68"
                         id="schematron-constraint-empty-based-on-mode-68"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode eq 'delete']"/>
    <svrl:active-pattern name="schematron-constraint-empty-based-on-mode-69"
                         id="schematron-constraint-empty-based-on-mode-69"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-empty-based-on-mode-70"
                         id="schematron-constraint-empty-based-on-mode-70"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') ]"/>
    <svrl:active-pattern name="schematron-constraint-sch_no_more-71"
                         id="schematron-constraint-sch_no_more-71"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:constraintSpec"/>
    <svrl:fired-rule context="tei:constraintSpec"/>
    <svrl:fired-rule context="tei:constraintSpec"/>
@@ -634,30 +634,30 @@
    <svrl:fired-rule context="tei:constraintSpec"/>
    <svrl:active-pattern name="schematron-constraint-isosch-72"
                         id="schematron-constraint-isosch-72"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') or not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') or not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') or not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') or not( @mode ) ]"/>
    <svrl:successful-report location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[8]/Q{http://www.tei-c.org/ns/1.0}constraintSpec[1]"
                            test="tei:constraint/sch:* and not( @scheme eq 'schematron')">
-      <svrl:text>Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute</svrl:text>
+      <svrl:text>Rules in the ISO Schematron language must be inside a &lt;constraintSpec&gt; with the value "schematron" on the @scheme attribute.</svrl:text>
    </svrl:successful-report>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') or not( @mode ) ]"/>
    <svrl:successful-report location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[8]/Q{http://www.tei-c.org/ns/1.0}constraintSpec[2]"
                            test="tei:constraint/sch:* and not( @scheme eq 'schematron')">
-      <svrl:text>Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute</svrl:text>
+      <svrl:text>Rules in the ISO Schematron language must be inside a &lt;constraintSpec&gt; with the value "schematron" on the @scheme attribute.</svrl:text>
    </svrl:successful-report>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') or not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') or not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace') or not( @mode ) ]"/>
    <svrl:successful-report location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[8]/Q{http://www.tei-c.org/ns/1.0}constraintSpec[5]"
                            test="tei:constraint/sch:* and not( @scheme eq 'schematron')">
-      <svrl:text>Rules in the ISO Schematron language must be inside a constraintSpec with the value 'schematron' on the scheme attribute</svrl:text>
+      <svrl:text>Rules in the ISO Schematron language must be inside a &lt;constraintSpec&gt; with the value "schematron" on the @scheme attribute.</svrl:text>
    </svrl:successful-report>
    <svrl:active-pattern name="schematron-constraint-context-required-73"
                         id="schematron-constraint-context-required-73"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="(tei:constraintSpec|tei:constraintDecl)[ @scheme eq 'schematron'][ .//sch:assert | .//sch:report ]"/>
    <svrl:fired-rule context="(tei:constraintSpec|tei:constraintDecl)[ @scheme eq 'schematron'][ .//sch:assert | .//sch:report ]"/>
    <svrl:fired-rule context="(tei:constraintSpec|tei:constraintDecl)[ @scheme eq 'schematron'][ .//sch:assert | .//sch:report ]"/>
@@ -669,7 +669,7 @@
    <svrl:fired-rule context="(tei:constraintSpec|tei:constraintDecl)[ @scheme eq 'schematron'][ .//sch:assert | .//sch:report ]"/>
    <svrl:active-pattern name="schematron-constraint-unique-constraintSpec-ident-74"
                         id="schematron-constraint-unique-constraintSpec-ident-74"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode eq 'add' or not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode eq 'add' or not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode eq 'add' or not( @mode ) ]"/>
@@ -679,45 +679,45 @@
    <svrl:fired-rule context="tei:constraintSpec[ @mode eq 'add' or not( @mode ) ]"/>
    <svrl:active-pattern name="schematron-constraint-usage_based_on_mode-75"
                         id="schematron-constraint-usage_based_on_mode-75"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[8]/Q{http://www.tei-c.org/ns/1.0}constraintSpec[1]"
                        test="@scheme">
-      <svrl:text>The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified (here on "add_missing_scheme")</svrl:text>
+      <svrl:text> The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified (here on "add_missing_scheme").</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[8]/Q{http://www.tei-c.org/ns/1.0}constraintSpec[2]"
                        test="@scheme">
-      <svrl:text>The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is "replace" (here on "replace_missing_scheme")</svrl:text>
+      <svrl:text> The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is "replace" (here on "replace_missing_scheme").</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:active-pattern name="schematron-constraint-usage_based_on_mode-76"
                         id="schematron-constraint-usage_based_on_mode-76"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[8]/Q{http://www.tei-c.org/ns/1.0}constraintSpec[1]"
                        test="@scheme">
-      <svrl:text>The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified (here on "add_missing_scheme")</svrl:text>
+      <svrl:text> The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is not specified (here on "add_missing_scheme").</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[8]/Q{http://www.tei-c.org/ns/1.0}constraintSpec[2]"
                        test="@scheme">
-      <svrl:text>The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is "replace" (here on "replace_missing_scheme")</svrl:text>
+      <svrl:text> The @scheme attribute of &lt;constraintSpec&gt; is required when the @mode is "replace" (here on "replace_missing_scheme").</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:fired-rule context="tei:constraintSpec[ @mode = ('add','replace')  or  not( @mode ) ]"/>
    <svrl:active-pattern name="schematron-constraint-no_duplicate_attrs-79"
                         id="schematron-constraint-no_duplicate_attrs-79"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:attList[ not( ancestor::tei:attList ) ]"/>
    <svrl:fired-rule context="tei:attList[ not( ancestor::tei:attList ) ]"/>
    <svrl:fired-rule context="tei:attList[ not( ancestor::tei:attList ) ]"/>
@@ -743,7 +743,7 @@
    </svrl:failed-assert>
    <svrl:active-pattern name="schematron-constraint-attDefContents-80"
                         id="schematron-constraint-attDefContents-80"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:fired-rule context="tei:attDef"/>
@@ -782,406 +782,403 @@
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[11]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @bad attribute in the no_duplicate_attrs_1_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @bad attribute in the "no_duplicate_attrs_1_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[11]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @good attribute in the no_duplicate_attrs_1_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @good attribute in the "no_duplicate_attrs_1_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[11]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[3]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @better attribute in the no_duplicate_attrs_1_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @better attribute in the "no_duplicate_attrs_1_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[11]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[4]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @best attribute in the no_duplicate_attrs_1_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @best attribute in the "no_duplicate_attrs_1_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[11]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[5]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @bad attribute in the no_duplicate_attrs_1_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @bad attribute in the "no_duplicate_attrs_1_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[12]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @bad attribute in the no_duplicate_attrs_1_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @bad attribute in the "no_duplicate_attrs_1_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[12]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @good attribute in the no_duplicate_attrs_1_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @good attribute in the "no_duplicate_attrs_1_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[12]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[3]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @better attribute in the no_duplicate_attrs_1_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @better attribute in the "no_duplicate_attrs_1_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[12]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[4]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @best attribute in the no_duplicate_attrs_1_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @best attribute in the "no_duplicate_attrs_1_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[12]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[5]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @bad attribute in the no_duplicate_attrs_1_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @bad attribute in the "no_duplicate_attrs_1_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[13]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @have attribute in the no_duplicate_attrs_2_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @have attribute in the "no_duplicate_attrs_2_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[13]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @fun attribute in the no_duplicate_attrs_2_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @fun attribute in the "no_duplicate_attrs_2_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[13]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @fun attribute in the no_duplicate_attrs_2_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @fun attribute in the "no_duplicate_attrs_2_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[13]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[3]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @fun attribute in the no_duplicate_attrs_2_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @fun attribute in the "no_duplicate_attrs_2_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[13]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @til attribute in the no_duplicate_attrs_2_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @til attribute in the "no_duplicate_attrs_2_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[13]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[3]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @her attribute in the no_duplicate_attrs_2_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @her attribute in the "no_duplicate_attrs_2_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[13]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[4]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @daddy attribute in the no_duplicate_attrs_2_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @daddy attribute in the "no_duplicate_attrs_2_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @Your attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @Your attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @My attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @My attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @spirit attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @spirit attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @and attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @and attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[2]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @my attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @my attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[2]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @your attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @your attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[3]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @voice attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @voice attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[4]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @in attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @in attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[5]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @one attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @one attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[6]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @combined attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @combined attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[7]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @The attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @The attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[8]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @Phantom attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @Phantom attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[9]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @of attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @of attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[10]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @the attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @the attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[11]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @Opera attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @Opera attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[12]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @is attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @is attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[13]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @there attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @there attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[14]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @Inside attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @Inside attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[3]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @my attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @my attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[3]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @your attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @your attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[14]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[15]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @mind attribute in the no_duplicate_attrs_3_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @mind attribute in the "no_duplicate_attrs_3_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @Your attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @Your attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @My attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @My attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @spirit attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @spirit attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @and attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @and attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[2]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @my attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @my attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[2]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @your attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @your attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[3]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @voice attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @voice attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[4]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @in attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @in attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[5]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @one attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @one attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[6]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @combined attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @combined attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[7]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @The attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @The attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[8]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @Phantom attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @Phantom attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[9]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @of attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @of attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[10]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @the attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @the attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[11]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @Opera attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @Opera attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[12]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @is attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @is attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[13]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @there attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @there attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[14]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @Inside attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @Inside attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[3]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @my attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @my attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[3]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @your attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @your attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[15]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[15]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @mind attribute in the no_duplicate_attrs_3_valid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @mind attribute in the "no_duplicate_attrs_3_valid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[16]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @all attribute in the no_duplicate_attrs_4_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @all attribute in the "no_duplicate_attrs_4_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[16]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @the attribute in the no_duplicate_attrs_4_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @the attribute in the "no_duplicate_attrs_4_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[16]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[3]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @leaves attribute in the no_duplicate_attrs_4_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @leaves attribute in the "no_duplicate_attrs_4_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[16]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[4]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @are attribute in the no_duplicate_attrs_4_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @are attribute in the "no_duplicate_attrs_4_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[16]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[5]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @brown attribute in the no_duplicate_attrs_4_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @brown attribute in the "no_duplicate_attrs_4_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[16]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @and attribute in the no_duplicate_attrs_4_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @and attribute in the "no_duplicate_attrs_4_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[16]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[1]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @the attribute in the no_duplicate_attrs_4_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @the attribute in the "no_duplicate_attrs_4_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[16]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @sky attribute in the no_duplicate_attrs_4_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @sky attribute in the "no_duplicate_attrs_4_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[16]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[2]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @is attribute in the no_duplicate_attrs_4_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @is attribute in the "no_duplicate_attrs_4_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[16]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[6]"
                        test="ancestor::teix:egXML[ @valid eq 'feasible']                        or @mode eq 'change'                        or @mode eq 'delete'                        or tei:datatype                        or tei:valList[ @type eq 'closed']">
-      <svrl:text> Attribute: the definition of the @gray attribute in the no_duplicate_attrs_4_invalid elementSpec should have a closed valList or a datatype</svrl:text>
+      <svrl:text> Attribute: the definition of the @gray attribute in the "no_duplicate_attrs_4_invalid"  &lt;elementSpec&gt; should have a child &lt;valList&gt; with a @type of "closed" or a child &lt;datatype&gt;.</svrl:text>
    </svrl:failed-assert>
    <svrl:active-pattern name="schematron-constraint-noDefault4Required-81"
                         id="schematron-constraint-noDefault4Required-81"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:attDef[@usage eq 'req']"/>
    <svrl:successful-report location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[7]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[3]"
                            test="tei:defaultVal">
-      <svrl:text>Since the @default-is-in-list-req attribute is required, it will always be specified. Thus the default value (of "ONE") will never be used. Either change the definition of the attribute so it is not required ("rec" or "opt"), or remove the defaultVal element.</svrl:text>
+      <svrl:text>Since the @default-is-in-list-req attribute is required, it will always be specified. Thus the default value (of "ONE") will never be used. Either change the definition of the attribute so it is not required ("rec" or "opt"), or remove the &lt;defaultVal&gt; element.</svrl:text>
    </svrl:successful-report>
    <svrl:fired-rule context="tei:attDef[@usage eq 'req']"/>
    <svrl:successful-report location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[7]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[6]"
                            test="tei:defaultVal">
-      <svrl:text>Since the @default-NOT-in-list-req attribute is required, it will always be specified. Thus the default value (of "ONE") will never be used. Either change the definition of the attribute so it is not required ("rec" or "opt"), or remove the defaultVal element.</svrl:text>
+      <svrl:text>Since the @default-NOT-in-list-req attribute is required, it will always be specified. Thus the default value (of "ONE") will never be used. Either change the definition of the attribute so it is not required ("rec" or "opt"), or remove the &lt;defaultVal&gt; element.</svrl:text>
    </svrl:successful-report>
    <svrl:active-pattern name="schematron-constraint-defaultIsInClosedList-twoOrMore-82"
                         id="schematron-constraint-defaultIsInClosedList-twoOrMore-82"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-defaultIsInClosedList-one-83"
                         id="schematron-constraint-defaultIsInClosedList-one-83"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="tei:attDef[     tei:defaultVal                                      and tei:valList[ @type eq 'closed']                                      and tei:datatype[                                             not(@maxOccurs)                                         or  ( if ( @maxOccurs castable as xs:integer ) then ( @maxOccurs cast as xs:integer eq 1 ) else false() )                                                      ]                                    ]"/>
    <svrl:fired-rule context="tei:attDef[     tei:defaultVal                                      and tei:valList[ @type eq 'closed']                                      and tei:datatype[                                             not(@maxOccurs)                                         or  ( if ( @maxOccurs castable as xs:integer ) then ( @maxOccurs cast as xs:integer eq 1 ) else false() )                                                      ]                                    ]"/>
    <svrl:fired-rule context="tei:attDef[     tei:defaultVal                                      and tei:valList[ @type eq 'closed']                                      and tei:datatype[                                             not(@maxOccurs)                                         or  ( if ( @maxOccurs castable as xs:integer ) then ( @maxOccurs cast as xs:integer eq 1 ) else false() )                                                      ]                                    ]"/>
    <svrl:fired-rule context="tei:attDef[     tei:defaultVal                                      and tei:valList[ @type eq 'closed']                                      and tei:datatype[                                             not(@maxOccurs)                                         or  ( if ( @maxOccurs castable as xs:integer ) then ( @maxOccurs cast as xs:integer eq 1 ) else false() )                                                      ]                                    ]"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[7]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[4]"
                        test="string(tei:defaultVal) = tei:valList/tei:valItem/@ident">
-      <svrl:text>In the elementSpec defining blort2 the default value of the @default-NOT-in-list-opt attribute is not among the closed list of possible values</svrl:text>
+      <svrl:text> In the &lt;elementSpec&gt; defining "blort2" the default value of the @default-NOT-in-list-opt attribute is not among the closed list of possible values.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef[     tei:defaultVal                                      and tei:valList[ @type eq 'closed']                                      and tei:datatype[                                             not(@maxOccurs)                                         or  ( if ( @maxOccurs castable as xs:integer ) then ( @maxOccurs cast as xs:integer eq 1 ) else false() )                                                      ]                                    ]"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[7]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[5]"
                        test="string(tei:defaultVal) = tei:valList/tei:valItem/@ident">
-      <svrl:text>In the elementSpec defining blort2 the default value of the @default-NOT-in-list-rec attribute is not among the closed list of possible values</svrl:text>
+      <svrl:text> In the &lt;elementSpec&gt; defining "blort2" the default value of the @default-NOT-in-list-rec attribute is not among the closed list of possible values.</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="tei:attDef[     tei:defaultVal                                      and tei:valList[ @type eq 'closed']                                      and tei:datatype[                                             not(@maxOccurs)                                         or  ( if ( @maxOccurs castable as xs:integer ) then ( @maxOccurs cast as xs:integer eq 1 ) else false() )                                                      ]                                    ]"/>
    <svrl:failed-assert location="/Q{http://www.tei-c.org/ns/1.0}TEI[1]/Q{http://www.tei-c.org/ns/1.0}text[1]/Q{http://www.tei-c.org/ns/1.0}body[1]/Q{http://www.tei-c.org/ns/1.0}div[1]/Q{http://www.tei-c.org/ns/1.0}schemaSpec[1]/Q{http://www.tei-c.org/ns/1.0}elementSpec[7]/Q{http://www.tei-c.org/ns/1.0}attList[1]/Q{http://www.tei-c.org/ns/1.0}attDef[6]"
                        test="string(tei:defaultVal) = tei:valList/tei:valItem/@ident">
-      <svrl:text>In the elementSpec defining blort2 the default value of the @default-NOT-in-list-req attribute is not among the closed list of possible values</svrl:text>
+      <svrl:text> In the &lt;elementSpec&gt; defining "blort2" the default value of the @default-NOT-in-list-req attribute is not among the closed list of possible values.</svrl:text>
    </svrl:failed-assert>
    <svrl:active-pattern name="schematron-constraint-restrictDataFacet-84"
                         id="schematron-constraint-restrictDataFacet-84"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-restrictAttResctrictionName-85"
                         id="schematron-constraint-restrictAttResctrictionName-85"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-linkTargets3-86"
                         id="schematron-constraint-linkTargets3-86"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-abstractModel-structure-ab-in-l-87"
                         id="schematron-constraint-abstractModel-structure-ab-in-l-87"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="schematron-constraint-joinTargets3-88"
                         id="schematron-constraint-joinTargets3-88"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern name="schematron-constraint-nested_standOff_should_be_typed-89"
-                        id="schematron-constraint-nested_standOff_should_be_typed-89"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="en-gloss-if-any"
                         id="en-gloss-if-any"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:fired-rule context="  tei:elementSpec[tei:gloss]                                  | tei:valItem[tei:gloss]                                  | tei:attDef[tei:gloss]                                  | tei:macroSpec[tei:gloss]                                  | tei:classSpec[tei:gloss]                                  | tei:dataSpec[tei:gloss]                                  "/>
    <svrl:fired-rule context="  tei:elementSpec[tei:gloss]                                  | tei:valItem[tei:gloss]                                  | tei:attDef[tei:gloss]                                  | tei:macroSpec[tei:gloss]                                  | tei:classSpec[tei:gloss]                                  | tei:dataSpec[tei:gloss]                                  "/>
    <svrl:fired-rule context="  tei:elementSpec[tei:gloss]                                  | tei:valItem[tei:gloss]                                  | tei:attDef[tei:gloss]                                  | tei:macroSpec[tei:gloss]                                  | tei:classSpec[tei:gloss]                                  | tei:dataSpec[tei:gloss]                                  "/>
@@ -1192,81 +1189,82 @@
    <svrl:fired-rule context="  tei:elementSpec[tei:gloss]                                  | tei:valItem[tei:gloss]                                  | tei:attDef[tei:gloss]                                  | tei:macroSpec[tei:gloss]                                  | tei:classSpec[tei:gloss]                                  | tei:dataSpec[tei:gloss]                                  "/>
    <svrl:fired-rule context="  tei:elementSpec[tei:gloss]                                  | tei:valItem[tei:gloss]                                  | tei:attDef[tei:gloss]                                  | tei:macroSpec[tei:gloss]                                  | tei:classSpec[tei:gloss]                                  | tei:dataSpec[tei:gloss]                                  "/>
    <svrl:fired-rule context="  tei:elementSpec[tei:gloss]                                  | tei:valItem[tei:gloss]                                  | tei:attDef[tei:gloss]                                  | tei:macroSpec[tei:gloss]                                  | tei:classSpec[tei:gloss]                                  | tei:dataSpec[tei:gloss]                                  "/>
-   <svrl:active-pattern documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
-   <svrl:active-pattern documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+   <svrl:active-pattern documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern documents="file:/TEI/P5/Test/detest.odd"/>
+   <svrl:active-pattern documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-1"
                         id="teipm-model-paramList-1"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-2"
                         id="teipm-model-paramList-2"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-3"
                         id="teipm-model-paramList-3"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-4"
                         id="teipm-model-paramList-4"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-5"
                         id="teipm-model-paramList-5"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-6"
                         id="teipm-model-paramList-6"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-7"
                         id="teipm-model-paramList-7"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-8"
                         id="teipm-model-paramList-8"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-9"
                         id="teipm-model-paramList-9"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-10"
                         id="teipm-model-paramList-10"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-11"
                         id="teipm-model-paramList-11"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-12"
                         id="teipm-model-paramList-12"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-13"
                         id="teipm-model-paramList-13"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-14"
                         id="teipm-model-paramList-14"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-15"
                         id="teipm-model-paramList-15"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-16"
                         id="teipm-model-paramList-16"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-17"
                         id="teipm-model-paramList-17"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-18"
                         id="teipm-model-paramList-18"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-19"
                         id="teipm-model-paramList-19"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-20"
                         id="teipm-model-paramList-20"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-21"
                         id="teipm-model-paramList-21"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-22"
                         id="teipm-model-paramList-22"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-23"
                         id="teipm-model-paramList-23"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-24"
                         id="teipm-model-paramList-24"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
    <svrl:active-pattern name="teipm-model-paramList-25"
                         id="teipm-model-paramList-25"
-                        documents="file:/home/syd/Documents/TEI_gitHub/P5/Test/detest.odd"/>
+                        documents="file:/TEI/P5/Test/detest.odd"/>
 </svrl:schematron-output>

--- a/P5/Test/expected-results/detest_xml_schematron.log
+++ b/P5/Test/expected-results/detest_xml_schematron.log
@@ -3,21 +3,21 @@ at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[2]/tei:div[2]/tei:head[1] —
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[2]/tei:div[2]/tei:div[1]/tei:p[1]/tei:s[1] —
    The @generatedBy attribute is for use within a <post> element.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[2]/tei:div[3]/tei:p[1]/tei:delSpan[3] —
-   The element indicated by @spanTo (#ds2) must follow the current delSpan element
+   The element indicated by @spanTo (#ds2) must follow the current <delSpan> element.
 at /tei:TEI[1]/tei:teiHeader[1]/tei:encodingDesc[1]/tei:styleDefDecl[1] —
    @schemeVersion can only be used if @scheme is specified.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[9]/tei:p[1]/tei:abbr[1] —
-   The abbr element should not be categorized in detail with @subtype unless also categorized in general with @type
+   The <abbr> element should not be categorized in detail with @subtype unless also categorized in general with @type.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[11]/tei:div[3] —
-   The div element should not be categorized in detail with @subtype unless also categorized in general with @type
+   The <div> element should not be categorized in detail with @subtype unless also categorized in general with @type.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[2]/tei:div[1]/tei:p[2]/tei:date[1] —
    @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this date element has no textual content.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[16]/tei:list[3] —
-   The content of a "gloss" list should include a sequence of one or more pairs of a label element followed by an item element
+   The content of a "gloss" list should include a sequence of one or more pairs of a <label> element followed by an <item> element.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[1]/tei:lg[1] —
    An lg element must contain at least one child l, lg, or gap element.
 at /tei:TEI[1]/tei:teiHeader[1]/tei:encodingDesc[1]/tei:editorialDecl[1]/tei:quotation[1] —
-   On quotation, either the @marks attribute should be used, or a paragraph of description provided
+   On <quotation>, either the @marks attribute should be used, or a paragraph of description provided.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[2]/tei:div[5] —
    divs of type 'canon' may contain only one 'canonText'
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[2]/tei:div[6]/tei:div[1] —
@@ -25,13 +25,13 @@ at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[2]/tei:div[6]/tei:div[1] —
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[2]/tei:div[7]/tei:div[1] —
    divs of type 'canon' may not be nested within 'register'
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[2]/tei:div[8]/tei:p[1]/tei:s[1] —
-   You may not nest one s element within another: use seg instead
+   You may not nest one <s> element within another: use <seg> instead.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[8]/tei:p[5]/tei:span[1] —
-   Only one of the attributes @target and @from may be supplied on span
+   Only one of the attributes @target and @from may be supplied on <span>.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[8]/tei:p[6]/tei:span[1] —
-   Only one of the attributes @target and @to may be supplied on span
+   Only one of the attributes @target and @to may be supplied on <span>.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[8]/tei:p[6]/tei:span[1] —
-   If @to is supplied on span, @from must be supplied as well
+   If @to is supplied on <span>, @from must be supplied as well.
 at /tei:TEI[1]/tei:teiHeader[1]/tei:encodingDesc[1]/tei:variantEncoding[1] —
    The @location value "external" is inconsistent with the parallel-segmentation method of apparatus markup.
 at /tei:TEI[1]/tei:facsimile[1]/tei:surface[1]/tei:zone[1] —
@@ -55,17 +55,17 @@ at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:p[2]/tei:delSpan[1] —
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[2]/tei:div[3]/tei:p[1]/tei:delSpan[2] —
    The @spanTo attribute of delSpan is required.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[7]/tei:p[1]/tei:subst[1] —
-   subst must have at least one child add and at least one child del or surplus
+   <subst> must have at least one child <add> and at least one child <del> or <surplus>.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[7]/tei:p[2]/tei:subst[1] —
-   subst must have at least one child add and at least one child del or surplus
+   <subst> must have at least one child <add> and at least one child <del> or <surplus>.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[7]/tei:p[3]/tei:subst[1] —
-   subst must have at least one child add and at least one child del or surplus
+   <subst> must have at least one child <add> and at least one child <del> or <surplus>.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[7]/tei:p[4]/tei:subst[1] —
-   subst must have at least one child add and at least one child del or surplus
+   <subst> must have at least one child <add> and at least one child <del> or <surplus>.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[7]/tei:p[4]/tei:subst[2] —
-   subst must have at least one child add and at least one child del or surplus
+   <subst> must have at least one child <add> and at least one child <del> or <surplus>.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[7]/tei:p[4]/tei:subst[3] —
-   subst must have at least one child add and at least one child del or surplus
+   <subst> must have at least one child <add> and at least one child <del> or <surplus>.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[12]/tei:msDesc[1]/tei:physDesc[2] —
    Only one physDesc is allowed as a child of msDesc.
 at /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:div[12]/tei:msDesc[1]/tei:history[3] —


### PR DESCRIPTION
Mostly put dots at end of Schematron msgs that are full sentences; but also put element names into pointy brackets, put at-sign in front of attr names, etc.

Note1: This PR replaced #2905 because I changed the branch name.

Note2: Regularizing the use of characters to indicate element names, attr names, and attr values for Schematron msgs that already end in dot is handled in branch "sydb_regularize_undotted_Schematron_msgs" by PR #2911.