### PR TITLE
Fix a few instances where descs started with a capital

### DIFF
--- a/P5/Source/Specs/dataFacet.xml
+++ b/P5/Source/Specs/dataFacet.xml
@@ -2,7 +2,7 @@
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="tagdocs" xml:id="gi-dataFacet" ident="dataFacet">
-  <desc versionDate="2016-11-21" xml:lang="en">Restricts the value of the strings used to represent values of a datatype, 
+  <desc versionDate="2016-11-21" xml:lang="en">restricts the value of the strings used to represent values of a datatype, 
     according to <ref target="#XSD2">XML Schema Part 2: Datatypes Second Edition</ref>.</desc>
   <desc versionDate="2024-09-02" xml:lang="ja"><ref target="#XSD2">XML Schemas: Part 2: Datatypes</ref>に従って、データ型の値を表すために使用される文字列の値を制限する。</desc>
   <classes>

--- a/P5/Source/Specs/secl.xml
+++ b/P5/Source/Specs/secl.xml
@@ -3,7 +3,7 @@
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="transcr" xml:id="gi-secl" ident="secl">
   <gloss versionDate="2015-08-06" xml:lang="en">secluded text</gloss>
-  <desc versionDate="2015-05-30" xml:lang="en">Secluded. Marks text present in the source which the editor believes to be genuine but out of its original place (which is unknown).</desc>
+  <desc versionDate="2015-05-30" xml:lang="en">marks text present in the source which the editor believes to be genuine but out of its original place (which is unknown).</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.dimensions"/>

--- a/P5/Source/Specs/standOff.xml
+++ b/P5/Source/Specs/standOff.xml
@@ -2,7 +2,7 @@
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" module="linking" xml:id="gi-standOff" ident="standOff">
-  <desc xml:lang="en" versionDate="2018-10-31">Functions as a container element for linked data, contextual information, and stand-off annotations embedded in a TEI document.</desc>
+  <desc xml:lang="en" versionDate="2018-10-31">functions as a container element for linked data, contextual information, and stand-off annotations embedded in a TEI document.</desc>
   <desc xml:lang="ja" versionDate="2023-07-29">リンクト・データや文脈情報、TEI文書に埋め込まれたスタンドオフ・アノテーションをコンテナ化する要素として機能する。</desc>
   <classes>
     <memberOf key="att.global"/>


### PR DESCRIPTION
I recently noticed that the description of the [standOff element](https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-standOff.html) looked a bit off: 

> `<standOff>` Functions as a container element for linked data, contextual information, and stand-off annotations embedded in a TEI document. 

I could only find two other instances in the Guidelines where a `*Spec` element had an English desc that started with a capital letter; both ought to be updated to be lowercase IMO, which is what this PR does. (This is a fairly small / trivial fix, but thought I ought to make a PR rather than commit right to dev)