### PR TITLE
remove `@mode` from `<schemaSpec>`

### DIFF
--- a/P5/Source/Specs/schemaSpec.xml
+++ b/P5/Source/Specs/schemaSpec.xml
@@ -17,7 +17,7 @@
   <classes>
     <memberOf key="att.global"/>
     <memberOf key="att.docStatus"/>
-    <memberOf key="att.identified"/>
+    <memberOf key="att.identified"/> <!-- except @mode removed -->
     <memberOf key="att.namespaceable"/>
     <memberOf key="model.encodingDescPart"/>
     <memberOf key="model.frontPart"/>
@@ -38,6 +38,7 @@
     </sequence>
   </content>
   <attList>
+    <attDef ident="mode" mode="delete"/>
     <attDef ident="start" usage="opt">
       <desc versionDate="2010-05-14" xml:lang="en">specifies entry points to the schema, i.e. which patterns may be used as the root of documents conforming to it.</desc>
       <desc versionDate="2007-12-20" xml:lang="ko">스키마에서 표제 항목 지점을 명시한다. 즉, 어떤 요소가 해당 문서의 뿌리로 사용되는 것이 허용되었는지를 명시한다.</desc>


### PR DESCRIPTION
Per #2846, I removed `@mode` from the `<schemaSpec>` element itself, as it gets it from a subclass, not a class it is directly a member of. Passes tests in a Docker on my machine.

In case it is not obvious, this has not been deprecated because I consider it a (flagrant) corrigible error. Not only do we have no idea what `schemaSpec/@mode` means, I submit we do not have much clue as to what it _might_ mean.

I have listed all of Council except @martindholmes, who has already approved the idea, as possible reviewers. I do not really think it needs nine reviews. :smile: 

N.B. TEIC/Stylesheets#817