### PR TITLE
allow singleton child of ODD grouping element

### DIFF
--- a/P5/Source/Specs/alternate.xml
+++ b/P5/Source/Specs/alternate.xml
@@ -10,18 +10,24 @@
     <memberOf key="model.contentPart"/>
   </classes>
   <content>
-    <alternate minOccurs="1" maxOccurs="unbounded">
-      <elementRef key="valList"/>
-      <classRef key="model.contentPart"/>
+    <alternate>
+      <sequence>
+        <elementRef key="valList" minOccurs="1" maxOccurs="1"/>
+        <classRef key="model.contentPart" minOccurs="0" maxOccurs="unbounded"/>
+      </sequence>
+      <sequence>
+        <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
+        <elementRef key="valList" minOccurs="0" maxOccurs="1"/>
+      </sequence>        
+      <!--
+          That is, either the content starts with a <valList>, in
+          which case it (the <valList>) may be followed by zero or
+          more contentPart elements, OR it starts with a contentPart
+          element, in which case they (the conentPart elements) may be
+          followed by zero or one <valList>.
+      -->
     </alternate>
   </content>
-  <constraintSpec ident="alternatechilden" scheme="schematron" xml:lang="en">
-    <constraint>
-      <sch:rule context="tei:alternate">
-        <sch:assert test="count(*) gt 1">The alternate element must have at least two child elements</sch:assert>
-      </sch:rule>
-    </constraint>
-  </constraintSpec>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-alternate-egXML-eg" xml:lang="en" source="#UND"><content>
       <alternate>

--- a/P5/Source/Specs/interleave.xml
+++ b/P5/Source/Specs/interleave.xml
@@ -9,23 +9,16 @@
     <memberOf key="model.contentPart"/>
   </classes>
   <content>
-    <classRef key="model.contentPart" maxOccurs="unbounded"/>
+    <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
   </content>
-  <constraintSpec ident="interleavechilden" scheme="schematron" xml:lang="en">
-    <constraint>
-      <sch:rule context="tei:interleave">
-        <sch:assert test="count(*) gt 1">The interleave element must have at least two child elements</sch:assert>
-      </sch:rule>
-    </constraint>
-  </constraintSpec>
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="en" source="#UND">
       <content>
         <interleave>
           <elementRef key="persName"/>
           <alternate minOccurs="0">
-              <elementRef key="placeName"/>
-              <elementRef key="location"/>
+            <elementRef key="placeName"/>
+            <elementRef key="location"/>
           </alternate>
           <elementRef key="note" minOccurs="0"/>
         </interleave>

--- a/P5/Source/Specs/sequence.xml
+++ b/P5/Source/Specs/sequence.xml
@@ -9,20 +9,12 @@
     <memberOf key="model.contentPart"/>
   </classes>
   <content>
-    <classRef key="model.contentPart" maxOccurs="unbounded"/>
+    <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
   </content>
-  <constraintSpec ident="sequencechilden" scheme="schematron" xml:lang="en">
-    <constraint>
-      <sch:rule context="tei:sequence">
-        <sch:assert test="count(*) gt 1">The sequence element must have at least two child elements</sch:assert>
-      </sch:rule>
-    </constraint>
-  </constraintSpec>
   <attList>
     <attDef ident="preserveOrder" validUntil="2027-05-06">
       <desc type="deprecationInfo" versionDate="2024-03-15" xml:lang="en">The <att>preserveOrder</att> on <gi>sequence</gi> has been deprecated. The <gi>interleave</gi> element should be used to denote unordered constructs.</desc>
-      <desc xml:lang="en" versionDate="2023-03-21">if false, indicates that
-      component elements of a sequence may occur in any order.</desc>
+      <desc xml:lang="en" versionDate="2023-03-21">if false, indicates that component elements of a sequence may occur in any order.</desc>
       <datatype><dataRef key="teidata.truthValue"/></datatype>
     </attDef>
   </attList>

--- a/P5/Utilities/TEI-to-tei_customization.xslt
+++ b/P5/Utilities/TEI-to-tei_customization.xslt
@@ -24,7 +24,7 @@
   -->
   
   <xsl:variable name="myName" select="tokenize( static-base-uri(), '/')[last()]"/>
-  <xsl:variable name="version" select="'1.10.0'"/>
+  <xsl:variable name="version" select="'1.11.0'"/>
   <xsl:param name="versionDate" select="format-date(current-date(),'[Y]-[M01]-[D01]')"/>
 
   <!--
