### PR TITLE
Add  `<witness>` to class `att.typed`

### DIFF
--- a/P5/Source/Specs/witness.xml
+++ b/P5/Source/Specs/witness.xml
@@ -19,6 +19,7 @@ referred to by a single sigil.</desc>
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.sortable"/>
+    <memberOf key="att.typed"/>
   </classes>
   <content>
     <alternate minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
This PR addresses issue #2944 and adds  `<witness>` to class `att.typed`. 

The `<witness>` element is repeatable and categorising `<witness>` elements is justifiable.