### PR TITLE
make `<front>` and `<back>` content models identical and add model.listLike to them

### DIFF
--- a/P5/Source/Guidelines/en/DS-DefaultTextStructure.xml
+++ b/P5/Source/Guidelines/en/DS-DefaultTextStructure.xml
@@ -1572,6 +1572,11 @@ unusual in modern books such as the initial prayer:
 from the remainder of the text, it may be preferable simply to mark
 its presence, either by means of an empty  <gi>divGen</gi> element or
 by using an appropriate processing instruction.</p>
+<p>Conventions vary as to which elements are grouped as back matter and
+which as front.  For example, some books place the table of contents at
+the front, and others at the back. Even title pages may appear at the
+back of a book as well as at the front. The content model for
+<gi>back</gi> and <gi>front</gi> elements are therefore identical.</p>
 </div>
 <div type="div2" xml:id="DSTITL"><head>Title Pages</head>
 <p>Detailed analysis of the title page and other
@@ -1682,16 +1687,13 @@ provided in chapter <ptr target="#PH"/>.
 </specGrp>
 </div>
 <div type="div2" xml:id="DSBACK"><head>Back Matter</head>
-<p>Conventions vary as to which elements are grouped as back matter and
-which as front.  For example, some books place the table of contents at
-the front, and others at the back.  Even title pages may appear at the
-back of a book as well as at the front.  The content model for
-<gi>back</gi> and <gi>front</gi> elements are therefore identical.
- </p>
-<p>The following suggested values may be used for the <att>type</att>
-attribute on all division elements, in order to distinguish various
-kinds of division characteristic of back matter:
-<list type="gloss"><label><val>appendix</val></label>
+<p>As mentioned in <ptr target="#DSFRONT"/>, the content models of
+<gi>front</gi> and <gi>back</gi> are identical. In order to
+distinguish the various kinds of division
+characteristic of back matter, the following
+suggested values for the <att>type</att> attribute on 
+division elements might be used: <list
+type="gloss"><label><val>appendix</val></label>
 <item>An ancillary self-contained section of
 a work, often providing additional but in some sense extra-canonical
 text.</item><label><val>glossary</val></label>

--- a/P5/Source/Specs/back.xml
+++ b/P5/Source/Specs/back.xml
@@ -31,35 +31,37 @@
     <sequence>
       <alternate minOccurs="0" maxOccurs="unbounded">
         <classRef key="model.frontPart"/>
-        <classRef key="model.pLike.front"/>
-        <classRef key="model.pLike"/>
-        <classRef key="model.listLike"/>
         <classRef key="model.global"/>
-      </alternate>
-      <alternate minOccurs="0">
-        <sequence>
-          <classRef key="model.div1Like"/>
-          <alternate minOccurs="0" maxOccurs="unbounded">
-            <classRef key="model.frontPart"/>
-            <classRef key="model.div1Like"/>
-            <classRef key="model.global"/>
-          </alternate>
-        </sequence>
-        <sequence>
-          <classRef key="model.divLike"/>
-          <alternate minOccurs="0" maxOccurs="unbounded">
-            <classRef key="model.frontPart"/>
-            <classRef key="model.divLike"/>
-            <classRef key="model.global"/>
-          </alternate>
-        </sequence>
+        <classRef key="model.listLike"/>
+        <classRef key="model.pLike"/>
+        <classRef key="model.pLike.front"/>
       </alternate>
       <sequence minOccurs="0">
-        <classRef key="model.divBottomPart"/>
-        <alternate minOccurs="0" maxOccurs="unbounded">
-          <classRef key="model.divBottomPart"/>
-          <classRef key="model.global"/>
+        <alternate>
+          <sequence>
+            <classRef key="model.div1Like"/>
+            <alternate minOccurs="0" maxOccurs="unbounded">
+              <classRef key="model.div1Like"/>
+              <classRef key="model.frontPart"/>
+              <classRef key="model.global"/>
+            </alternate>
+          </sequence>
+          <sequence>
+            <classRef key="model.divLike"/>
+            <alternate minOccurs="0" maxOccurs="unbounded">
+              <classRef key="model.divLike"/>
+              <classRef key="model.frontPart"/>
+              <classRef key="model.global"/>
+            </alternate>
+          </sequence>
         </alternate>
+        <sequence minOccurs="0">
+          <classRef key="model.divBottom"/>
+          <alternate minOccurs="0" maxOccurs="unbounded">
+            <classRef key="model.divBottom"/>
+            <classRef key="model.global"/>
+          </alternate>
+        </sequence>
       </sequence>
     </sequence>
   </content>

--- a/P5/Source/Specs/front.xml
+++ b/P5/Source/Specs/front.xml
@@ -34,21 +34,15 @@
   </classes>
   <content>
     <sequence>
-      <!-- 
-           we start with allowing a group of mixed-up p-like elements.
-           when we are done with them, we can start considering
-           div-like elements, and the things that
-           can occur after them.
-      -->
       <alternate minOccurs="0" maxOccurs="unbounded">
         <classRef key="model.frontPart"/>
+        <classRef key="model.global"/>
+        <classRef key="model.listLike"/>
         <classRef key="model.pLike"/>
         <classRef key="model.pLike.front"/>
-        <classRef key="model.global"/>
       </alternate>
       <sequence minOccurs="0">
         <alternate>
-          <!-- 1. has a div1Like, after optional front parts -->
           <sequence>
             <classRef key="model.div1Like"/>
             <alternate minOccurs="0" maxOccurs="unbounded">
@@ -57,7 +51,6 @@
               <classRef key="model.global"/>
             </alternate>
           </sequence>
-          <!-- 1. has a divLike, after optional front parts -->
           <sequence>
             <classRef key="model.divLike"/>
             <alternate minOccurs="0" maxOccurs="unbounded">
@@ -67,7 +60,6 @@
             </alternate>
           </sequence>
         </alternate>
-        <!-- and some bottoms, mebbe -->
         <sequence minOccurs="0">
           <classRef key="model.divBottom"/>
           <alternate minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
In order to address #2374, @martinascholger and I

1. converged the content models of `<front>` and `<back>`, because the prose says they are supposed to be identical;
2. add model.listLike to content model (now of both the `<front>` and `<back>` ) per the original request;
3. use model.bottom instead of model.bottomPart;
4. moved the sentence in the prose about them being identical from the section on back matter to the section on front matter, and then repeated the information (without the explanation) in the section on  back matter.