### PR TITLE
fix ambiguous sample DTD content model

### DIFF
--- a/P5/Source/Specs/interleave.xml
+++ b/P5/Source/Specs/interleave.xml
@@ -37,18 +37,24 @@
     <gi>note</gi> element, in any order.</p>
     <p>To express this content model in a DTD, the original schema
     language for XML, one might use
-    <eg xml:space="preserve">(   persName
-      | ( persName, note )
-      | ( persName, ( placeName | location ) ) 
-      | ( note, persName )
-      | ( ( placeName | location ), persName )
-      | ( persName, note, ( placeName | location ) )
-      | ( persName, ( placeName | location ), note )
-      | ( note, persName, ( placeName | location ) )
-      | ( note, ( placeName | location ), persName )
-      | ( ( placeName | location ), note, persName )
-      | ( ( placeName | location ), persName, note )
-    )</eg></p>
+    <eg xml:space="preserve">  ( location,  (   ( note,                   persName? ) | ( persName, note?                     ) )? )
+|
+  ( note,      ( ( ( location | placeName ), persName? ) | ( persName, ( location | placeName )? ) )? )
+|
+  ( persName,  ( ( ( location | placeName ), note?     ) | ( note,     ( location | placeName )? ) )? )
+|
+  ( placeName, (   ( note,                   persName? ) | ( persName, note?                     ) )? )
+)</eg></p>
+<!-- also deterministic, aka non-ambiguous; and more what I would
+     probably write, but a bit less easy to make sense of:
+(
+  ( persName, ( ( ( placeName | location ), note? ) | ( note, ( placeName | location )? ) )? )
+|
+  ( ( placeName | location ), ( ( note, persName? ) | ( persName, note? ) )? )
+|
+  ( note, ( ( ( placeName | location ), persName? ) | ( persName, ( placeName | location )? ) )? )
+)
+ — Syd, 2026-08-15 -->
   </exemplum>
   <remarks ident="interleave-remarks" xml:lang="en" versionDate="2025-05-18">
     <p>If an ODD file makes use of this element, current processing


### PR DESCRIPTION
This PR addresses #2937 by replacing the sample DTD content model in the `<interleave>` tagdoc with a deterministic (aka non-ambiguous) version of same.

Recommended review process:

- Download the [error demonstration file](https://github.com/user-attachments/files/30482094/sample_DTD_problem_demo.zip) from the ticket itself; this file contains a copy of the current content model
- Convince yourself the content model in the downloaded file matches that which is in the current tagdoc for interleave (on release or dev)
- Convince yourself the content model is ambiguous, either through inspection or by validating that file (with something other than a modern version of oXygen)
-  Download the [fixed_DTD_demo.zip](https://github.com/user-attachments/files/31113169/fixed_DTD_demo.zip), the same file with the new version of the content model
- Convince yourself the content model in that new file matches that which is in the tagdoc for interleave on this branch
- Convince yourself that this new version is deterministic, either through inspection or validating that file (with something other than a modern version of oXygen)