@@ -68,6 +68,12 @@
 
   <xsl:variable name="revisionDesc">
     <revisionDesc>
+      <change who="#sbauman.emt" when="2026-06-23">
+        Change the content models of the grouping elements
+        (<gi>alternate</gi>, <gi>interleave</gi>, and
+        <gi>sequence</gi>) so they require two children, as P5 no
+        longer does.
+      </change>
       <change who="#sbauman.emt" when="2024-09-20">
         Add capability for new <gi>constraintDecl</gi> element:
         * Require <att>scheme</att>
@@ -685,7 +691,7 @@
             customization.</p>
             <p>We call this TEI language the <name>TEI ODD Customization for writing TEI ODD
                 Customizations</name> language (or TOCTOC for short).
-              It is instantited in the TEI exemplar <name type="file">tei_customization</name>,
+              It is instantiated in the TEI exemplar <name type="file">tei_customization</name>,
               which differs from <name
                   type="file">tei_odds</name><note>Available in <ref
                     target="https://raw.githubusercontent.com/TEIC/TEI/dev/P5/Exemplars/tei_odds.odd"
@@ -694,17 +700,21 @@
               <list>
                 <item>constraining the elements available (e.g., <gi>gap</gi> and
                     <gi>imprimatur</gi> are not available)</item>
+                <item>altering the content model of some elements (in
+                    particular, the <gi>alternate</gi>, <gi>interleave</gi>, and
+                    <gi>sequence</gi> elements are required to have two
+                    children each)</item>
                 <item>requiring some otherwise optional attributes (e.g., <att>mode</att> of
                     <gi>classes</gi>, or <att>module</att> on <gi>elementSpec</gi> unless the
                     <att>mode</att> is specified as <val>add</val>)</item>
                 <item>limiting the content of <gi>constraint</gi> to ISO Schematron, and thus
-                  permitting validation of the Schematron therein</item>
+                    permitting validation of the Schematron therein</item>
                 <item>constraining the values of several attributes</item>
                 <item>requiring that the four required modules be imported</item>
                 <item>requiring that <gi>altIdent</gi> be an NCName (i.e., not have a prefix) unless
-                it is the child of <gi>valItem</gi> (or <gi>taxonomy</gi>)</item>
+                    it is the child of <gi>valItem</gi> (or <gi>taxonomy</gi>)</item>
                 <item>flagging <tag>*Spec</tag> elements that are neither in the <gi>schemaSpec</gi>
-                  nor referred to from a <gi>specGrpRef</gi> within it</item>
+                    nor referred to from a <gi>specGrpRef</gi> within it</item>
                 <item>warning if required elements (e.g., <gi>teiHeader</gi>) are deleted</item>
                 <item>using, and encouraging the use of, the
                 <att>prefix</att> attribute of
@@ -1256,6 +1266,89 @@
                 </content>
               </elementSpec>
 
