### PR TITLE
allow only one child `<desc>`, `<gloss>`, or `<remarks>` of a given language

### DIFF
--- a/P5/Source/Specs/att.translatable.xml
+++ b/P5/Source/Specs/att.translatable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
-<classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tagdocs" type="atts" ident="att.translatable" predeclare="true">
+<classSpec xmlns="http://www.tei-c.org/ns/1.0" module="tagdocs" type="atts" ident="att.translatable" xmlns:sch="http://purl.oclc.org/dsdl/schematron" predeclare="true">
   <desc versionDate="2006-10-15" xml:lang="en">provides attributes used to  indicate the status of a translatable
 portion of an ODD document.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">ODD 문서의 번역 가능 부분의 상태를 나타내는 속성을 제시한다.</desc>
@@ -11,6 +11,53 @@ portion of an ODD document.</desc>
       d'une partie traduisible d'un document ODD.</desc>
   <desc versionDate="2007-05-04" xml:lang="es">proporciona atributos utilizados para indicar el estatus de un fragmento traducibile de un documento aislado.</desc>
   <desc versionDate="2007-01-21" xml:lang="it">assegna degli attributi utilizzati per indicare lo status di una porzione traducibile di un documento isolato.</desc>
+  <constraintSpec mode="add" ident="only-one-each-lang" scheme="schematron" xml:lang="en">
+    <!-- Added per ticket https://github.com/TEIC/TEI/issues/2729 -->
+    <desc xml:lang="en" versionDate="2026-08-21">
+      This constraint requires that there be only one of any sibling
+      element type from att.translatable with a given <att>type</att>
+      for any given natural language. Note that to determine natural
+      language we simply compare <att>xml:lang</att> values, such that
+      <val>fr-CA</val> and <val>fr-FR</val> would be considered
+      different languages.
+      <!-- We may want to be smarter about this in the future. -->
+    </desc>
+    <!--
+        We would prefer to be able to say “a member of
+        att.translatable”, but there is currently no way
+        to do that, so we just enumerate them.
+    -->
+    <constraint>
+      <sch:rule context="  tei:elementSpec/tei:desc
+                         | tei:elementSpec/tei:gloss
+                         | tei:elementSpec/tei:remarks
+                         | tei:classSpec/tei:desc
+                         | tei:classSpec/tei:gloss
+                         | tei:classSpec/tei:remarks
+                         | tei:macroSpec/tei:desc
+                         | tei:macroSpec/tei:gloss
+                         | tei:macroSpec/tei:remarks
+                         | tei:attDef/tei:desc
+                         | tei:attDef/tei:gloss
+                         | tei:attDef/tei:remarks
+                         | tei:valItem/tei:desc
+                         | tei:valItem/tei:gloss
+                         | tei:valItem/tei:remarks
+                         | tei:moduleSpec/tei:desc
+                         | tei:moduleSpec/tei:gloss
+                         | tei:moduleSpec/tei:remarks
+                         ">
+        <sch:let name="myGI" value="name(.)"/>
+        <sch:let name="noType" value="not( @type )"/>
+        <sch:let name="myType" value="normalize-space( @type )"/>
+        <sch:let name="lang" value="normalize-space( ancestor-or-self::*[@xml:lang][1]/@xml:lang )"/>
+        <sch:report test="preceding-sibling::*[ name(.) eq $myGI ]
+                                              [ ( not( @type) and $noType )  or  normalize-space( @type ) eq $myType ]
+                                              [ normalize-space( ancestor-or-self::*[@xml:lang][1]/@xml:lang ) eq $lang ]">
+        The sibling &lt;<sch:value-of select="$myGI"/>> children of a &lt;<sch:value-of select="name(..)"/>> should each have a different @xml:lang; this one duplicates the "<sch:value-of select="$lang"/>" of a preceding sibling.</sch:report>
+      </sch:rule>
+    </constraint>
+  </constraintSpec>
   <attList>
     <attDef ident="versionDate" usage="opt">
       <desc versionDate="2012-05-23" xml:lang="en">specifies the date on which the source text was extracted and sent to the translator</desc>

--- a/P5/p5odds.odd
+++ b/P5/p5odds.odd
@@ -538,42 +538,6 @@
               </sch:rule>
             </constraint>
           </constraintSpec>
