### PR TITLE
replace broken link

### DIFF
--- a/P5/Source/Guidelines/en/USE.xml
+++ b/P5/Source/Guidelines/en/USE.xml
@@ -743,10 +743,9 @@ that practice. -->
         how the TEI encoding schema might be adopted to meet 90% of the needs of 90% of the TEI user
         community, the TEI editors produced a brief tutorial defining one specific
           <soCalled>clean</soCalled> modification of the TEI schema, which they called TEI Lite.
-        This tutorial and its associated DTD became very popular and are still available from the
-        TEI web site at <ptr target="http://www.tei-c.org/Guidelines/Customization/Lite/"/>. The
-        tutorial and associated schema specification is also included as one of the exemplars
-        provided with TEI P5. </p>
+        This tutorial and its associated DTD became very popular and remain available in the TEI P5 Vault at <ptr target="https://tei-c.org/Vault/P4/Lite/"/>. The
+        lastest version of the tutorial and associated schema specification is included as one of the exemplars
+        provided with TEI P5 and is available from the TEI web site at <ptr target="https://tei-c.org/guidelines/customization/"/>. </p>
       <p>An updated and expanded version of this schema known as <ident>TEI simplePrint</ident> was
         added to the Exemplars at release 3.1.0. The elements it defines have been modified to take
         advantage of the <soCalled>processing model</soCalled> features (see further <ptr target="#TDPM"/>) introduced to the Guidelines at release 3.0.0. </p>


### PR DESCRIPTION
This replaces the broken link in USE.xml, addressing #2700. Rather than linking to the PDF suggested in the issue, it points to the TEI P4 Vault, where both the tutorial and its DTD are available. It also adds a link to the TEI P5 customization page on the TEI website, which provides the current version of TEI Lite.