+              <elementSpec module="tagdocs" ident="alternate" mode="change">
+                <content>
+                <!--
+                    What we would like to have is
+                      <interleave>
+                        <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
+                        <alternate>
+                          <classRef key="model.contentPart" minOccurs="1" maxOccurs="1"/>
+                          <elementRef key="valList" minOccurs="0" maxOccurs="1">
+                        </alternate>
+                      </interleave>
+                    OR, equivalently,
+                    ( model.contentPart+ & ( model.contentPart | valList? ) )
+                    but
+                    a) that is not valid in RELAX NG, anyway (because
+                       model.contentPart is a member of an interleave
+                       more than once); and
+                    b) even if it were it probably could not be converted to DTD (or to XSD?)
+                       due to ambiguity.   
+    
+                    So the following mildly complex content model does the
+                    same thing without use of <interleave> and in an
+                    unambiguous way. (Thus it can be converted to a valid
+                    DTD.) Here is a briefly annotated version of the ODD
+                    content model that follows, expressed using the RELAX
+                    NG compact syntax instead:
+                    (
+                      ( valList, model.contentPart+ )        # starts with <valList>
+                      |                                      # (and is followed by %contentPart;s)
+                      (                                      # OR
+                        model.contentPart,                   # starts with %contentPart;
+                        (                                    #   which is followed by
+                          valList                            #     <valList>
+                          |                                  #     or
+                          ( model.contentPart+, valList? )   #     more %contentPart;s and maybe a <valList>
+                        )
+                      )
+                    )
+                -->
+                <alternate minOccurs="1" maxOccurs="1">
+                  <!--
+                      Two possible sets of children: my content either starts with
+                      <valList> or with a member of model.contentPart.
+                  -->
+                  <sequence minOccurs="1" maxOccurs="1">
+                    <!-- Content starts with <valList> is simple: a single
+                         <valList> followed by one or more members of
+                         model.contentPart: -->
+                    <elementRef key="valList" minOccurs="1" maxOccurs="1"/>
+                    <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
+                  </sequence>
+                  <sequence minOccurs="1" maxOccurs="1">
+                    <!-- Content starts with a member of model.contentPart is not
+                         as simple: after the single initial member of
+                         model.contentPart we could either have just a <valList>
+                         (for a total of 2 children) or we could have an
+                         additional one or more members of model.contentPart,
+                         optionally followed by a <valList>. -->
+                    <classRef key="model.contentPart" minOccurs="1" maxOccurs="1"/>
+                    <alternate minOccurs="1" maxOccurs="1">
+                      <elementRef key="valList" minOccurs="1" maxOccurs="1"/>
+                      <sequence minOccurs="1" maxOccurs="1">
+                        <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>       
+                        <elementRef key="valList" minOccurs="0" maxOccurs="1"/>
+                      </sequence>
+                    </alternate>
+                  </sequence>
+                </alternate>
+                </content>
+              </elementSpec>
+
+              <elementSpec module="tagdocs" ident="interleave" mode="change">
+                <content>
+                  <classRef key="model.contentPart" minOccurs="2" maxOccurs="unbounded"/>
+                </content>
+              </elementSpec>
+              
+              <elementSpec module="tagdocs" ident="sequence" mode="change">
+                <content>
+                  <classRef key="model.contentPart" minOccurs="2" maxOccurs="unbounded"/>
+                </content>
+              </elementSpec>
+              
               <elementSpec module="tagdocs" ident="valList" mode="change">
                 <attList>
                   <attDef mode="change" ident="type" usage="req"/>

--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -700,12 +700,85 @@
             <content>, or <sequence>, we are not allowing ourselves to
             use it within P5 at all.
         -->
-        <elementSpec module="tagdocs" ident="interleave" mode="change">
-          <classes>
-            <memberOf key="att.repeatable" mode="delete"/>
-          </classes>
-        </elementSpec>
+        <elementSpec module="tagdocs" ident="interleave" mode="delete"/>
 
+        <elementSpec module="tagdocs" ident="alternate" mode="change">
+          <content>
+            <!--
+                What we would like to have is
+                  <interleave>
+                    <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
+                    <alternate>
+                      <classRef key="model.contentPart" minOccurs="1" maxOccurs="1"/>
+                      <elementRef key="valList" minOccurs="0" maxOccurs="1">
+                    </alternate>
+                  </interleave>
+                OR, equivalently,
+                ( model.contentPart+ & ( model.contentPart | valList? ) )
+                but
+                a) that is not valid in RELAX NG, anyway (because
+                   model.contentPart is a member of an interleave
+                   more than once); and
+                b) even if it were it probably could not be converted to DTD (or to XSD?)
+                   due to ambiguity.   
+
+                So the following mildly complex content model does the
+                same thing without use of <interleave> and in an
+                unambiguous way. (Thus it can be converted to a valid
+                DTD.) Here is a briefly annotated version of the ODD
+                content model that follows, expressed using the RELAX
+                NG compact syntax instead:
+                (
+                  ( valList, model.contentPart+ )        # starts with <valList>
+                  |                                      # (and is followed by %contentPart;s)
+                  (                                      # OR
+                    model.contentPart,                   # starts with %contentPart;
+                    (                                    #   which is followed by
+                      valList                            #     <valList>
+                      |                                  #     or
+                      ( model.contentPart+, valList? )   #     more %contentPart;s and maybe a <valList>
+                    )
+                  )
+                )
+            -->
+            <alternate minOccurs="1" maxOccurs="1">
+              <!--
+                  Two possible sets of children: my content either starts with
+                  <valList> or with a member of model.contentPart.
+              -->
+              <sequence minOccurs="1" maxOccurs="1">
+                <!-- Content starts with <valList> is simple: a single
+                     <valList> followed by one or more members of
+                     model.contentPart: -->
+                <elementRef key="valList" minOccurs="1" maxOccurs="1"/>
+                <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>
+              </sequence>
+              <sequence minOccurs="1" maxOccurs="1">
+                <!-- Content starts with a member of model.contentPart is not
+                     as simple: after the single initial member of
+                     model.contentPart we could either have just a <valList>
+                     (for a total of 2 children) or we could have an
+                     additional one or more members of model.contentPart,
+                     optionally followed by a <valList>. -->
+                <classRef key="model.contentPart" minOccurs="1" maxOccurs="1"/>
+                <alternate minOccurs="1" maxOccurs="1">
+                  <elementRef key="valList" minOccurs="1" maxOccurs="1"/>
+                  <sequence minOccurs="1" maxOccurs="1">
+                    <classRef key="model.contentPart" minOccurs="1" maxOccurs="unbounded"/>       
+                    <elementRef key="valList" minOccurs="0" maxOccurs="1"/>
+                  </sequence>
+                </alternate>
+              </sequence>
+            </alternate>
+          </content>
+        </elementSpec>
+        
+        <elementSpec module="tagdocs" ident="sequence" mode="change">
+          <content>
+            <classRef key="model.contentPart" minOccurs="2" maxOccurs="unbounded"/>
+          </content>
+        </elementSpec>
+        
         <elementSpec ident="classes" mode="change" module="tagdocs">
           <constraintSpec mode="add" scheme="schematron" ident="order_of_membership">
             <desc>Added per <ref target="https://github.com/TEIC/TEI/issues/2463">#2463</ref>.</desc>