-          <constraintSpec mode="add" ident="only-one-each-lang" scheme="schematron" xml:lang="en">
-            <desc xml:lang="en" versionDate="2022-05-13">Per ticket <ref target="https://github.com/TEIC/TEI/issues/2279">2279</ref>, require that there be only one
-              of any given att.translatable element sibling for any given language. Note that
-              we would prefer to be able to say <said>a member of att.translatable</said>, but
-              there is currently no way to that, so we enumerate them. Also note that we simply
-              compare <att>xml:lang</att> values, such that <val>fr-CA</val> and <val>fr-FR</val>
-              would be considered different languages. (We may want to be smarter about this in
-              the future.)</desc>
-            <constraint>
-              <sch:rule context="  tei:elementSpec/tei:desc[ position() gt 1 ]
-                                 | tei:elementSpec/tei:gloss[ position() gt 1 ]
-                                 | tei:elementSpec/tei:remarks[ position() gt 1 ]
-                                 | tei:classSpec/tei:desc[ position() gt 1 ]
-                                 | tei:classSpec/tei:gloss[ position() gt 1 ]
-                                 | tei:classSpec/tei:remarks[ position() gt 1 ]
-                                 | tei:macroSpec/tei:desc[ position() gt 1 ]
-                                 | tei:macroSpec/tei:gloss[ position() gt 1 ]
-                                 | tei:macroSpec/tei:remarks[ position() gt 1 ]
-                                 | tei:attDef/tei:desc[ position() gt 1 ]
-                                 | tei:attDef/tei:gloss[ position() gt 1 ]
-                                 | tei:attDef/tei:remarks[ position() gt 1 ]
-                                 | tei:valItem/tei:desc[ position() gt 1 ]
-                                 | tei:valItem/tei:gloss[ position() gt 1 ]
-                                 | tei:valItem/tei:remarks[ position() gt 1 ]
-                                 | tei:moduleSpec/tei:desc[ position() gt 1 ]
-                                 | tei:moduleSpec/tei:gloss[ position() gt 1 ]
-                                 | tei:moduleSpec/tei:remarks[ position() gt 1 ]
-                                  ">
-                <sch:let name="myGI" value="name(.)"/>
-                <sch:let name="myType" value="@type"/>
-                <sch:let name="hasType" value="if (@type) then true() else false()"/>
-                <sch:let name="lang" value="normalize-space( @xml:lang )"/>
-                <sch:report test="preceding-sibling::*[ name(.) eq $myGI ][(not(@type) and not($hasType)) or @type eq $myType][ normalize-space( @xml:lang) eq $lang ]">The sibling <sch:value-of select="$myGI"/> children of a <sch:value-of select="name(..)"/> should each have a different @xml:lang; this one duplicates the "<sch:value-of select="$lang"/>" of a preceding sibling.</sch:report>
-              </sch:rule>
-            </constraint>
-          </constraintSpec>
           <constraintSpec ident="all-sibling-parent-desc" scheme="schematron" xml:lang="en">
             <constraint>
               <sch:rule context="*[tei:desc[@versionDate]]">


### PR DESCRIPTION
Per #2729, move the "only-one-each-lang" constraint from p5odds to p5 itself.

There are some minor differences between the code that was deleted and that which was added, though:

- In p5odds each clause of the `@context` had a predicate to prevent firing on the 1st sibling (because it has no preceding siblings that might meet the criteria we are investigating). While it might have been faster, and some might think it clearer, it might have been slower, and others would say it is more confusing. So, given that those predicates were previously problematic, I removed them. The `preceding-sibling::` axis will always be empty, so the `<sch:report>` will never fire on the 1st sibling, anyway. 
- In p5odds we _knew_ there was an `@xml:lang` on each  `<desc>`, `<gloss>`, or `<remarks>` because the schema required it. Here we do not know, so we need to look at `ancestor-or-self::*[@xml:lang][1]/@xml:lang` rather than just `@xml:lang`.
- There were things in the `<desc>` that should not appear on the tagdoc, so got moved to comments.
- The previous code failed to normalize spaces of the `@type` attrs before comparison.