### PR TITLE
Update DOI badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Text Encoding Initiative Repository
 
 [![GitHub release](https://img.shields.io/github/release/TEIC/TEI.svg)](https://github.com/TEIC/TEI/releases)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3413524.svg)](https://doi.org/10.5281/zenodo.3413524)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.3413524-blue)](https://doi.org/10.5281/zenodo.3413524)
 [![TEI Guidelines Tests](https://github.com/TEIC/TEI/actions/workflows/test.yml/badge.svg)](https://github.com/TEIC/TEI/actions/workflows/test.yml)
 
 The [TEI](https://www.tei-c.org) is an international and interdisciplinary standard used by libraries, museums, publishers, and academics to represent all kinds of literary and linguistic texts, using an encoding scheme that is maximally expressive and minimally obsolescent.


### PR DESCRIPTION
The zenodo badge is doing nothing more than fetching and filling in a badge from `shields.io`, with the disadvantage, that it is not displayed whenever zenodo is down. With this change it takes the badge directly without the detour. 