--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -50,7 +50,7 @@
           </attList>
         </elementSpec>
         
-        <constraintSpec scheme="schematron" ident="when_glosses_English_required">
+        <constraintSpec scheme="schematron" ident="when_glosses_English_required" xml:lang="en">
           <desc>Per <ref
           target="https://github.com/TEIC/TEI/issues/2037">ticket
           237</ref>, Council has decided that every specification
@@ -173,7 +173,7 @@
           </content>
         </elementSpec>
         <elementSpec ident="eg" mode="change" module="tagdocs">
-          <constraintSpec ident="no_leading_nor_trailing_new_newlines" scheme="schematron">
+          <constraintSpec ident="no_leading_nor_trailing_new_newlines" scheme="schematron" xml:lang="en">
             <desc xml:lang="en" versionDate="2020-12-18">
               In order to prevent inconsistent <soCalled>sizes</soCalled> of the box
               that holds the example in the HTML output, and even moreso to avoid
@@ -477,7 +477,7 @@
         </elementSpec>
 
         <classSpec ident="att.translatable" mode="change" type="atts">
-          <constraintSpec mode="add"
+          <constraintSpec mode="add" xml:lang="en"
                           ident="require-translatability"
                           scheme="schematron">
             <constraint>
@@ -506,7 +506,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec mode="add" ident="en-first" scheme="schematron">
+          <constraintSpec mode="add" ident="en-first" scheme="schematron" xml:lang="en">
             <desc xml:lang="en" versionDate="2022-05-13">Per ticket
               <ref target="https://github.com/TEIC/TEI/issues/2279">2279</ref>,
               require that the English translatable element goes
@@ -538,7 +538,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec mode="add" ident="only-one-each-lang" scheme="schematron">
+          <constraintSpec mode="add" ident="only-one-each-lang" scheme="schematron" xml:lang="en">
             <desc xml:lang="en" versionDate="2022-05-13">Per ticket <ref target="https://github.com/TEIC/TEI/issues/2279">2279</ref>, require that there be only one
               of any given att.translatable element sibling for any given language. Note that
               we would prefer to be able to say <said>a member of att.translatable</said>, but
@@ -574,7 +574,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="all-sibling-parent-desc" scheme="schematron">
+          <constraintSpec ident="all-sibling-parent-desc" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="*[tei:desc[@versionDate]]">
                 <sch:report role="nonfatal" test="count( tei:desc )
@@ -586,7 +586,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="all-sibling-parent-gloss" scheme="schematron">
+          <constraintSpec ident="all-sibling-parent-gloss" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="*[tei:gloss[@versionDate]]">
                 <sch:report role="nonfatal" test="count( tei:gloss )
@@ -598,7 +598,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="all-sibling-parent-remarks" scheme="schematron">
+          <constraintSpec ident="all-sibling-parent-remarks" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="*[tei:remarks[@versionDate]]">
                 <sch:report role="nonfatal" test="count( tei:remarks )
