### PR TITLE
Make birth and death members of att.locatable (addresses #2873)

### DIFF
--- a/P5/Source/Specs/birth.xml
+++ b/P5/Source/Specs/birth.xml
@@ -83,7 +83,7 @@
   </exemplum>
   <exemplum xml:lang="en">
     <!--Example derived from https://lim.dhil.lib.sfu.ca/BURKE1.html-->
-    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-birth-egXML-where">
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-birth-egXML-wh">
       <birth where="https://www.wikidata.org/wiki/Q662158">Born on the Island of <placeName>North Uist</placeName></birth>
     </egXML>
   </exemplum>

--- a/P5/Source/Specs/birth.xml
+++ b/P5/Source/Specs/birth.xml
@@ -16,6 +16,7 @@
     <memberOf key="att.datable"/>
     <memberOf key="att.dimensions"/>
     <memberOf key="att.editLike"/>
+    <memberOf key="att.locatable"/>
     <memberOf key="att.naming"/>
     <memberOf key="att.typed"/>
     <memberOf key="model.personPart"/>
@@ -78,6 +79,12 @@
       <birth when="1960-12-10">In a small cottage near <name type="place">Aix-la-Chapelle</name>,
         early in the morning of <date>10 Dec 1960</date>
          </birth>
+    </egXML>
+  </exemplum>
+  <exemplum xml:lang="en">
+    <!--Example derived from https://lim.dhil.lib.sfu.ca/BURKE1.html-->
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-birth-egXML-where">
+      <birth where="https://www.wikidata.org/wiki/Q662158">Born on the Island of <placeName>North Uist</placeName></birth>
     </egXML>
   </exemplum>
   <listRef>

--- a/P5/Source/Specs/death.xml
+++ b/P5/Source/Specs/death.xml
@@ -71,10 +71,10 @@
     </egXML>
   </exemplum>
   <exemplum xml:lang="en">
-    <!--Example taken from https://lyoninmourning.dhil.lib.sfu.ca/BURKE1.html-->
-    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-death-egXML-where">
-      <death when="1751-11-23" where="plc:EDIN2">Died in <placeName ref="plc:EDIN2">Edinburgh</placeName> on <date when="1751-11-23">November 23, 1751</date>.</death>
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-death-egXML-wh">
+      <death when="2024-08-16" where="gn:US-NM-039-5467024"/>
     </egXML>
+    <p>In this example, the value of <att>where</att> demonstrates the use of private URI scheme and custom prefix (<val>gn:</val>), which would typically be defined by a <gi>prefixDef</gi> in the document's <gi>teiHeader</gi>.</p>
   </exemplum>
   <listRef>
     <ptr target="#CCAHPA"/>

--- a/P5/Source/Specs/death.xml
+++ b/P5/Source/Specs/death.xml
@@ -16,6 +16,7 @@
     <memberOf key="att.datable"/>
     <memberOf key="att.dimensions"/>
     <memberOf key="att.editLike"/>
+    <memberOf key="att.locatable"/>
     <memberOf key="att.naming"/>
     <memberOf key="att.typed"/>
     <memberOf key="model.personPart"/>
@@ -67,6 +68,12 @@
   <exemplum xml:lang="en">
     <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-death-egXML-cj">
       <death when="1960-12-10">Passed away near <name type="place">Aix-la-Chapelle</name>, after suffering from cerebral palsy. </death>
+    </egXML>
+  </exemplum>
+  <exemplum xml:lang="en">
+    <!--Example taken from https://lyoninmourning.dhil.lib.sfu.ca/BURKE1.html-->
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-death-egXML-where">
+      <death when="1751-11-23" where="plc:EDIN2">Died in <placeName ref="plc:EDIN2">Edinburgh</placeName> on <date when="1751-11-23">November 23, 1751</date>.</death>
     </egXML>
   </exemplum>
   <listRef>


### PR DESCRIPTION
Fairly straightforward addition of att.locatable to birth and death. I've added a couple of examples (both derived from The Lyon in Mourning where we incidentally had customized the `<birth>` and `<death>` already to have `@where`!), but did not touch any of the prose or examples in ND. 