### PR TITLE
Fix for issue #2949: add missing Z in @when and explanation.

### DIFF
--- a/P5/Source/Guidelines/en/CO-CoreElements.xml
+++ b/P5/Source/Guidelines/en/CO-CoreElements.xml
@@ -2443,10 +2443,13 @@ Some typical examples follow:
 <date when="--09">September</date>
 <date when="---11">Eleventh of the month</date>
 <time when="08:48:00">8:48</time>
-<date when="2001-09-11T12:48:00">Sept 11th, 12 minutes before 9 am</date>
+<date when="2001-09-11T12:48:00Z">Sept 11th, 12 minutes before 9 am</date>
 </egXML>Note in the last example the use of a normalized representation for
 the date string which includes a time: this example could thus equally
-well be tagged using the <gi>time</gi> element. 
+well be tagged using the <gi>time</gi> element. The time in the <att>when</att>
+  attribute is normalized to UTC (signified by the <q>Z</q>), while the time in 
+  the text content of the element expresses local (New York) time, which is four 
+  hours behind UTC.
 </p>
 <p>The following examples demonstrate the use of the
 <gi>date</gi> element to mark a period of time:<egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="CONADA-egXML-xe" source="#CONADA-eg-143"><p>Those five years — 


### PR DESCRIPTION
Simple fix for a confusing datetime example, per issue #2949.