@@ -610,7 +610,7 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec ident="all-sibling-parent-valDesc" scheme="schematron">
+          <constraintSpec ident="all-sibling-parent-valDesc" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="*[tei:valDesc[@versionDate]]">
                 <sch:report role="nonfatal" test="
@@ -696,11 +696,20 @@
             Stylesheets cannot generate a DTD from that
             ODD. Furthermore, it would be very difficult to impossible
             to alter the Stylesheets do so. Thus although vanilla P5
-            alows for <interleave> to occur inside <alternation>,
+            allows for <interleave> to occur inside <alternation>,
             <content>, or <sequence>, we are not allowing ourselves to
             use it within P5 at all.
+            HOWEVER, we cannot actually delete the entire element here
+            because (I think) of the way examples are validated during
+            our build process. They (the content of the <egXML>
+            elements) are (incorrectly, IMHO) validated against
+            p5odds, not against tei_all.
         -->
-        <elementSpec module="tagdocs" ident="interleave" mode="delete"/>
+        <elementSpec module="tagdocs" ident="interleave" mode="change">
+          <classes>
+            <memberOf key="att.repeatable" mode="delete"/>
+          </classes>
+        </elementSpec>
 
         <elementSpec module="tagdocs" ident="alternate" mode="change">
           <content>
@@ -780,7 +789,7 @@
         </elementSpec>
         
         <elementSpec ident="classes" mode="change" module="tagdocs">
-          <constraintSpec mode="add" scheme="schematron" ident="order_of_membership">
+          <constraintSpec mode="add" scheme="schematron" ident="order_of_membership" xml:lang="en">
             <desc>Added per <ref target="https://github.com/TEIC/TEI/issues/2463">#2463</ref>.</desc>
             <constraint>
               <sch:rule context="tei:classes">
@@ -831,7 +840,7 @@
         </macroSpec>
 
         <elementSpec mode="change" ident="TEI">
-          <constraintSpec ident="must-have-attglobal" scheme="schematron" mode="add">
+          <constraintSpec ident="must-have-attglobal" scheme="schematron" mode="add" xml:lang="en">
             <constraint>
               <sch:rule context="tei:elementSpec[not(@mode)]">
                 <sch:assert test="tei:classes/tei:memberOf[@key='att.global']">Error: TEI element <sch:value-of select="@ident"/> must be member of att.global class</sch:assert>
@@ -841,7 +850,7 @@
         </elementSpec>
 
         <elementSpec ident="remarks" mode="change">          
-          <constraintSpec ident="only-one-remark-per-lang" scheme="schematron" mode="add">
+          <constraintSpec ident="only-one-remark-per-lang" scheme="schematron" mode="add" xml:lang="en">
             <constraint>
               <sch:rule context="tei:remarks[@xml:lang]">
                 <sch:let name="langVal" value="@xml:lang"/>
@@ -857,7 +866,7 @@
 
         <!-- Per TEI ticket #2285, restrict where <altIdent> can go in GLs. -->
         <elementSpec ident="altIdent" module="tagdocs" mode="change">
-          <constraintSpec scheme="schematron" ident="restricted-altIdent-placement">
+          <constraintSpec scheme="schematron" ident="restricted-altIdent-placement" xml:lang="en">
             <constraint>
               <sch:rule context="tei:altIdent">
                 <sch:assert test="parent::tei:elementSpec|parent::tei:attDef|parent::tei:valItem">The &lt;altIdent> element should only be used as a child of &lt;elementSpec>, &lt;attDef>, or &lt;valItem>.</sch:assert>
@@ -867,7 +876,7 @@
         </elementSpec>
         
         <dataSpec ident="teidata.temporal.working" mode="change">
-          <constraintSpec ident="not_in_future" scheme="schematron">
+          <constraintSpec ident="not_in_future" scheme="schematron" xml:lang="en">
             <desc>When a <att>versionDate</att> is specified, its value
             should not be in the future.</desc>
             <!-- Note that this constraint is fired on the specific *attributes* that


### PR DESCRIPTION
This PR addresses #2913 by removing from P5 the constraint that an `<alternate>`, `<interleave>`, or `<sequence>` must have two or more children, and adding that same constraint to p5odds and tei_customization.

It also fixes the bug discovered in #2734 wherein `<valList>` was allowed to occur as a child of `<alternate>` more than once. (Which should not be allowed, in large part because the Stylesheets drop the entire construct when this happens.)