### PR TITLE
add required XLink namespace decls

### DIFF
--- a/P5/Test/testplus.odd
+++ b/P5/Test/testplus.odd
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0"
+     xmlns:xi="http://www.w3.org/2001/XInclude"
+     xmlns:rng="http://relaxng.org/ns/structure/1.0"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     xml:lang="en">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/P5/p5odds-examples.odd
+++ b/P5/p5odds-examples.odd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -4,6 +4,7 @@
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5odds.isosch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0"
      xmlns:rng="http://relaxng.org/ns/structure/1.0"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
      xmlns:sqf="http://www.schematron-quickfix.com/validator/process"
      xmlns:sch="http://purl.oclc.org/dsdl/schematron" >
   <teiHeader>


### PR DESCRIPTION
This morning Council merged Stylesheets#811, as it passed the tests in the Stylesheets repo. But we forgot to check the tests in the TEI repo, where (apparently) three files had relied on that system. Here we fix #2930 by just adding an explicit namespace declaration for XLink in those three files.